### PR TITLE
feat: 报关单输出字段目录

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # DocParse
 
-多格式单据解析骨架：用户上传压缩包 / PDF / Excel / 图片，流水线解析出报关单号等业务字段。
+多格式单据解析骨架：用户上传压缩包 / PDF / Excel / 图片，最终输出一张出口报关单（表头 + 商品项）。
 
-当前阶段是**框架层**。需求方尚未给出真实样本和字段清单，因此：
+当前阶段：Excel 框表 dump 已有；输出字段目录见 [docs/field-schema.md](docs/field-schema.md)。约束：
 
 - 主链路是确定性流水线，不是 Agent，也不引入 LangChain / LangGraph
 - 模型只通过云 API 调用，不部署本地大模型

--- a/docs/field-schema.md
+++ b/docs/field-schema.md
@@ -1,37 +1,157 @@
-# 字段 Schema（占位）
-
-真实字段等需求方给 case 后再填。这里只固定**形状**，让抽取器和校验器可以先接线。
+# 报关单输出字段目录
 
 运行时读取 [`src/docparse/schema/fields.yaml`](../src/docparse/schema/fields.yaml)。
 
-## 字段记录
+形状对齐 Demo `字段说明.json`；草单上看得到、json 没有的从 `报关字段说明.md` 补。客户原件不进仓库。
 
-| 键 | 含义 |
+本目录只回答「输出什么、从哪类版面来」。名称转 code 是 #14，BOX/TABLE 别名是 #13，映射组装是 #17–#19。
+
+本期**不区分必填 / 选填**，YAML 里 `required` 一律未标。后期再优化。
+
+目录可继续加字段，不锁死。同义词、列名别名（毛重 / G.W.、出货数量）不在本 Issue 展开，交给 #13。
+
+## 版面来源
+
+| `layout` | 含义 |
 |---|---|
-| `name` | 程序内字段名 |
-| `display_name` | 中文名 |
-| `required` | 是否必填 |
-| `value_type` | `string` / `date` / `money` / `number` |
-| `sources` | 优先从哪些文档类型取 |
-| `pattern` | 可选正则 |
-| `extractors` | 允许的抽取器，按顺序尝试 |
+| `box_kv` | 框表 KV（上标签下取值；冒号键值同类） |
+| `table_col` | 商品表列。有海关商品表以它为主，箱单 / 发票 / 合同只补充 |
+| `caller` | 调用方传入，不解析 |
+| `default` | 组装默认值（本期出口 `cusIEFlag=E`） |
+| `none` | 不从版面抽，可空 |
+| `empty_array` | 输出 `[]`，本期不展开 |
 
-抽取器约定：
+抽不到或不符规则 → `needs_review`，不编造。
 
-```text
-rule        锚点 / 表头 / 正则
-llm         云 API 文本结构化抽取
-vlm         云 API 视觉模型读局部图（本阶段接口预留）
-human       仅人工填写，流水线不得自动写
-```
+## 口岸对照（会上已定）
 
-## 结果对象
+| 草单标签 | 输出字段 | 码表 | 说明 |
+|---|---|---|---|
+| 申报地海关 | `customMaster` | 海关口岸代码（四位） | 如 5341 深惠州关、5352 梅沙海关。草单不一定有独立格 |
+| 出境关别 / 进境关别 | `iePort` | 海关口岸代码（四位） | 标准表「进/出口口岸」。恒信「莲塘口岸」进这里，**不要**写进 `customMaster` |
+| 离境口岸 / 入境口岸 | `ciqEntyPortCode` | 入境/离境口岸 | CIQ 口岸，不是四位关区。半岛参考值 477101 |
+| 指运港 / 经停港 | `distinatePort` | 港口代码 | 识别结果用 `HKG000` / `HKG003` 风格。六位特殊监管区码型交 #14 |
+| 启运港 | `despPortCode` | 港口代码 | json 漏标；出口草单常空，有则抽 |
 
