### PR TITLE
feat: Excel 框表解析（恒信商品表）

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ curl http://127.0.0.1:8088/health
 
 ```bash
 python -m docparse.cli parse path/to/file.zip
+python -m docparse.cli layout path/to/file.xlsx   # 只看键值和表，不做字段映射
 ```
 
 ## 文档

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -28,8 +28,8 @@ docparse/
 |---|---|---|---|
 | 接入与安全检查 | `pipeline/steps/ingest.py` | 骨架：大小 / 空文件 | 补 MIME、真实类型 |
 | 安全解压 | `adapters/parsers/unpack.py` + `steps/unpack.py` | 骨架：zip 穿越 / 层数 / 体积 | rar/7z、加密包 |
-| 按文件类型解析 | `adapters/parsers/` | 文本可用；PDF/Excel 需可选依赖；图片未接 OCR | 分类型各开 Issue |
-| 统一文档 IR | `domain/ir.py` | 已定形状 | 非必要不改 |
+| 按文件类型解析 | `adapters/parsers/` | 文本可用；Excel 全 sheet + 框表/冒号/表头（#9）；PDF 需可选依赖；图片未接 OCR | PDF / 国光冒号加强 / 扫描件 OCR |
+| 统一文档 IR | `domain/ir.py` | Cell 含合并/边框/公式；Sheet 含 key_values / tables | 非必要不改契约名 |
 | 文档分类 | `extraction/classify.py` | 关键词占位 | 按真实样本补规则 / LLM |
 | 字段抽取 | `extraction/fields.py` | 锚点规则 + LLM 接口 | 等字段清单和 case |
 | 标准化与校验 | `extraction/validate.py` | 格式 / 必填 / 证据 | 金额、日期、跨字段 |
@@ -46,7 +46,7 @@ docparse/
 
 1. 字段表按真实清单改 `schema/fields.yaml`
 2. PDF 文本层解析（`parsers/pdf.py`）
-3. Excel 解析（`parsers/excel.py`）
+3. Excel 框表解析（`parsers/excel.py` + `layout.py`，#9）
 4. 报关单规则抽取（锚点 / 表头）
 5. LLM API 兜底（提示词 + Schema）
 6. 图片 / 扫描件云 OCR 或 VLM
@@ -55,6 +55,8 @@ docparse/
 9. 人工复核页（如需要）
 
 ## 模块接口约定
+
+Excel 框表拆分（#9）：`adapters/parsers/layout.py` 从格子拆 `key_values` / `tables`，还不映射报关字段。本地对眼用 `python -m docparse.cli layout file.xlsx`。
 
 每个 parser 只做一件事：`bytes + filename → DocumentIR`。
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest>=8.3", "ruff>=0.8"]
+dev = ["pytest>=8.3", "ruff>=0.8", "openpyxl>=3.1"]
 pdf = ["pymupdf>=1.24"]
 excel = ["openpyxl>=3.1"]
 

--- a/src/docparse/adapters/parsers/excel.py
+++ b/src/docparse/adapters/parsers/excel.py
@@ -1,8 +1,21 @@
 import csv
 import io
+import re
+from datetime import date, datetime
 from uuid import uuid4
 
-from docparse.domain.ir import Cell, DocumentIR, Sheet
+from docparse.adapters.parsers.layout import split_sheet
+from docparse.domain.ir import Cell, CellBorder, DocumentIR, Sheet
+
+_XLSX = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+_SHEET_REF = re.compile(
+    r"^=(?:'([^']+)'|([^'!]+))!(\$?[A-Z]{1,3}\$?\d+)$",
+    re.IGNORECASE,
+)
+_MUL_REF = re.compile(
+    r"^=(\$?[A-Z]{1,3}\$?\d+)\s*\*\s*(\$?[A-Z]{1,3}\$?\d+)$",
+    re.IGNORECASE,
+)
 
 
 def parse_excel(data: bytes, *, file_id: str, filename: str) -> DocumentIR:
@@ -15,42 +28,183 @@ def parse_excel(data: bytes, *, file_id: str, filename: str) -> DocumentIR:
             document_id=uuid4().hex,
             file_id=file_id,
             filename=filename,
-            media_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            media_type=_XLSX,
             warnings=["未安装 openpyxl，Excel 仅登记未解析。pip install 'docparse[excel]'"],
         )
 