-每个字段输出不是裸字符串，而是：
+## 调用方传入（不解析）
+
+`agentCode` / `agentName` / `agentScc` / `agentCiqCode`：申报单位，调用时传入。
+
+生产销售单位 / 消费使用单位（`owner*`）文件里有就抽，没有就空。
+
+## 表头必须项对照
+
+用户列出的表头格子 → 本目录字段：
+
+| 草单 / 用户说法 | 输出字段 | 版面 |
+|---|---|---|
+| 预录入编号 | `preEntryId` | box_kv |
+| 海关编号 | `entryId` | box_kv |
+| 境内发/收货人 | `tradeName` + `tradeCode`（同一格常粘在一起，拆分交 #17） | box_kv |
+| 出/进境关别 | `iePort` | box_kv |
+| 进口日期 / 出口日期 | `ieDate` | box_kv |
+| 申报日期 | `declDate`（json/md 未列此键，键名待确认） | box_kv |
+| 备案号 | `manualNo` | box_kv |
+| 境外收/发货人 | `consignorEname` | box_kv |
+| 运输方式 | `cusTrafMode` | box_kv |
+| 运输工具名称及航次号 | `trafName` + `cusVoyageNo`（同一格，拆分交 #17） | box_kv |
+| 提运单号 | `billNo` | box_kv |
+| 货物存放地点 | `goodsPlace` | box_kv |
+| 生产销售单位 / 消费使用单位 | `ownerName` + `ownerCode` | box_kv |
+| 监管方式 | `supvModeCdde` | box_kv |
+| 许可证号 | `licenseNo` | box_kv |
+| 启运港 | `despPortCode` | box_kv |
+| 合同协议号 | `contrNo` | box_kv |
+| 贸易国（地区） | `cusTradeNationCode` | box_kv |
+| 运抵国（地区） / 启运国（地区） | `cusTradeCountry` | box_kv |
+| 指运港 / 经停港 | `distinatePort` | box_kv |
+| 离/入境口岸 | `ciqEntyPortCode` | box_kv |
+| 包装种类 | `wrapType` | box_kv |
+| 件数 | `packNo` | box_kv |
+| 毛重（千克） | `grossWt` | box_kv |
+| 净重（千克） | `netWt` | box_kv |
+| 成交方式 | `transMode` | box_kv |
+| 运费 | `feeMark` / `feeRate` / `feeCurr`（同一格，拆分交 #17） | box_kv |
+| 保费 | `insurMark` / `insurRate` / `insurCurr` | box_kv |
+| 杂费 | `otherMark` / `otherRate` / `otherCurr` | box_kv |
+| 随附单证及编号 | `attachedDocs`（原文）+ `tdecDocusVoArr`（数组，拆条交后续） | box_kv |
+| 标记唛码及备注 | `markNo` + `noteS`（同一格，拆分交 #17） | box_kv |
+
+json 另有、用户这次没点名但仍收的：`cusIEFlag`、`entryType`、`cutMode`、`customMaster`、`tradeScc`、`tradeCiqCode`、`ownerScc`、`ownerCiqCode`、`promiseItems`。
+
+## 商品必须项对照
+
+| 草单 / 用户说法 | 输出字段 | 版面 |
+|---|---|---|
+| 项号 | `gno` | table_col |
+| 商品编码 | `codeTs` | table_col |
+| 商品名称及规格型号 | `gname`（名称） | table_col |
+| 申报要素 | `gmodel`（恒信在这一列；规范编码本期留原文） | table_col |
+| 品牌 | `brand` | table_col |
+| 数量 | `gqty` | table_col |
+| 单位 | `gunit` | table_col |
+| 单价 | `declPrice` | table_col |
+| 总价 | `declTotal` | table_col |
+| 币制 | `tradeCurr` | table_col |
+| 原产国 | `cusOriginCountry` | table_col |
+| 最终目的地（地区） | `destinationCountry` | table_col |
+| 境内目的地 | `districtCode`（出口草单常写境内货源地，同一字段） | table_col |
+
+json 另有、用户这次没点名但仍收的：`qty1` / `unit1` / `qty2` / `unit2`、`dutyMode`、`customGrossWet`、`customNetWt`、`exgVersion`。
+
+商品项挂在 `tdecGoodsitemsVoArr`。
+
+## 可忽略（系统主键 / json 明确说可忽略的非业务项）
+
+`dataSource`、`promiseItem1` / `2` / `3`、商品项内部 `id`、`sysBillNo`、`ownerCompanyId` / `Code` / `Name`、`requestId`、`headId`（表头主键）、`decId`。
+
+`brand` **不再忽略**。
+
+## 空数组（本期不展开）
+
+`tdecContasVoArr` 集装箱、`tdecCoplimitVoArr` 企业资质、`tdecEdocRealationVoArr` 电子随附单据、`tdecOthersPacksVoArr` 其他包装、`tdecRequCertVoArr`、`tdecUsersVoArr`、`tdecEcoRelVoArr`、`tdecGoodsitemsVin`。
+
+`tdecDocusVoArr` 随附单证：**不再当空数组忽略**，有字则收。
+
+数组没有值时输出 `[]`，不能是 `null`。
+
+## 相对 json 的增补
+
+| 字段 | 中文 | 理由 |
+|---|---|---|
+| `declDate` | 申报日期 | 草单有格；json/md 未列键名 |
+| `billNo` | 提运单号 | 草单有格 |
+| `licenseNo` | 许可证号 | 草单有格 |
+| `ieDate` | 进/出口日期 | 草单有「出口日期」 |
+| `iePort` | 进/出口口岸 | 草单「出境关别」 |
+| `ciqEntyPortCode` | 离境口岸 | json 漏标 |
+| `trafName` | 运输工具名称 | 草单有格 |
+| `cusVoyageNo` | 航次号 | json 漏标 |
+| `despPortCode` | 启运港 | json 漏标 |
+| `goodsPlace` | 货物存放地点 | json 漏标 |
+| `entryId` | 海关编号 | 草单有格 |
+| `preEntryId` | 预录入编号 | 草单有格 |
+| `attachedDocs` | 随附单证及编号 | 草单有格 |
+| `brand` | 品牌 | 草单商品表有列 |
+
+## 本期不做 / 交给后面 Issue
+
+- 必填 / 选填
+- BOX / TABLE 同义词、列名别名（#13）
+- 名称转 code（#14）
+- 同一格拆成多个字段、跨表补充（#17 / #18）
+- 集装箱 / VIN 等块：空数组
+- `gmodel` 规范编码（`0|0|...`）先留原文
+- json 未列的 `*Name` 名称镜像字段不收
+- 客户原件入库
+
+## 流水线结果对象
+
+每个**已抽取**字段仍不是裸字符串：
 
 ```json
 {
-  "name": "customs_declaration_no",
+  "name": "entryId",
   "value": null,
   "normalized_value": null,
   "confidence": 0.0,
@@ -44,4 +164,4 @@ human       仅人工填写，流水线不得自动写
 
 `status`：`accepted` | `needs_review` | `missing` | `conflict` | `invalid`
 
-需求方字段到位后，优先改 YAML，不要先改流水线代码。
+最终交付给调用方的是一张报关单对象（表头 + `tdecGoodsitemsVoArr`），由后续 Issue 组装。本 Issue 只定目录。

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -31,7 +31,7 @@ docparse/
 | 按文件类型解析 | `adapters/parsers/` | 文本可用；Excel 全 sheet + 框表/冒号/表头（#9）；PDF 需可选依赖；图片未接 OCR | PDF / 国光冒号加强 / 扫描件 OCR |
 | 统一文档 IR | `domain/ir.py` | Cell 含合并/边框/公式；Sheet 含 key_values / tables | 非必要不改契约名 |
 | 文档分类 | `extraction/classify.py` | 关键词占位 | 按真实样本补规则 / LLM |
-| 字段抽取 | `extraction/fields.py` | 锚点规则 + LLM 接口 | 等字段清单和 case |
+| 字段抽取 | `extraction/fields.py` | 锚点规则 + LLM 接口 | 目录已在 #12，映射交 #17/#18 |
 | 标准化与校验 | `extraction/validate.py` | 格式 / 必填 / 证据 | 金额、日期、跨字段 |
 | 包级对账 | `pipeline/steps/reconcile.py` | 同名字段冲突 | 金额、单号跨文件 |
 | 自动通过 / 待复核 | `pipeline/steps/route_review.py` | 只打状态 | 复核页另开 Issue |
@@ -44,7 +44,7 @@ docparse/
 
 需求方 case 和字段清单到位后，按这个顺序拆，一次一个 worktree：
 
-1. 字段表按真实清单改 `schema/fields.yaml`
+1. 字段表按真实清单改 `schema/fields.yaml`（#12）
 2. PDF 文本层解析（`parsers/pdf.py`）
 3. Excel 框表解析（`parsers/excel.py` + `layout.py`，#9）
 4. 报关单规则抽取（锚点 / 表头）

--- a/src/docparse/schema/__init__.py
+++ b/src/docparse/schema/__init__.py
@@ -1,3 +1,3 @@
-from docparse.schema.loader import FieldSpec, Schema, load_schema
+from docparse.schema.loader import FieldSpec, PortMapping, Schema, load_schema
 
-__all__ = ["FieldSpec", "Schema", "load_schema"]
+__all__ = ["FieldSpec", "PortMapping", "Schema", "load_schema"]

--- a/src/docparse/schema/fields.yaml
+++ b/src/docparse/schema/fields.yaml
@@ -1,5 +1,9 @@
-# 占位字段。需求方给出真实清单后只改本文件。
-version: 1
+# 出口报关单输出字段目录（Issue #12）
+# 形状对齐 Demo 字段说明.json；草单上看得到、json 没有的从 报关字段说明.md 补。
+# 客户原件不进仓库。本文件只是目录，不接样本、不改组装。
+
+version: 2
+goods_array: tdecGoodsitemsVoArr
 document_types:
   - customs_declaration
   - invoice
@@ -8,44 +12,843 @@ document_types:
   - contract
   - unknown
 
-fields:
-  - name: customs_declaration_no
-    display_name: 报关单号
-    required: true
-    value_type: string
+# 出境关别 / 申报地海关 / 离境口岸。字段已定；码型与样本错填见 notes。
+port_mapping:
+  - draft_label: 申报地海关
+    field: customMaster
+    code_table: 海关口岸代码
+    status: decided
+    notes: 四位关区代码（如 5341 深惠州关、5352 梅沙海关）。草单不一定有独立格。
+
+  - draft_label: 出境关别
+    field: iePort
+    code_table: 海关口岸代码
+    status: decided
+    notes: 标准表「进/出口口岸」。恒信草单标签是「出境关别」。参考 JSON 把莲塘写进 customMaster，目录不跟着错。
+
+  - draft_label: 离境口岸
+    field: ciqEntyPortCode
+    code_table: 入境/离境口岸
+    status: decided
+    notes: CIQ 口岸，不是四位海关关区。半岛参考值 477101。
+
+  - draft_label: 指运港
+    field: distinatePort
+    code_table: 港口代码
+    status: decided
+    notes: 识别结果用 HKG000 / HKG003 风格。六位特殊监管区码型交 #14，不改本字段。
+
+  - draft_label: 启运港
+    field: despPortCode
+    code_table: 港口代码
+    status: decided
+    notes: json 漏标；出口草单常空。有则抽。
+
+caller_params:
+  - name: agentCode
+    display_name: 10位申报单位海关代码
+    group: caller
+    layout: caller
+    parse: false
+    notes: 申报单位不解析，调用方传入。
+
+  - name: agentName
+    display_name: 申报单位名称
+    group: caller
+    layout: caller
+    parse: false
+    notes: 申报单位不解析，调用方传入。
+
+  - name: agentScc
+    display_name: 18位申报单位信用代码
+    group: caller
+    layout: caller
+    parse: false
+    notes: 申报单位不解析，调用方传入。
+
+  - name: agentCiqCode
+    display_name: 申报单位检验检疫代码
+    group: caller
+    layout: caller
+    parse: false
+    notes: md 有、json 字段说明无；同属申报单位，外传不解析。
+
+ignored:
+  - name: dataSource
+    display_name: 数据来源
+    group: ignored
+    layout: none
+    parse: false
+    ignore: true
+    notes: json 标注可忽略。
+
+  - name: promiseItem1
+    display_name: 承诺事项1
+    group: ignored
+    layout: none
+    parse: false
+    ignore: true
+    notes: json 标注可忽略。
+
+  - name: promiseItem2
+    display_name: 承诺事项2
+    group: ignored
+    layout: none
+    parse: false
+    ignore: true
+    notes: json 标注可忽略。
+
+  - name: promiseItem3
+    display_name: 承诺事项3
+    group: ignored
+    layout: none
+    parse: false
+    ignore: true
+    notes: json 标注可忽略。
+
+  - name: id
+    display_name: 商品项内部ID
+    group: goods
+    layout: none
+    parse: false
+    ignore: true
+    notes: json 标注可忽略。不要生成 UUID。输出商品项时不要写这个键。
+
+  - name: sysBillNo
+    display_name: 公司单据编号
+    group: ignored
+    layout: none
+    parse: false
+    ignore: true
+    notes: 系统主键，不解析。
+
+  - name: ownerCompanyId
+    display_name: 业务所属公司主键
+    group: ignored
+    layout: none
+    parse: false
+    ignore: true
+    notes: 系统主键，不解析。
+
+  - name: ownerCompanyCode
+    display_name: 业务所属公司代码
+    group: ignored
+    layout: none
+    parse: false
+    ignore: true
+    notes: 系统主键，不解析。
+
+  - name: ownerCompanyName
+    display_name: 业务所属公司名称
+    group: ignored
+    layout: none
+    parse: false
+    ignore: true
+    notes: 系统主键，不解析。
+
+  - name: requestId
+    display_name: API传递ID
+    group: ignored
+    layout: none
+    parse: false
+    ignore: true
+    notes: 系统主键，不解析。
+
+  - name: headId
+    display_name: 表头主键id
+    group: head
+    layout: none
+    parse: false
+    ignore: true
+    notes: json 字段名是 id。系统主键，不解析。
+
+  - name: decId
+    display_name: 报关单id
+    group: ignored
+    layout: none
+    parse: false
+    ignore: true
+    notes: 系统主键，不解析。
+
+empty_arrays:
+  - name: tdecContasVoArr
+    display_name: 集装箱
+    group: array
+    layout: empty_array
+    parse: false
+    value_type: array
+    notes: 有则空数组。本期不验收必填。
+
+  - name: tdecCoplimitVoArr
+    display_name: 企业资质
+    group: array
+    layout: empty_array
+    parse: false
+    value_type: array
+    notes: 有则空数组。本期不验收必填。
+
+  - name: tdecDocusVoArr
+    display_name: 随附单证
+    group: array
+    layout: empty_array
+    parse: false
+    value_type: array
+    notes: 有则空数组。草单原文先收在 attachedDocs，拆条交后续组装。
+
+  - name: tdecEdocRealationVoArr
+    display_name: 电子随附单据
+    group: array
+    layout: empty_array
+    parse: false
+    value_type: array
+    notes: 有则空数组。本期不验收必填。
+
+  - name: tdecOthersPacksVoArr
+    display_name: 其他包装
+    group: array
+    layout: empty_array
+    parse: false
+    value_type: array
+    notes: 有则空数组。本期不验收必填。
+
+  - name: tdecRequCertVoArr
+    display_name: 检验检疫申报要素
+    group: array
+    layout: empty_array
+    parse: false
+    value_type: array
+    notes: 有则空数组。本期不验收必填。
+
+  - name: tdecUsersVoArr
+    display_name: 检验检疫使用单位联系人
+    group: array
+    layout: empty_array
+    parse: false
+    value_type: array
+    notes: 有则空数组。本期不验收必填。
+
+  - name: tdecEcoRelVoArr
+    display_name: 原产地
+    group: array
+    layout: empty_array
+    parse: false
+    value_type: array
+    notes: 有则空数组。本期不验收必填。
+
+  - name: tdecGoodsitemsVin
+    display_name: 许可证VIN
+    group: array
+    layout: empty_array
+    parse: false
+    value_type: array
+    notes: 有则空数组。本期不验收必填。
+
+head:
+  - name: cusIEFlag
+    display_name: 进出口类型
+    group: head
+    layout: default
     sources: [customs_declaration]
-    pattern: '^[A-Za-z0-9]{10,32}$'
+    anchors: [进出口类型]
+    notes: E 出口 / I 进口。本期只做出口，组装时默认 E，不从申报单位猜。
+
+  - name: entryType
+    display_name: 报关单类型
+    group: head
+    layout: none
+    sources: [customs_declaration]
+    anchors: [报关单类型]
+    code_table: 报关单类型
+    notes: 参考 JSON 常为 M。草单通常无此格，抽不到就空，不编造。
+
+  - name: entryId
+    display_name: 海关编号
+    group: head
+    layout: box_kv
+    sources: [customs_declaration]
     anchors: [海关编号, 报关单号, 报关单编号]
-    extractors: [rule, llm]
+    notes: md 补。未申报常空，不作为本期必填。
 
-  - name: invoice_no
-    display_name: 发票号
-    required: false
-    value_type: string
-    sources: [invoice, customs_declaration]
-    anchors: [发票号, Invoice No, Invoice Number]
-    extractors: [rule, llm]
+  - name: preEntryId
+    display_name: 预录入编号
+    group: head
+    layout: box_kv
+    sources: [customs_declaration]
+    anchors: [预录入编号]
+    notes: md 补。草单有格则抽。
 
-  - name: contract_no
-    display_name: 合同号
-    required: false
-    value_type: string
-    sources: [contract, customs_declaration]
-    anchors: [合同号, 合同协议号, Contract No]
-    extractors: [rule, llm]
-
-  - name: declaration_date
+  - name: declDate
     display_name: 申报日期
-    required: false
+    group: head
+    layout: box_kv
     value_type: date
     sources: [customs_declaration]
-    anchors: [申报日期, 出口日期, 进口日期]
-    extractors: [rule, llm]
+    anchors: [申报日期]
+    notes: 草单有独立格，和 ieDate（进/出口日期）不是同一个字段。json / md 都未列此键，键名待业务确认（海关报文常用 dDate）。
 
-  - name: total_amount
-    display_name: 总价
-    required: false
-    value_type: money
+  - name: tradeName
+    display_name: 境内收发货人名称
+    group: head
+    layout: box_kv
+    sources: [customs_declaration]
+    anchors: [境内发货人, 境内收发货人]
+    notes: 框表常与海关代码写在同一格，名称/代码拆分交 #17。
+
+  - name: tradeCode
+    display_name: 10位境内收发货人海关代码
+    group: head
+    layout: box_kv
+    sources: [customs_declaration]
+    anchors: [境内发货人, 境内收发货人]
+    notes: 常嵌在「境内发货人」同一格末尾。
+
+  - name: tradeScc
+    display_name: 18位境内收发货人信用代码
+    group: head
+    layout: box_kv
+    sources: [customs_declaration]
+    anchors: [信用代码, 社会信用代码]
+    notes: 草单常无独立格；有则抽。
+
+  - name: tradeCiqCode
+    display_name: 境内收发货人检验检疫代码
+    group: head
+    layout: box_kv
+    sources: [customs_declaration]
+    anchors: [检验检疫代码]
+    notes: 草单常无独立格；有则抽。
+
+  - name: consignorEname
+    display_name: 境外收发货人英文名称
+    group: head
+    layout: box_kv
+    sources: [customs_declaration]
+    anchors: [境外收货人, 境外收发货人]
+    notes: 出口草单「境外收货人」。
+
+  - name: ownerName
+    display_name: 生产销售单位名称
+    group: head
+    layout: box_kv
+    sources: [customs_declaration]
+    anchors: [生产销售单位, 消费使用单位]
+    notes: 文件里有就抽，没有就空。
+
+  - name: ownerCode
+    display_name: 生产销售单位代码
+    group: head
+    layout: box_kv
+    sources: [customs_declaration]
+    anchors: [生产销售单位, 消费使用单位]
+    notes: 文件里有就抽。常与名称同一格。
+
+  - name: ownerScc
+    display_name: 18位生产销售单位信用代码
+    group: head
+    layout: box_kv
+    sources: [customs_declaration]
+    anchors: [生产销售单位]
+    notes: 文件里有就抽。
+
+  - name: ownerCiqCode
+    display_name: 生产销售单位检验检疫代码
+    group: head
+    layout: box_kv
+    sources: [customs_declaration]
+    anchors: [生产销售单位]
+    notes: 文件里有就抽。
+
+  - name: customMaster
+    display_name: 申报地海关代码
+    group: head
+    layout: box_kv
+    sources: [customs_declaration]
+    anchors: [申报地海关]
+    code_table: 海关口岸代码
+    notes: 四位关区。见 port_mapping。草单不一定有独立格。
+
+  - name: iePort
+    display_name: 进/出口口岸
+    group: head
+    layout: box_kv
+    sources: [customs_declaration]
+    anchors: [出境关别, 出口口岸, 进口口岸, 进/出口口岸]
+    code_table: 海关口岸代码
+    notes: md 补。草单「出境关别」进本字段，不要写进 customMaster。
+
+  - name: ciqEntyPortCode
+    display_name: 入境/离境口岸代码
+    group: head
+    layout: box_kv
+    sources: [customs_declaration]
+    anchors: [离境口岸, 入境口岸]
+    code_table: 入境/离境口岸
+    notes: md / json 漏标。见 port_mapping。
+
+  - name: distinatePort
+    display_name: 经停港/指运港
+    group: head
+    layout: box_kv
+    sources: [customs_declaration]
+    anchors: [指运港, 经停港]
+    code_table: 港口代码
+    notes: 名称转码交 #14。
+
+  - name: despPortCode
+    display_name: 启运港
+    group: head
+    layout: box_kv
+    sources: [customs_declaration]
+    anchors: [启运港]
+    code_table: 港口代码
+    notes: json 漏标。出口常空。
+
+  - name: ieDate
+    display_name: 进/出口日期
+    group: head
+    layout: box_kv
+    value_type: date
+    sources: [customs_declaration]
+    anchors: [出口日期, 进口日期, 进/出口日期]
+    notes: md 补。不要和「申报日期」混成一个字段。
+
+  - name: cusTrafMode
+    display_name: 运输方式代码
+    group: head
+    layout: box_kv
+    sources: [customs_declaration]
+    anchors: [运输方式]
+    code_table: 运输方式
+    notes: 名称如「公路运输」转码交 #14。
+
+  - name: trafName
+    display_name: 运输工具名称
+    group: head
+    layout: box_kv
+    sources: [customs_declaration]
+    anchors: [运输工具名称及航次号, 运输工具名称]
+    notes: md 补。草单常与航次号同一格，拆分交 #17。
+
+  - name: cusVoyageNo
+    display_name: 航次号
+    group: head
+    layout: box_kv
+    sources: [customs_declaration]
+    anchors: [运输工具名称及航次号, 航次号]
+    notes: md / json 漏标。与 trafName 同一格。
+
+  - name: billNo
+    display_name: 提运单号
+    group: head
+    layout: box_kv
+    sources: [customs_declaration]
+    anchors: [提运单号]
+    notes: md 补。国光参考 JSON 有此字段。
+
+  - name: licenseNo
+    display_name: 许可证号
+    group: head
+    layout: box_kv
+    sources: [customs_declaration]
+    anchors: [许可证号]
+    notes: md 补。无则空。
+
+  - name: manualNo
+    display_name: 备案号
+    group: head
+    layout: box_kv
+    sources: [customs_declaration]
+    anchors: [备案号]
+    notes: 无则空。
+
+  - name: contrNo
+    display_name: 合同协议号
+    group: head
+    layout: box_kv
+    sources: [customs_declaration, contract]
+    anchors: [合同协议号, 合同号, Contract No]
+    notes: 框表优先；合同 sheet 只补充。
+
+  - name: supvModeCdde
+    display_name: 监管方式/贸易方式
+    group: head
+    layout: box_kv
+    sources: [customs_declaration]
+    anchors: [监管方式, 贸易方式]
+    code_table: 监管方式
+    notes: 字段名按 json 原样（Cdde）。恒信草单 G7 标签错写成「监管方式」的版面问题不在本 Issue。
+
+  - name: cutMode
+    display_name: 征免性质
+    group: head
+    layout: box_kv
+    sources: [customs_declaration]
+    anchors: [征免性质]
+    code_table: 征免性质
+    notes: 恒信草单该格不在正下方，版面刀 #15 再补；目录仍收此字段。
+
+  - name: cusTradeNationCode
+    display_name: 贸易国别(地区)
+    group: head
+    layout: box_kv
+    sources: [customs_declaration]
+    anchors: [贸易国（地区）, 贸易国(地区), 贸易国别]
+    code_table: 国别
+    notes: 框表「贸易国（地区）」。
+
+  - name: cusTradeCountry
+    display_name: 启运(运抵)国
+    group: head
+    layout: box_kv
+    sources: [customs_declaration]
+    anchors: [运抵国（地区）, 运抵国(地区), 启运国, 运抵国]
+    code_table: 国别
+    notes: 出口对应运抵国。
+
+  - name: wrapType
+    display_name: 包装种类代码
+    group: head
+    layout: box_kv
+    sources: [customs_declaration]
+    anchors: [包装种类]
+    code_table: 包装种类
+    notes: 名称转码交 #14。
+
+  - name: packNo
+    display_name: 件数
+    group: head
+    layout: box_kv
+    value_type: number
+    sources: [customs_declaration, packing_list]
+    anchors: [件数]
+    notes: 恒信草单公式引用装箱单。有海关框表以框表为准，箱单补充。
+
+  - name: grossWt
+    display_name: 毛重(公斤)
+    group: head
+    layout: box_kv
+    value_type: number
+    sources: [customs_declaration, packing_list]
+    anchors: [毛重（千克）, 毛重(千克), 毛重]
+    notes: 框表优先。别名 G.W. 交 #13。
+
+  - name: netWt
+    display_name: 净重(公斤)
+    group: head
+    layout: box_kv
+    value_type: number
+    sources: [customs_declaration, packing_list]
+    anchors: [净重（千克）, 净重(千克), 净重]
+    notes: 框表优先。别名 N.W. 交 #13。
+
+  - name: transMode
+    display_name: 成交方式
+    group: head
+    layout: box_kv
+    sources: [customs_declaration]
+    anchors: [成交方式]
+    code_table: 成交方式
+    notes: 名称如 FOB 转码交 #14。
+
+  - name: feeMark
+    display_name: 运费标志
+    group: head
+    layout: box_kv
+    sources: [customs_declaration]
+    anchors: [运费]
+    notes: 与 feeRate / feeCurr 同一格，拆分交 #17。无则空。
+
+  - name: feeRate
+    display_name: 运费值
+    group: head
+    layout: box_kv
+    value_type: number
+    sources: [customs_declaration]
+    anchors: [运费]
+    notes: 与运费标志同一格。
+
+  - name: feeCurr
+    display_name: 运费货币类型
+    group: head
+    layout: box_kv
+    sources: [customs_declaration]
+    anchors: [运费]
+    code_table: 币制
+    notes: 与运费标志同一格。
+
+  - name: insurMark
+    display_name: 保险费标志
+    group: head
+    layout: box_kv
+    sources: [customs_declaration]
+    anchors: [保费, 保险费]
+    notes: 与 insurRate / insurCurr 同一格。无则空。
+
+  - name: insurRate
+    display_name: 保费值
+    group: head
+    layout: box_kv
+    value_type: number
+    sources: [customs_declaration]
+    anchors: [保费, 保险费]
+    notes: 与保费标志同一格。
+
+  - name: insurCurr
+    display_name: 保费货币类型
+    group: head
+    layout: box_kv
+    sources: [customs_declaration]
+    anchors: [保费, 保险费]
+    code_table: 币制
+    notes: 与保费标志同一格。
+
+  - name: otherMark
+    display_name: 杂费标志
+    group: head
+    layout: box_kv
+    sources: [customs_declaration]
+    anchors: [杂费]
+    notes: 与 otherRate / otherCurr 同一格。无则空。
+
+  - name: otherRate
+    display_name: 杂费值
+    group: head
+    layout: box_kv
+    value_type: number
+    sources: [customs_declaration]
+    anchors: [杂费]
+    notes: 与杂费标志同一格。
+
+  - name: otherCurr
+    display_name: 杂费货币类型
+    group: head
+    layout: box_kv
+    sources: [customs_declaration]
+    anchors: [杂费]
+    code_table: 币制
+    notes: 与杂费标志同一格。
+
+  - name: markNo
+    display_name: 标记唛码
+    group: head
+    layout: box_kv
+    sources: [customs_declaration, packing_list]
+    anchors: [标记唛码及备注, 标记唛码]
+    notes: json 默认 N/M。草单常与备注同一格，拆分交 #17。抽不到不编造 N/M（那是接口侧默认，校验 #20 再定）。
+
+  - name: noteS
+    display_name: 备注
+    group: head
+    layout: box_kv
+    sources: [customs_declaration]
+    anchors: [备注, 标记唛码及备注]
+    notes: 与唛码可能同一格。
+
+  - name: attachedDocs
+    display_name: 随附单证及编号
+    group: head
+    layout: box_kv
+    sources: [customs_declaration]
+    anchors: [随附单证及编号, 随附单证]
+    notes: 草单有格。结构化数组见 tdecDocusVoArr；本字段先收原文。拆条交后续组装。
+
+  - name: goodsPlace
+    display_name: 货物存放地点
+    group: head
+    layout: box_kv
+    sources: [customs_declaration]
+    anchors: [货物存放地点]
+    notes: json 漏标。半岛参考 JSON 有；出口草单常无。
+
+  - name: promiseItems
+    display_name: 其他事项确认(TCS承诺事项)
+    group: head
+    layout: none
+    sources: [customs_declaration]
+    anchors: [承诺事项, 其他事项确认]
+    notes: json 有。草单通常无。promiseItem1/2/3 已忽略，本字段可空。
+
+goods:
+  - name: gno
+    display_name: 商品序号
+    group: goods
+    layout: table_col
+    value_type: number
+    sources: [customs_declaration]
+    anchors: [项号]
+    notes: 商品表列。有海关商品表以它为主。
+
+  - name: codeTs
+    display_name: 商品编号(T+S)
+    group: goods
+    layout: table_col
+    sources: [customs_declaration]
+    anchors: [商品编号]
+    notes: HS 编码。
+
+  - name: gname
+    display_name: 商品名称
+    group: goods
+    layout: table_col
+    sources: [customs_declaration, packing_list, invoice]
+    anchors: [商品名称, 商品名称及规格型号, 货物名称, 物料名称]
+    notes: 海关商品表优先。别名交 #13。
+
+  - name: gmodel
+    display_name: 规格型号
+    group: goods
+    layout: table_col
+    sources: [customs_declaration]
+    anchors: [申报要素, 规格型号]
+    notes: 恒信在「申报要素」列。规范编码 0|0|... 本期留原文，不在本 Issue 组装。
+
+  - name: brand
+    display_name: 品牌
+    group: goods
+    layout: table_col
+    sources: [customs_declaration]
+    anchors: [品牌]
+    notes: 草单商品表有「品牌」列。json 曾标可忽略，按必须项收入。也可能写进 gmodel，重复时交 #18。
+
+  - name: declPrice
+    display_name: 申报单价
+    group: goods
+    layout: table_col
+    value_type: number
     sources: [customs_declaration, invoice]
-    anchors: [总价, 价税合计, Amount]
-    extractors: [rule, llm]
+    anchors: [单价]
+    notes: 海关商品表优先，发票补充。
+
+  - name: declTotal
+    display_name: 申报总价
+    group: goods
+    layout: table_col
+    value_type: number
+    sources: [customs_declaration, invoice]
+    anchors: [总价]
+    notes: 海关商品表优先。可能是公式。
+
+  - name: tradeCurr
+    display_name: 币制
+    group: goods
+    layout: table_col
+    sources: [customs_declaration, invoice]
+    anchors: [币制]
+    code_table: 币制
+    notes: 表上常是 HKD/USD 字母，转码交 #14。
+
+  - name: gqty
+    display_name: 成交数量
+    group: goods
+    layout: table_col
+    value_type: number
+    sources: [customs_declaration, packing_list, invoice]
+    anchors: [数量, 成交数量, 出货数量, Qty]
+    notes: 海关商品表优先。别名交 #13。
+
+  - name: gunit
+    display_name: 成交单位
+    group: goods
+    layout: table_col
+    sources: [customs_declaration]
+    anchors: [计价单位, 成交单位]
+    code_table: 计量单位
+    notes: 名称转码交 #14。
+
+  - name: qty1
+    display_name: 法定第一数量
+    group: goods
+    layout: table_col
+    value_type: number
+    sources: [customs_declaration, packing_list]
+    anchors: [重量, 重量KG, 法定数量, 净重]
+    notes: 恒信「重量KG」进本字段还是 customNetWt，交 #18。本期目录两字段都收。
+
+  - name: unit1
+    display_name: 法定第一计量单位
+    group: goods
+    layout: table_col
+    sources: [customs_declaration]
+    anchors: [法定第一计量单位, 法定单位]
+    code_table: 计量单位
+    notes: 草单常无独立列；有则抽。
+
+  - name: qty2
+    display_name: 法定第二数量
+    group: goods
+    layout: table_col
+    value_type: number
+    sources: [customs_declaration]
+    anchors: [法定第二数量]
+    notes: 仅部分商品有。无则空。
+
+  - name: unit2
+    display_name: 法定第二计量单位
+    group: goods
+    layout: table_col
+    sources: [customs_declaration]
+    anchors: [法定第二计量单位]
+    code_table: 计量单位
+    notes: 仅部分商品有。无则空。
+
+  - name: cusOriginCountry
+    display_name: 原产国(地区)
+    group: goods
+    layout: table_col
+    sources: [customs_declaration]
+    anchors: [原产国]
+    code_table: 国别
+    notes: 名称转码交 #14。
+
+  - name: destinationCountry
+    display_name: 最终目的国代码
+    group: goods
+    layout: table_col
+    sources: [customs_declaration]
+    anchors: [最终目的国]
+    code_table: 国别
+    notes: 名称转码交 #14。
+
+  - name: districtCode
+    display_name: 境内目的地/境内货源地
+    group: goods
+    layout: table_col
+    sources: [customs_declaration]
+    anchors: [境内货源地, 境内目的地]
+    code_table: 国内地区
+    notes: 出口为境内货源地。
+
+  - name: dutyMode
+    display_name: 征免方式
+    group: goods
+    layout: table_col
+    sources: [customs_declaration]
+    anchors: [征免, 征免方式]
+    code_table: 征免方式
+    notes: 与表头 cutMode（征免性质）不是同一个字段。
+
+  - name: customGrossWet
+    display_name: 自定义毛重
+    group: goods
+    layout: table_col
+    value_type: number
+    sources: [customs_declaration, packing_list]
+    anchors: [毛重]
+    notes: json 原字段名 Wet。箱单可补充。无则空。
+
+  - name: customNetWt
+    display_name: 自定义净重
+    group: goods
+    layout: table_col
+    value_type: number
+    sources: [customs_declaration, packing_list]
+    anchors: [净重, 重量KG]
+    notes: 与 qty1 的分工交 #18。
+
+  - name: exgVersion
+    display_name: 加工成品单耗版本号
+    group: goods
+    layout: table_col
+    sources: [customs_declaration]
+    anchors: [单耗版本号]
+    notes: json 有。一般贸易常空。

--- a/src/docparse/schema/loader.py
+++ b/src/docparse/schema/loader.py
@@ -2,27 +2,63 @@ from functools import lru_cache
 from pathlib import Path
 
 import yaml
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 
 class FieldSpec(BaseModel):
     name: str
     display_name: str
-    required: bool = False
+    required: bool = False  # 本期不区分必填/选填，一律 False；后期再标
     value_type: str = "string"
     sources: list[str] = Field(default_factory=list)
     pattern: str | None = None
     anchors: list[str] = Field(default_factory=list)
     extractors: list[str] = Field(default_factory=lambda: ["rule"])
+    group: str = "head"
+    layout: str = "box_kv"
+    parse: bool = True
+    ignore: bool = False
+    notes: str = ""
+    code_table: str | None = None
+
+
+class PortMapping(BaseModel):
+    draft_label: str
+    field: str
+    code_table: str
+    status: str
+    notes: str = ""
 
 
 class Schema(BaseModel):
-    version: int = 1
+    version: int = 2
     document_types: list[str] = Field(default_factory=list)
+    goods_array: str = "tdecGoodsitemsVoArr"
+    port_mapping: list[PortMapping] = Field(default_factory=list)
+    caller_params: list[FieldSpec] = Field(default_factory=list)
+    ignored: list[FieldSpec] = Field(default_factory=list)
+    empty_arrays: list[FieldSpec] = Field(default_factory=list)
+    head: list[FieldSpec] = Field(default_factory=list)
+    goods: list[FieldSpec] = Field(default_factory=list)
     fields: list[FieldSpec] = Field(default_factory=list)
 
+    @model_validator(mode="after")
+    def fill_fields(self) -> "Schema":
+        if not self.fields:
+            self.fields = [*self.head, *self.goods]
+        return self
+
     def field(self, name: str) -> FieldSpec | None:
-        return next((item for item in self.fields if item.name == name), None)
+        for collection in (
+            self.fields,
+            self.caller_params,
+            self.ignored,
+            self.empty_arrays,
+        ):
+            hit = next((item for item in collection if item.name == name), None)
+            if hit is not None:
+                return hit
+        return None
 
 
 @lru_cache(maxsize=1)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -23,7 +23,7 @@ def test_parse_text_declaration_number() -> None:
     assert job.status in {JobStatus.SUCCEEDED, JobStatus.NEEDS_REVIEW}
     assert job.result is not None
     fields = job.result.package.fields
-    field = next(item for item in fields if item.name == "customs_declaration_no")
+    field = next(item for item in fields if item.name == "entryId")
     assert field.value == "ABCD1234567890"
     assert field.evidence
     docs = job.result.package.documents
@@ -37,7 +37,7 @@ def test_parse_zip_with_text_member() -> None:
     job = _pipeline().process("pack.zip", buffer.getvalue())
     assert job.result is not None
     fields = job.result.package.fields
-    field = next(item for item in fields if item.name == "customs_declaration_no")
+    field = next(item for item in fields if item.name == "entryId")
     assert field.value == "XYZ9876543210"
 
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,7 +1,238 @@
+from pathlib import Path
+
 from docparse.schema.loader import load_schema
 
+ROOT = Path(__file__).resolve().parents[1]
 
-def test_placeholder_schema_loads() -> None:
+JSON_HEAD = {
+    "cusIEFlag",
+    "consignorEname",
+    "agentCode",
+    "agentName",
+    "agentScc",
+    "ownerCode",
+    "ownerName",
+    "ownerScc",
+    "ownerCiqCode",
+    "transMode",
+    "contrNo",
+    "cusTradeCountry",
+    "cusTradeNationCode",
+    "cutMode",
+    "grossWt",
+    "netWt",
+    "cusTrafMode",
+    "customMaster",
+    "distinatePort",
+    "entryType",
+    "feeCurr",
+    "feeMark",
+    "feeRate",
+    "insurCurr",
+    "insurMark",
+    "insurRate",
+    "otherCurr",
+    "otherMark",
+    "otherRate",
+    "manualNo",
+    "markNo",
+    "noteS",
+    "promiseItems",
+    "supvModeCdde",
+    "wrapType",
+    "tradeScc",
+    "tradeCode",
+    "tradeCiqCode",
+    "tradeName",
+    "packNo",
+    "dataSource",
+    "promiseItem1",
+    "promiseItem2",
+    "promiseItem3",
+}
+
+JSON_GOODS = {
+    "gno",
+    "codeTs",
+    "gname",
+    "gmodel",
+    "declPrice",
+    "declTotal",
+    "tradeCurr",
+    "gqty",
+    "gunit",
+    "qty1",
+    "unit1",
+    "qty2",
+    "unit2",
+    "cusOriginCountry",
+    "destinationCountry",
+    "districtCode",
+    "dutyMode",
+    "exgVersion",
+    "customGrossWet",
+    "customNetWt",
+    "id",
+    "brand",
+}
+
+MUST_HEAD = {
+    "preEntryId",
+    "entryId",
+    "tradeName",
+    "tradeCode",
+    "iePort",
+    "ieDate",
+    "declDate",
+    "manualNo",
+    "consignorEname",
+    "cusTrafMode",
+    "trafName",
+    "cusVoyageNo",
+    "billNo",
+    "goodsPlace",
+    "ownerName",
+    "ownerCode",
+    "supvModeCdde",
+    "licenseNo",
+    "despPortCode",
+    "contrNo",
+    "cusTradeNationCode",
+    "cusTradeCountry",
+    "distinatePort",
+    "ciqEntyPortCode",
+    "wrapType",
+    "packNo",
+    "grossWt",
+    "netWt",
+    "transMode",
+    "feeMark",
+    "insurMark",
+    "otherMark",
+    "attachedDocs",
+    "markNo",
+    "noteS",
+}
+
+MUST_GOODS = {
+    "gno",
+    "codeTs",
+    "gname",
+    "gmodel",
+    "brand",
+    "gqty",
+    "gunit",
+    "declPrice",
+    "declTotal",
+    "tradeCurr",
+    "cusOriginCountry",
+    "destinationCountry",
+    "districtCode",
+}
+
+
+def _all_names(schema) -> set[str]:
+    names: set[str] = set()
+    for collection in (
+        schema.head,
+        schema.goods,
+        schema.caller_params,
+        schema.ignored,
+        schema.empty_arrays,
+    ):
+        names.update(item.name for item in collection)
+    return names
+
+
+def test_catalog_covers_json_and_must_items() -> None:
     schema = load_schema()
-    assert schema.field("customs_declaration_no") is not None
-    assert "rule" in schema.field("customs_declaration_no").extractors
+    names = _all_names(schema)
+    assert not (JSON_HEAD - names), JSON_HEAD - names
+    assert not (JSON_GOODS - names), JSON_GOODS - names
+    assert not (MUST_HEAD - names), MUST_HEAD - names
+    assert not (MUST_GOODS - names), MUST_GOODS - names
+    assert schema.goods_array == "tdecGoodsitemsVoArr"
+    assert schema.field("entryId") is not None
+    assert "rule" in schema.field("entryId").extractors
+
+
+def test_no_required_distinction_this_issue() -> None:
+    schema = load_schema()
+    for spec in [*schema.head, *schema.goods]:
+        assert spec.required is False, spec.name
+
+
+def test_agent_fields_are_caller_params() -> None:
+    schema = load_schema()
+    by_name = {item.name: item for item in schema.caller_params}
+    for name in ("agentCode", "agentName", "agentScc", "agentCiqCode"):
+        spec = by_name[name]
+        assert spec.parse is False
+        assert spec.layout == "caller"
+        assert spec.group == "caller"
+
+
+def test_ignored_items_listed() -> None:
+    schema = load_schema()
+    names = {item.name for item in schema.ignored}
+    assert {
+        "dataSource",
+        "promiseItem1",
+        "promiseItem2",
+        "promiseItem3",
+        "sysBillNo",
+        "ownerCompanyId",
+        "requestId",
+        "decId",
+    } <= names
+    assert "brand" not in names
+    assert any(item.name == "id" and item.group == "goods" for item in schema.ignored)
+    assert any(item.name == "headId" for item in schema.ignored)
+    assert all(item.ignore and not item.parse for item in schema.ignored)
+
+
+def test_port_mapping() -> None:
+    schema = load_schema()
+    by_label = {item.draft_label: item for item in schema.port_mapping}
+    assert by_label["申报地海关"].field == "customMaster"
+    assert by_label["出境关别"].field == "iePort"
+    assert by_label["离境口岸"].field == "ciqEntyPortCode"
+    assert by_label["指运港"].field == "distinatePort"
+    assert {item.status for item in schema.port_mapping} == {"decided"}
+    assert schema.field("iePort").layout == "box_kv"
+    assert schema.field("customMaster").code_table == "海关口岸代码"
+    assert schema.field("ciqEntyPortCode").code_table == "入境/离境口岸"
+
+
+def test_layouts_answer_where_fields_come_from() -> None:
+    schema = load_schema()
+    allowed = {"box_kv", "table_col", "caller", "default", "none", "empty_array"}
+    for spec in [*schema.head, *schema.goods, *schema.caller_params, *schema.empty_arrays]:
+        assert spec.layout in allowed, spec.name
+        assert spec.notes, spec.name
+    assert schema.field("declDate").layout == "box_kv"
+    assert schema.field("brand").layout == "table_col"
+    assert schema.field("attachedDocs").layout == "box_kv"
+    assert schema.field("tdecDocusVoArr").layout == "empty_array"
+    assert schema.field("gmodel").layout == "table_col"
+    assert schema.field("tdecContasVoArr").layout == "empty_array"
+
+
+def test_customer_originals_not_in_repo() -> None:
+    forbidden_names = (
+        "（恒信）一般贸易草单HDX260251BLU.xlsx",
+        "（国光）箱单发票合同26VN0502-1.xlsx",
+        "基础报关参数数据.xlsx",
+        "SJ25084373-310795HKD.pdf",
+    )
+    tracked = [
+        path
+        for path in ROOT.rglob("*")
+        if path.is_file() and ".git" not in path.parts and "__pycache__" not in path.parts
+    ]
+    names = {path.name for path in tracked}
+    for name in forbidden_names:
+        assert name not in names, name
+    for path in tracked:
+        if path.suffix.lower() in {".xlsx", ".xls", ".pdf", ".zip"}:
+            raise AssertionError(f"binary original slipped in: {path}")


### PR DESCRIPTION
Closes #12

## 改了什么

- 用 json 字段名收表头 + 商品项目录，草单上看得到、json 没有的从 md 补（申报日期 `declDate`、提运单号、许可证号、出境关别、离境口岸、运输工具/航次、随附单证原文等）
- `agent*` 标明外传、不解析；系统主键 / `dataSource` / `promiseItem1-3` 列入忽略
- 集装箱等块约定空数组，本期不展开
- 口岸对照写死：出境关别 → `iePort`，申报地海关 → `customMaster`，离境口岸 → `ciqEntyPortCode`
- 本期不区分必填/选填；同义词和列名别名交给 #13

## 怎么验

- [x] `ruff check src tests`
- [x] `pytest`
- [x] 对照 Issue 验收标准已满足
- [x] 客户原件不进仓库