-    workbook = load_workbook(io.BytesIO(data), data_only=True, read_only=True)
-    sheets: list[Sheet] = []
-    parts: list[str] = []
-    for sheet in workbook.worksheets:
-        cells: list[Cell] = []
-        for row in sheet.iter_rows():
-            for item in row:
-                if item.value is None:
-                    continue
-                value = str(item.value).strip()
-                if not value:
-                    continue
-                address = item.coordinate
-                cells.append(
-                    Cell(
-                        address=address,
-                        value=value,
-                        raw_value=value,
-                        row=item.row,
-                        column=item.column,
-                    )
-                )
-                parts.append(f"{sheet.title}!{address}:{value}")
-        sheets.append(Sheet(name=sheet.title, cells=cells))
+    raw_book = load_workbook(io.BytesIO(data), data_only=False)
+    value_book = load_workbook(io.BytesIO(data), data_only=True)
+    value_sheets = {sheet.title: sheet for sheet in value_book.worksheets}
+
+    parsed: list[Sheet] = []
+    grids: dict[str, dict[str, str]] = {}
+    pending: list[tuple[str, Cell]] = []
+
+    for raw_sheet in raw_book.worksheets:
+        value_sheet = value_sheets.get(raw_sheet.title)
+        sheet, grid, formulas = _read_sheet(raw_sheet, value_sheet)
+        grids[sheet.name] = grid
+        parsed.append(sheet)
+        pending.extend((sheet.name, cell) for cell in formulas)
+
+    _resolve_formulas(grids, pending)
+
+    sheets = [split_sheet(sheet) for sheet in parsed]
+    parts = [
+        f"{sheet.name}!{cell.address}:{cell.value}" for sheet in sheets for cell in sheet.cells
+    ]
     return DocumentIR(
         document_id=uuid4().hex,
         file_id=file_id,
         filename=filename,
-        media_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        media_type=_XLSX,
         sheets=sheets,
         raw_text="\n".join(parts),
     )
+
+
+def _read_sheet(raw_sheet, value_sheet) -> tuple[Sheet, dict[str, str], list[Cell]]:
+    merges = _merge_origins(raw_sheet)
+    covered = _covered_cells(raw_sheet)
+    cells: list[Cell] = []
+    grid: dict[str, str] = {}
+    formulas: list[Cell] = []
+
+    for row in raw_sheet.iter_rows():
+        for item in row:
+            address = item.coordinate
+            if address in covered and address not in merges:
+                continue
+            cached = None
+            if value_sheet is not None:
+                cached = value_sheet[address].value
+            raw = item.value
+            formula = raw if isinstance(raw, str) and raw.startswith("=") else None
+            fallback = None if formula else raw
+            display = _stringify(cached if cached is not None else fallback)
+            if not display and not formula and address not in merges:
+                continue
+            cell = Cell(
+                address=address,
+                value=display,
+                raw_value=formula or _stringify(item.value) or None,
+                row=item.row,
+                column=item.column,
+                merge_range=merges.get(address),
+                formula=formula,
+                border=_border(item),
+            )
+            cells.append(cell)
+            if display:
+                grid[address] = display
+            if formula and not display:
+                formulas.append(cell)
+
+    return Sheet(name=raw_sheet.title, cells=cells), grid, formulas
+
+
+def _merge_origins(sheet) -> dict[str, str]:
+    origins: dict[str, str] = {}
+    for item in sheet.merged_cells.ranges:
+        origins[item.start_cell.coordinate] = str(item)
+    return origins
+
+
+def _covered_cells(sheet) -> set[str]:
+    covered: set[str] = set()
+    for item in sheet.merged_cells.ranges:
+        min_col, min_row, max_col, max_row = item.bounds
+        for row in range(min_row, max_row + 1):
+            for col in range(min_col, max_col + 1):
+                covered.add(f"{_col_letter(col)}{row}")
+    return covered
+
+
+def _col_letter(index: int) -> str:
+    letters = ""
+    while index:
+        index, rem = divmod(index - 1, 26)
+        letters = chr(65 + rem) + letters
+    return letters
+
+
+def _border(item) -> CellBorder | None:
+    border = item.border
+    if border is None:
+        return None
+    sides = CellBorder(
+        left=bool(border.left and border.left.style),
+        right=bool(border.right and border.right.style),
+        top=bool(border.top and border.top.style),
+        bottom=bool(border.bottom and border.bottom.style),
+    )
+    if not any((sides.left, sides.right, sides.top, sides.bottom)):
+        return None
+    return sides
+
+
+def _stringify(value: object) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, float):
+        if value.is_integer():
+            return str(int(value))
+        return format(value, ".10g")
+    if isinstance(value, datetime):
+        return value.isoformat(sep=" ", timespec="seconds")
+    if isinstance(value, date):
+        return value.isoformat()
+    return str(value).strip()
+
+
+def _resolve_formulas(
+    grids: dict[str, dict[str, str]],
+    pending: list[tuple[str, Cell]],
+) -> None:
+    for _ in range(8):
+        leftover: list[tuple[str, Cell]] = []
+        progress = False
+        for sheet_name, cell in pending:
+            resolved = _eval_formula(cell.formula or "", sheet_name, grids)
+            if resolved is None:
+                leftover.append((sheet_name, cell))
+                continue
+            cell.value = resolved
+            grids.setdefault(sheet_name, {})[cell.address] = resolved
+            progress = True
+        pending = leftover
+        if not progress or not pending:
+            break
+
+
+def _eval_formula(formula: str, sheet_name: str, grids: dict[str, dict[str, str]]) -> str | None:
+    match = _SHEET_REF.match(formula.replace("$", ""))
+    if match:
+        target = match.group(1) or match.group(2)
+        address = match.group(3).upper()
+        value = grids.get(target, {}).get(address)
+        return value or None
+    match = _MUL_REF.match(formula.replace("$", ""))
+    if match:
+        left = _as_number(grids.get(sheet_name, {}).get(match.group(1).upper()))
+        right = _as_number(grids.get(sheet_name, {}).get(match.group(2).upper()))
+        if left is None or right is None:
+            return None
+        return _stringify(left * right)
+    return None
+
+
+def _as_number(text: str | None) -> float | None:
+    if text is None or text == "":
+        return None
+    try:
+        return float(text)
+    except ValueError:
+        return None
 
 
 def _parse_csv(data: bytes, *, file_id: str, filename: str) -> DocumentIR:
@@ -66,11 +220,12 @@ def _parse_csv(data: bytes, *, file_id: str, filename: str) -> DocumentIR:
             address = f"R{r_idx}C{c_idx}"
             cells.append(Cell(address=address, value=cleaned, row=r_idx, column=c_idx))
             parts.append(f"{address}:{cleaned}")
+    sheet = split_sheet(Sheet(name="Sheet1", cells=cells))
     return DocumentIR(
         document_id=uuid4().hex,
         file_id=file_id,
         filename=filename,
         media_type="text/csv",
-        sheets=[Sheet(name="Sheet1", cells=cells)],
+        sheets=[sheet],
         raw_text="\n".join(parts),
     )

--- a/src/docparse/adapters/parsers/layout.py
+++ b/src/docparse/adapters/parsers/layout.py
@@ -1,0 +1,271 @@
+"""从格子拆出版面：框表键值、冒号键值、表头行。
+
+不做报关单字段映射，只把看得到的键值和对表留下来。
+"""
+
+from __future__ import annotations
+
+import re
+
+from docparse.domain.ir import Cell, KeyValue, Sheet, Table
+
+_COLON = re.compile(r"^([^：:]{1,40}?)\s*[：:]\s*(.+)$")
+
+_BOX_LABELS = frozenset(
+    {
+        "境内发货人",
+        "出境关别",
+        "出口日期",
+        "进口日期",
+        "申报日期",
+        "备案号",
+        "境外收货人",
+        "运输方式",
+        "运输工具名称及航次号",
+        "提运单号",
+        "生产销售单位",
+        "监管方式",
+        "征免性质",
+        "许可证号",
+        "合同协议号",
+        "贸易国（地区）",
+        "运抵国（地区）",
+        "指运港",
+        "离境口岸",
+        "包装种类",
+        "件数",
+        "毛重（千克）",
+        "净重（千克）",
+        "成交方式",
+        "运费",
+        "保费",
+        "杂费",
+        "随附单证及编号",
+        "标记唛码及备注",
+        "预录入编号",
+        "海关编号",
+        "备注",
+    }
+)
+
+_TABLE_HEADERS = (
+    "项号",
+    "商品编号",
+    "商品名称",
+    "规格型号",
+    "申报要素",
+    "品牌",
+    "数量",
+    "计价单位",
+    "重量",
+    "单价",
+    "总价",
+    "币制",
+    "原产国",
+    "最终目的国",
+    "境内货源地",
+    "征免",
+)
+
+
+def split_sheet(sheet: Sheet) -> Sheet:
+    tables = _detect_tables(sheet.cells)
+    occupied = _table_cells(tables, sheet.cells)
+    key_values = _detect_key_values(sheet.cells, occupied)
+    return sheet.model_copy(update={"tables": tables, "key_values": key_values})
+
+
+def _detect_tables(cells: list[Cell]) -> list[Table]:
+    by_row: dict[int, list[Cell]] = {}
+    for cell in cells:
+        if cell.row is None or not cell.value:
+            continue
+        by_row.setdefault(cell.row, []).append(cell)
+
+    tables: list[Table] = []
+    used_rows: set[int] = set()
+    for row_idx in sorted(by_row):
+        if row_idx in used_rows:
+            continue
+        row_cells = sorted(by_row[row_idx], key=lambda c: c.column or 0)
+        if not _is_header_row(row_cells):
+            continue
+        headers = [c.value for c in row_cells]
+        header_cells = [c.address for c in row_cells]
+        columns = [c.column for c in row_cells]
+        body: list[dict[str, str]] = []
+        for body_row in range(row_idx + 1, row_idx + 200):
+            if body_row not in by_row:
+                break
+            used_rows.add(body_row)
+            values_by_col = {c.column: c.value for c in by_row[body_row]}
+            record = {
+                header: values_by_col.get(col, "")
+                for header, col in zip(headers, columns, strict=True)
+            }
+            if not any(record.values()):
+                break
+            body.append(record)
+        used_rows.add(row_idx)
+        tables.append(
+            Table(
+                header_row=row_idx,
+                headers=headers,
+                header_cells=header_cells,
+                rows=body,
+            )
+        )
+    return tables
+
+
+def _is_header_row(row_cells: list[Cell]) -> bool:
+    if len(row_cells) < 3:
+        return False
+    hits = 0
+    for cell in row_cells:
+        text = cell.value
+        if any(token in text for token in _TABLE_HEADERS):
+            hits += 1
+    return hits >= 2
+
+
+def _table_cells(tables: list[Table], cells: list[Cell]) -> set[str]:
+    if not tables:
+        return set()
+    table_rows: set[int] = set()
+    for table in tables:
+        table_rows.add(table.header_row)
+        table_rows.update(range(table.header_row + 1, table.header_row + 1 + len(table.rows)))
+    return {cell.address for cell in cells if cell.row in table_rows}
+
+
+def _detect_key_values(cells: list[Cell], occupied: set[str]) -> list[KeyValue]:
+    by_pos = {(c.row, c.column): c for c in cells if c.row is not None and c.column is not None}
+    found: list[KeyValue] = []
+    seen: set[tuple[str, str, str]] = set()
+
+    def add(item: KeyValue) -> None:
+        key = (item.key, item.value, item.strategy)
+        if key in seen or not item.value:
+            return
+        seen.add(key)
+        found.append(item)
+
+    for cell in cells:
+        if cell.address in occupied or not cell.value:
+            continue
+        same = _same_cell_colon(cell)
+        if same:
+            add(same)
+            continue
+        below = _value_below(cell, by_pos, occupied)
+        if below:
+            add(below)
+            continue
+        right = _value_right(cell, by_pos, occupied)
+        if right:
+            add(right)
+
+    return found
+
+
+def _same_cell_colon(cell: Cell) -> KeyValue | None:
+    match = _COLON.match(cell.value)
+    if not match:
+        return None
+    key, value = match.group(1).strip(), match.group(2).strip()
+    if not key or not value:
+        return None
+    if any(token in key for token in _TABLE_HEADERS):
+        return None
+    return KeyValue(
+        key=key,
+        value=value,
+        key_cell=cell.address,
+        value_cell=cell.address,
+        strategy="same_cell",
+    )
+
+
+def _looks_like_label(text: str) -> bool:
+    stripped = text.strip()
+    cleaned = stripped.rstrip("：:").strip()
+    if not cleaned or len(cleaned) > 20:
+        return False
+    if cleaned in _BOX_LABELS:
+        return True
+    if stripped.endswith((":", "：")) and not re.fullmatch(r"[\d.\-]+", cleaned):
+        return True
+    return False
+
+
+def _value_below(
+    cell: Cell,
+    by_pos: dict[tuple[int, int], Cell],
+    occupied: set[str],
+) -> KeyValue | None:
+    if cell.row is None or cell.column is None:
+        return None
+    if not _looks_like_label(cell.value):
+        return None
+    below_row = _merge_bottom(cell) + 1
+    other = by_pos.get((below_row, cell.column))
+    if other is None or other.address in occupied or not other.value:
+        return None
+    if _looks_like_label(other.value) and not _COLON.match(other.value):
+        return None
+    key = cell.value.strip().rstrip("：:").strip()
+    return KeyValue(
+        key=key,
+        value=other.value,
+        key_cell=cell.address,
+        value_cell=other.address,
+        strategy="below",
+    )
+
+
+def _value_right(
+    cell: Cell,
+    by_pos: dict[tuple[int, int], Cell],
+    occupied: set[str],
+) -> KeyValue | None:
+    if cell.row is None or cell.column is None:
+        return None
+    text = cell.value.strip()
+    key = text.rstrip("：:").strip()
+    if not (text.endswith((":", "：")) or key in _BOX_LABELS):
+        return None
+    right_col = _merge_right(cell) + 1
+    other = by_pos.get((cell.row, right_col))
+    if other is None or other.address in occupied or not other.value:
+        return None
+    if _looks_like_label(other.value):
+        return None
+    return KeyValue(
+        key=key,
+        value=other.value,
+        key_cell=cell.address,
+        value_cell=other.address,
+        strategy="right",
+    )
+
+
+def _merge_bottom(cell: Cell) -> int:
+    if cell.merge_range and ":" in cell.merge_range:
+        end = cell.merge_range.split(":")[1]
+        digits = "".join(ch for ch in end if ch.isdigit())
+        if digits:
+            return int(digits)
+    return cell.row or 0
+
+
+def _merge_right(cell: Cell) -> int:
+    if cell.merge_range and ":" in cell.merge_range:
+        end = cell.merge_range.split(":")[1]
+        letters = "".join(ch for ch in end if ch.isalpha())
+        if letters:
+            col = 0
+            for ch in letters.upper():
+                col = col * 26 + (ord(ch) - 64)
+            return col
+    return cell.column or 0

--- a/src/docparse/cli.py
+++ b/src/docparse/cli.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
+from uuid import uuid4
 
+from docparse.adapters.parsers.registry import parse_bytes
 from docparse.pipeline.runner import Pipeline
 
 
@@ -11,12 +13,17 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(prog="docparse")
     sub = parser.add_subparsers(dest="command", required=True)
 
-    parse_cmd = sub.add_parser("parse", help="解析本地文件并打印 JSON")
+    parse_cmd = sub.add_parser("parse", help="解析本地文件并打印任务 JSON")
     parse_cmd.add_argument("path", type=Path)
+
+    layout_cmd = sub.add_parser("layout", help="只打印解析 IR 的键值和表，不做字段映射")
+    layout_cmd.add_argument("path", type=Path)
 
     args = parser.parse_args(argv)
     if args.command == "parse":
         return _parse(args.path)
+    if args.command == "layout":
+        return _layout(args.path)
     return 1
 
 
@@ -26,6 +33,25 @@ def _parse(path: Path) -> int:
     payload = job.model_dump(mode="json")
     print(json.dumps(payload, ensure_ascii=False, indent=2))
     return 0 if job.status.value != "failed" else 2
+
+
+def _layout(path: Path) -> int:
+    document = parse_bytes(path.read_bytes(), file_id=uuid4().hex, filename=path.name)
+    payload = {
+        "filename": document.filename,
+        "warnings": document.warnings,
+        "sheets": [
+            {
+                "name": sheet.name,
+                "cells": len(sheet.cells),
+                "key_values": [item.model_dump() for item in sheet.key_values],
+                "tables": [table.model_dump() for table in sheet.tables],
+            }
+            for sheet in document.sheets
+        ],
+    }
+    print(json.dumps(payload, ensure_ascii=False, indent=2))
+    return 0 if not document.warnings or document.sheets else 2
 
 
 if __name__ == "__main__":

--- a/src/docparse/domain/ir.py
+++ b/src/docparse/domain/ir.py
@@ -26,17 +26,46 @@ class Page(BaseModel):
     blocks: list[TextBlock] = Field(default_factory=list)
 
 
+class CellBorder(BaseModel):
+    left: bool = False
+    right: bool = False
+    top: bool = False
+    bottom: bool = False
+
+
 class Cell(BaseModel):
     address: str
     value: str
     raw_value: str | None = None
     row: int | None = None
     column: int | None = None
+    merge_range: str | None = None
+    formula: str | None = None
+    border: CellBorder | None = None
+
+
+class KeyValue(BaseModel):
+    """版面拆出的键值，还不是报关单字段。"""
+
+    key: str
+    value: str
+    key_cell: str
+    value_cell: str
+    strategy: str
+
+
+class Table(BaseModel):
+    header_row: int
+    headers: list[str] = Field(default_factory=list)
+    header_cells: list[str] = Field(default_factory=list)
+    rows: list[dict[str, str]] = Field(default_factory=list)
 
 
 class Sheet(BaseModel):
     name: str
     cells: list[Cell] = Field(default_factory=list)
+    key_values: list[KeyValue] = Field(default_factory=list)
+    tables: list[Table] = Field(default_factory=list)
 
 
 class Evidence(BaseModel):

--- a/tests/test_excel_layout.py
+++ b/tests/test_excel_layout.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("openpyxl")
+
+from openpyxl import Workbook
+from openpyxl.styles import Border, Side
+
+from docparse.adapters.parsers.excel import parse_excel
+
+REAL_HENGXIN = Path(
+    "/Users/chenzecong/Documents/泰洲数据/AI识别Demo/AI识别Demo/"
+    "（恒信）一般贸易草单HDX260251BLU.xlsx"
+)
+
+
+def _thin() -> Border:
+    line = Side(style="thin")
+    return Border(left=line, right=line, top=line, bottom=line)
+
+
+def _box_workbook() -> bytes:
+    book = Workbook()
+    draft = book.active
+    draft.title = "一般贸易出口"
+    packing = book.create_sheet("装箱单")
+
+    packing["G58"] = 40
+    packing["I58"] = 296.46
+    packing["H58"] = 218.375
+
+    draft.merge_cells("A3:D3")
+    draft["A3"] = "境内发货人"
+    draft.merge_cells("A4:D4")
+    draft["A4"] = "惠州市恒德信精密科技有限公司441394164D"
+
+    draft["E3"] = "出境关别"
+    draft["E4"] = "莲塘口岸"
+
+    draft.merge_cells("A5:D5")
+    draft["A5"] = "境外收货人"
+    draft.merge_cells("A6:D6")
+    draft["A6"] = "BLU PRECISION LIMITED"
+
+    draft["E5"] = "运输方式"
+    draft["E6"] = "公路运输"
+
+    draft.merge_cells("A7:D7")
+    draft["A7"] = "生产销售单位"
+    draft.merge_cells("A8:D8")
+    draft["A8"] = "惠州市恒德信精密科技有限公司"
+
+    draft["E7"] = "监管方式"
+    draft["E8"] = "一般贸易"
+    draft.merge_cells("I7:J7")
+    draft["I7"] = "征免性质"
+    draft["I8"] = "一般征税"
+
+    draft.merge_cells("A9:D9")
+    draft["A9"] = "合同协议号"
+    draft.merge_cells("A10:D10")
+    draft["A10"] = "HDX2026-251"
+
+    draft.merge_cells("A11:C11")
+    draft["A11"] = "包装种类"
+    draft["D11"] = "件数"
+    draft["E11"] = "毛重（千克）"
+    draft["F11"] = "净重（千克）"
+    draft.merge_cells("G11:H11")
+    draft["G11"] = "成交方式"
+
+    draft.merge_cells("A12:C12")
+    draft["A12"] = "其它"
+    draft["D12"] = "=装箱单!G58"
+    draft["E12"] = "=装箱单!I58"
+    draft["F12"] = "=装箱单!H58"
+    draft.merge_cells("G12:H12")
+    draft["G12"] = "FOB"
+
+    headers = [
+        "项号",
+        "商品编号",
+        "商品名称及规格型号",
+        "申报要素",
+        "数量PCS",
+        "计价单位",
+        "重量KG",
+        "单价",
+        "总价",
+    ]
+    for col, header in enumerate(headers, start=1):
+        draft.cell(17, col, header)
+    draft["A18"] = 1
+    draft["B18"] = "9111900000"
+    draft["C18"] = "表壳配件/壳体"
+    draft["D18"] = "不锈钢"
+    draft["E18"] = 150
+    draft["F18"] = "只"
+    draft["G18"] = 5.74
+    draft["H18"] = 98
+    draft["I18"] = "=E18*H18"
+
+    for row in draft.iter_rows(min_row=3, max_row=18, min_col=1, max_col=9):
+        for cell in row:
+            cell.border = _thin()
+
+    buffer = io.BytesIO()
+    book.save(buffer)
+    return buffer.getvalue()
+
+
+def _pairs(sheet) -> dict[str, str]:
+    return {item.key: item.value for item in sheet.key_values}
+
+
+def test_box_form_key_values_and_table() -> None:
+    document = parse_excel(_box_workbook(), file_id="f1", filename="draft.xlsx")
+    assert {sheet.name for sheet in document.sheets} == {"一般贸易出口", "装箱单"}
+    draft = next(sheet for sheet in document.sheets if sheet.name == "一般贸易出口")
+    pairs = _pairs(draft)
+
+    assert pairs["境内发货人"] == "惠州市恒德信精密科技有限公司441394164D"
+    assert pairs["境外收货人"] == "BLU PRECISION LIMITED"
+    assert pairs["合同协议号"] == "HDX2026-251"
+    assert pairs["运输方式"] == "公路运输"
+    assert pairs["监管方式"] == "一般贸易"
+    assert pairs["征免性质"] == "一般征税"
+    assert pairs["件数"] == "40"
+    assert pairs["毛重（千克）"] == "296.46"
+    assert pairs["净重（千克）"] == "218.375"
+    assert pairs["成交方式"] == "FOB"
+
+    weight = next(cell for cell in draft.cells if cell.address == "E12")
+    assert weight.formula == "=装箱单!I58"
+    assert weight.value == "296.46"
+
+    assert draft.tables
+    table = draft.tables[0]
+    assert "项号" in table.headers
+    assert "商品编号" in table.headers
+    assert table.rows[0]["项号"] == "1"
+    assert table.rows[0]["商品编号"] == "9111900000"
+    assert table.rows[0]["商品名称及规格型号"] == "表壳配件/壳体"
+    assert table.rows[0]["总价"] == "14700"
+
+
+@pytest.mark.skipif(not REAL_HENGXIN.exists(), reason="本地恒信样本不在 CI")
+def test_hengxin_sample_keeps_formulas_and_goods_table() -> None:
+    document = parse_excel(
+        REAL_HENGXIN.read_bytes(),
+        file_id="hx",
+        filename=REAL_HENGXIN.name,
+    )
+    assert len(document.sheets) >= 4
+    draft = next(sheet for sheet in document.sheets if "一般贸易" in sheet.name)
+    pairs = _pairs(draft)
+    assert pairs["合同协议号"] == "HDX2026-251"
+    assert pairs["境外收货人"] == "BLU PRECISION LIMITED"
+    assert pairs["出境关别"] == "莲塘口岸"
+    assert pairs["离境口岸"] == "莲塘口岸"
+    assert pairs["件数"] == "40"
+    assert pairs["毛重（千克）"] == "296.46"
+    assert draft.tables
+    first = draft.tables[0].rows[0]
+    assert first["项号"] == "1"
+    assert first["商品编号"] == "9111900000"


### PR DESCRIPTION
Closes #9

Excel 全 sheet 进 IR，保留合并格、边框和公式。框表按上标签下取值拆键值，表头行拆成商品表。

恒信「一般贸易出口」已本地对过：框表 KV 和商品表（含申报要素列）效果确认可用。件数/毛净重按装箱单公式算出（40 / 296.46 / 218.375）。客户原件不入库，仓库夹具覆盖同一结构。

已知不修、不挡本 Issue：真实草单 G7 标签写成「监管方式」，「征免性质」不在正下方，这两处不当键值。国光、半岛、字段映射不在本 PR。

用法：`python -m docparse.cli layout <xlsx>`