### PR TITLE
feat: 版面刀补齐冒号、双行表头与商业单据 KV

### DIFF
--- a/docs/layout-vocab.md
+++ b/docs/layout-vocab.md
@@ -2,28 +2,44 @@
 
 运行时读取 [`src/docparse/schema/layout_vocab.yaml`](../src/docparse/schema/layout_vocab.yaml)。`layout.py` 不再维护 Python 词表常量。
 
-本文件只回答「哪些格子算框表标签 / 表头词」。抽出的 key、列名仍是格子原文，不在这里映射到报关字段（那是 #17 / #18）。
+本文件只回答「哪些格子算框表标签 / 商业单据键 / 表头词」。抽出的 key、列名仍是格子原文，不在这里映射到报关字段（那是 #17 / #18）。
 
-## 匹配规则（本期不改刀法）
+## 匹配规则（#15 刀法）
 
 | 词表 | 怎么比 |
 |---|---|
-| BOX | 去首尾空白和 `:` / `：` 后**整词相等** |
+| BOX | 去首尾空白和冒号后**整词相等** |
+| KV | 同 BOX；大小写不敏感。商业单据键，**不参与**「整行 BOX 不当表头」 |
 | TABLE | token 是单元格的**子串**；英文 token 大小写不敏感，且按字母数字词边界（`HS` 不打中 `THIS`） |
 | 表头行 | 一行至少 3 个非空格，且至少 **2** 个格子命中 TABLE token |
 | 例外 | 一行格子去冒号后**全部**是 BOX 标签（至少 3 个）→ 框表标签横排，不当表头。否则「毛重」进 TABLE 后会把恒信草单 r11 吃成表 |
+| 双行表头 | 表头下一行像翻译（≥2 格像列名、不像数字/日期）→ 并入 `headers`（中英文空格拼接），英文行不当 body[0]。`header_row` 仍是第一行，`header_rows` 记下两行 |
+| 冒号 | 半角 `:`、全角 `：`、小冒号 `﹕`（U+FE55）、竖排 `︰`。整格已是日期时间则不切；切完左侧像日期时间也不切。值里后续冒号保留 |
 
-双行表头（中文行 + 下一行英文翻译）并入 header，交 [#15](https://github.com/Baldwinzc/docparse/issues/15)，本词表只提供英文 token。
+几何策略仍是互斥：`same_cell` > `below` > `right`。多候选按值域排除交 [#29](https://github.com/Baldwinzc/docparse/issues/29)。
+
+`id` 只是分组，不接到 `fields.yaml`。值域约束以后挂在 id 上，不挂每条 alias。
 
 ## BOX
 
 恒信草单「一般贸易出口」框表标签迁入，并补 #12 对照表里这张出口草单没有的进出口镜像和空格。
 
-中文简称「毛重」「净重」收入 BOX。**G.W. / N.W. 不进 BOX**（样本里只当列名）。
-
-英文商业单据 KV（`Invoice No.`、`Bill To`、`DATE`、`SELLER` / `BUYER`、`CONTRACT NO.`、`SHIPPED PER`）本期不收，后期子 Issue 只补 BOX 英文 KV，TABLE 英文已在本文件。
+中文简称「毛重」「净重」收入 BOX。**G.W. / N.W. 不进 BOX / KV**（样本里只当列名）。
 
 每条别名的 `source` 写在 YAML 里（哪张表哪格，或 #12 依据）。
+
+## KV
+
+商业单据键，和 BOX 分开，避免一行三个英文标签被「整行 BOX」当成框表横排。
+
+- 发票号：`Invoice No.`、`INVOICE NO.`、`发票号INVOICE NO.`、`发票/INVOICE NO.`
+- 收货：`Bill To`
+- 日期：`DATE`、`Date`、`日期DATE`、`日期`
+- 买卖方：`SELLER` / `卖方SELLER` / `卖 方`，`BUYER` / `买方BUYER` / `买 方`
+- 合同号：`CONTRACT NO.`、`合同号CONTRACT NO.`
+- 运输：`SHIPPED PER`、`运输工具 SHIPPED PER`
+
+`same_cell` / `right` 认键时用 `box ∪ kv`。以后 `P.O. No.` 只加 YAML。
 
 ## TABLE
 
@@ -42,4 +58,4 @@
 
 ## 增别名
 
-改 YAML，不必改 Python。`id` 只是分组，不接到 `fields.yaml`。
+改 YAML，不必改 Python。新格子关系（不是新文案）另开刀法 Issue。

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -28,7 +28,7 @@ docparse/
 |---|---|---|---|
 | 接入与安全检查 | `pipeline/steps/ingest.py` | 骨架：大小 / 空文件 | 补 MIME、真实类型 |
 | 安全解压 | `adapters/parsers/unpack.py` + `steps/unpack.py` | 骨架：zip 穿越 / 层数 / 体积 | rar/7z、加密包 |
-| 按文件类型解析 | `adapters/parsers/` | 文本可用；Excel 全 sheet + 框表/冒号/表头（#9）；PDF 需可选依赖；图片未接 OCR | PDF / 国光冒号加强 / 扫描件 OCR |
+| 按文件类型解析 | `adapters/parsers/` | 文本可用；Excel 全 sheet + 框表/冒号/双行表头/KV（#9 #15）；PDF 需可选依赖；图片未接 OCR | PDF / 扫描件 OCR |
 | 统一文档 IR | `domain/ir.py` | Cell 含合并/边框/公式；Sheet 含 key_values / tables | 非必要不改契约名 |
 | 文档分类 | `extraction/classify.py` | 关键词占位 | 按真实样本补规则 / LLM |
 | 字段抽取 | `extraction/fields.py` | 锚点规则 + LLM 接口 | 目录已在 #12，映射交 #17/#18 |
@@ -56,7 +56,7 @@ docparse/
 
 ## 模块接口约定
 
-Excel 框表拆分（#9）：`adapters/parsers/layout.py` 从格子拆 `key_values` / `tables`，还不映射报关字段。BOX / TABLE 词表在 `schema/layout_vocab.yaml`（#13），`layout.py` 读文件不再维护 Python 常量。本地对眼用 `python -m docparse.cli layout file.xlsx`。
+Excel 框表拆分（#9 / #15）：`adapters/parsers/layout.py` 从格子拆 `key_values` / `tables`，还不映射报关字段。词表在 `schema/layout_vocab.yaml`（#13）：BOX 框表标签、KV 商业单据键、TABLE 表头词。`layout.py` 读文件不再维护 Python 常量。刀法：冒号变体、日期时间不切、双行表头并入 `headers`（`header_rows` 可多行）。值域排除交 #29。本地对眼用 `python -m docparse.cli layout file.xlsx`。
 
 名称转 code（#14）：`schema/code_tables.yaml` 全量转录 + `load_code_tables().lookup(表, 名称)`。精确匹配，未知返回空。海关口岸（四位）与港口代码分开。xlsx 原件不入库。俗称别名交 #27。
 

--- a/src/docparse/adapters/parsers/layout.py
+++ b/src/docparse/adapters/parsers/layout.py
@@ -10,7 +10,17 @@ import re
 from docparse.domain.ir import Cell, KeyValue, Sheet, Table
 from docparse.schema.loader import load_layout_vocab
 
-_COLON = re.compile(r"^([^：:]{1,40}?)\s*[：:]\s*(.+)$")
+# 半角 / 全角 / 小冒号（U+FE55）/ 竖排冒号。不按客户码点特判。
+_COLON_CHARS = ":：﹕︰"
+_COLON_CLASS = re.escape(_COLON_CHARS)
+_SPLIT_COLON = re.compile(rf"^(.{{1,40}}?)\s*[{_COLON_CLASS}]\s*(.+)$")
+_TRAIL_COLON = re.compile(rf"[{_COLON_CLASS}]+$")
+_DATETIME_FULL = re.compile(
+    r"^\d{4}[-/]\d{1,2}[-/]\d{1,2}(?:[ T]\d{1,2}:\d{2}(?::\d{2}(?:\.\d+)?)?)?$"
+)
+_DATETIME_LEFT = re.compile(r"^\d{4}[-/]\d{1,2}[-/]\d{1,2}(?:[ T]\d{1,2})?$")
+_TIME_FULL = re.compile(r"^\d{1,2}:\d{2}(?::\d{2}(?:\.\d+)?)?$")
+_NUMERIC = re.compile(r"^[\d.,]+$")
 
 
 def split_sheet(sheet: Sheet) -> Sheet:
@@ -35,11 +45,18 @@ def _detect_tables(cells: list[Cell]) -> list[Table]:
         row_cells = sorted(by_row[row_idx], key=lambda c: c.column or 0)
         if not _is_header_row(row_cells):
             continue
-        headers = [c.value for c in row_cells]
+        header_rows = [row_idx]
+        extra_row = row_idx + 1
+        extra_cells = sorted(by_row.get(extra_row, []), key=lambda c: c.column or 0)
+        if extra_row not in used_rows and _is_translation_row(extra_cells):
+            header_rows.append(extra_row)
+            used_rows.add(extra_row)
+        headers = _compose_headers(row_cells, extra_cells if len(header_rows) > 1 else [])
         header_cells = [c.address for c in row_cells]
         columns = [c.column for c in row_cells]
+        body_start = header_rows[-1] + 1
         body: list[dict[str, str]] = []
-        for body_row in range(row_idx + 1, row_idx + 200):
+        for body_row in range(body_start, body_start + 200):
             if body_row not in by_row:
                 break
             used_rows.add(body_row)
@@ -55,12 +72,33 @@ def _detect_tables(cells: list[Cell]) -> list[Table]:
         tables.append(
             Table(
                 header_row=row_idx,
+                header_rows=header_rows,
                 headers=headers,
                 header_cells=header_cells,
                 rows=body,
             )
         )
     return tables
+
+
+def _compose_headers(row_cells: list[Cell], extra_cells: list[Cell]) -> list[str]:
+    extra_by_col = {c.column: c.value for c in extra_cells}
+    headers: list[str] = []
+    for cell in row_cells:
+        headers.append(_join_header(cell.value, extra_by_col.get(cell.column, "")))
+    return headers
+
+
+def _join_header(primary: str, extra: str) -> str:
+    left = primary.strip()
+    right = extra.strip()
+    if not right or right == left:
+        return left
+    if left in right:
+        return right
+    if right in left:
+        return left
+    return f"{left} {right}"
 
 
 def _table_tokens() -> tuple[str, ...]:
@@ -71,6 +109,30 @@ def _box_labels() -> frozenset[str]:
     return load_layout_vocab().box_labels()
 
 
+def _kv_labels() -> frozenset[str]:
+    return load_layout_vocab().kv_labels()
+
+
+def _all_kv_keys() -> frozenset[str]:
+    return _box_labels() | _kv_labels()
+
+
+def _norm_label(text: str) -> str:
+    cleaned = re.sub(r"\s+", " ", _label_text(text))
+    return cleaned.casefold()
+
+
+def _kv_norms() -> frozenset[str]:
+    return frozenset(_norm_label(item) for item in _all_kv_keys())
+
+
+def _is_known_key(text: str) -> bool:
+    cleaned = _label_text(text)
+    if cleaned in _all_kv_keys():
+        return True
+    return _norm_label(cleaned) in _kv_norms()
+
+
 def _token_in_text(token: str, text: str) -> bool:
     if token.isascii() and any(ch.isalpha() for ch in token):
         pattern = r"(?<![A-Za-z0-9])" + re.escape(token) + r"(?![A-Za-z0-9])"
@@ -79,11 +141,16 @@ def _token_in_text(token: str, text: str) -> bool:
 
 
 def _label_text(text: str) -> str:
-    return text.strip().rstrip("：:").strip()
+    return _TRAIL_COLON.sub("", text.strip()).strip()
+
+
+def _ends_with_colon(text: str) -> bool:
+    stripped = text.strip()
+    return bool(stripped) and stripped[-1] in _COLON_CHARS
 
 
 def _is_box_label_row(row_cells: list[Cell]) -> bool:
-    """框表标签横排（包装种类/件数/毛重…）不当表头。"""
+    """框表标签横排（包装种类/件数/毛重…）不当表头。只看 BOX，不看 KV。"""
     labels = _box_labels()
     hits = 0
     for cell in row_cells:
@@ -107,13 +174,58 @@ def _is_header_row(row_cells: list[Cell]) -> bool:
     return hits >= 2
 
 
+def _looks_like_data_cell(text: str) -> bool:
+    stripped = text.strip()
+    if not stripped:
+        return False
+    if _DATETIME_FULL.match(stripped) or _TIME_FULL.match(stripped):
+        return True
+    if _NUMERIC.match(stripped) and any(ch.isdigit() for ch in stripped):
+        return True
+    return False
+
+
+def _looks_like_header_cell(text: str) -> bool:
+    stripped = text.strip()
+    if not stripped or _looks_like_data_cell(stripped):
+        return False
+    if any(_token_in_text(token, stripped) for token in _table_tokens()):
+        return True
+    letters = [ch for ch in stripped if ch.isalpha()]
+    if len(letters) < 3:
+        return False
+    ascii_letters = [ch for ch in letters if ch.isascii()]
+    return len(ascii_letters) >= 3 and len(ascii_letters) >= len(letters) * 0.6
+
+
+def _is_translation_row(row_cells: list[Cell]) -> bool:
+    """中文表头下一行是英文翻译 / 补充表头，不当数据行。"""
+    if len(row_cells) < 2:
+        return False
+    if _is_box_label_row(row_cells):
+        return False
+    data_like = 0
+    header_like = 0
+    for cell in row_cells:
+        text = cell.value
+        if _looks_like_data_cell(text):
+            data_like += 1
+        elif _looks_like_header_cell(text):
+            header_like += 1
+    if data_like >= 2:
+        return False
+    return header_like >= 2 and header_like > data_like
+
+
 def _table_cells(tables: list[Table], cells: list[Cell]) -> set[str]:
     if not tables:
         return set()
     table_rows: set[int] = set()
     for table in tables:
-        table_rows.add(table.header_row)
-        table_rows.update(range(table.header_row + 1, table.header_row + 1 + len(table.rows)))
+        header_rows = table.header_rows or [table.header_row]
+        table_rows.update(header_rows)
+        start = max(header_rows) + 1
+        table_rows.update(range(start, start + len(table.rows)))
     return {cell.address for cell in cells if cell.row in table_rows}
 
 
@@ -147,12 +259,25 @@ def _detect_key_values(cells: list[Cell], occupied: set[str]) -> list[KeyValue]:
     return found
 
 
-def _same_cell_colon(cell: Cell) -> KeyValue | None:
-    match = _COLON.match(cell.value)
+def _split_colon(text: str) -> tuple[str, str] | None:
+    match = _SPLIT_COLON.match(text.strip())
     if not match:
         return None
     key, value = match.group(1).strip(), match.group(2).strip()
     if not key or not value:
+        return None
+    return key, value
+
+
+def _same_cell_colon(cell: Cell) -> KeyValue | None:
+    text = cell.value.strip()
+    if _DATETIME_FULL.match(text) or _TIME_FULL.match(text):
+        return None
+    split = _split_colon(text)
+    if not split:
+        return None
+    key, value = split
+    if _DATETIME_LEFT.match(key) or _TIME_FULL.match(key):
         return None
     if any(_token_in_text(token, key) for token in _table_tokens()):
         return None
@@ -167,12 +292,12 @@ def _same_cell_colon(cell: Cell) -> KeyValue | None:
 
 def _looks_like_label(text: str) -> bool:
     stripped = text.strip()
-    cleaned = stripped.rstrip("：:").strip()
-    if not cleaned or len(cleaned) > 20:
+    cleaned = _label_text(stripped)
+    if not cleaned or len(cleaned) > 40:
         return False
-    if cleaned in _box_labels():
+    if _is_known_key(cleaned):
         return True
-    if stripped.endswith((":", "：")) and not re.fullmatch(r"[\d.\-]+", cleaned):
+    if _ends_with_colon(stripped) and not re.fullmatch(r"[\d.\-]+", cleaned):
         return True
     return False
 
@@ -190,9 +315,9 @@ def _value_below(
     other = by_pos.get((below_row, cell.column))
     if other is None or other.address in occupied or not other.value:
         return None
-    if _looks_like_label(other.value) and not _COLON.match(other.value):
+    if _same_cell_colon(other) is not None or _looks_like_label(other.value):
         return None
-    key = cell.value.strip().rstrip("：:").strip()
+    key = _label_text(cell.value)
     return KeyValue(
         key=key,
         value=other.value,
@@ -210,14 +335,14 @@ def _value_right(
     if cell.row is None or cell.column is None:
         return None
     text = cell.value.strip()
-    key = text.rstrip("：:").strip()
-    if not (text.endswith((":", "：")) or key in _box_labels()):
+    key = _label_text(text)
+    if not (_ends_with_colon(text) or _is_known_key(key)):
         return None
     right_col = _merge_right(cell) + 1
     other = by_pos.get((cell.row, right_col))
     if other is None or other.address in occupied or not other.value:
         return None
-    if _looks_like_label(other.value):
+    if _same_cell_colon(other) is not None or _looks_like_label(other.value):
         return None
     return KeyValue(
         key=key,

--- a/src/docparse/domain/ir.py
+++ b/src/docparse/domain/ir.py
@@ -56,6 +56,7 @@ class KeyValue(BaseModel):
 
 class Table(BaseModel):
     header_row: int
+    header_rows: list[int] = Field(default_factory=list)
     headers: list[str] = Field(default_factory=list)
     header_cells: list[str] = Field(default_factory=list)
     rows: list[dict[str, str]] = Field(default_factory=list)

--- a/src/docparse/schema/layout_vocab.yaml
+++ b/src/docparse/schema/layout_vocab.yaml
@@ -1,15 +1,12 @@
-# 版面词表（Issue #13）
-# BOX：去冒号后整词相等。TABLE：子串匹配（英文大小写不敏感），一行 ≥2 命中才当表头。
+# 版面词表（Issue #13 / #15）
+# BOX：去冒号后整词相等；整行都是 BOX 才不当表头。
+# KV：商业单据键，匹配同 BOX，但不参与「整行 BOX 不当表头」。
+# TABLE：子串匹配（英文大小写不敏感），一行 ≥2 命中才当表头。
 # 抽出的 key / 列名仍是格子原文，不在这里映射到 fields.yaml。
 # 客户原件不进仓库；source 只引用样本路径，方便对照。
-#
-# 本期不收（后期子 Issue：商业单据英文 KV 别名 BOX）：
-#   Invoice No. 恒信装箱单!I4；Bill To 恒信装箱单!A7；
-#   DATE / 日期DATE 国光总箱单!A6；SELLER / BUYER 国光总箱单!A8/F8；
-#   CONTRACT NO. 国光总箱单!G7；SHIPPED PER 国光发票!A11；
-#   G.W. / N.W. 当框表键（样本里只当列名）。
-# 双行表头（中文行 + 英文翻译行并入 header）交 #15，不在本文件改刀法。
+# G.W. / N.W. 不进 BOX / KV（样本里只当列名）。
 # TABLE 不加「单位」（防误伤「生产销售单位」）。
+# 值域排除（多候选按形状丢掉不像的）交 #29，本文件先不写 value:。
 
 version: 1
 
@@ -229,6 +226,66 @@ box:
     aliases:
       - text: 申报地海关
         source: "#12 customMaster。恒信 G2 只有「（深惠州关）」，无此标签"
+
+kv:
+  - id: invoice_no
+    aliases:
+      - text: "Invoice No."
+        source: "恒信装箱单!I4（格末 U+FE55 小冒号，值在右格）"
+      - text: "INVOICE NO."
+        source: "国光发票!F6「发票号INVOICE NO.」"
+      - text: "发票号INVOICE NO."
+        source: 国光发票!F6
+      - text: "发票/INVOICE NO."
+        source: 国光总箱单 发票号混写格
+
+  - id: bill_to
+    aliases:
+      - text: Bill To
+        source: "恒信装箱单!A7「Bill To : BLU PRECISION LIMITED」"
+
+  - id: date
+    aliases:
+      - text: DATE
+        source: "国光总箱单!A6「日期DATE:」；值在右格，可能是 Excel 日期时间"
+      - text: Date
+        source: "恒信装箱单!I5「Date：2026-8-6」"
+      - text: 日期DATE
+        source: 国光总箱单!A6
+      - text: 日期
+        source: 国光「日期DATE」中文短写
+
+  - id: seller
+    aliases:
+      - text: SELLER
+        source: 国光总箱单!A8
+      - text: 卖方SELLER
+        source: 国光总箱单卖方格
+      - text: 卖 方
+        source: "恒信合同!A5「卖 方:」"
+
+  - id: buyer
+    aliases:
+      - text: BUYER
+        source: 国光总箱单买方格
+      - text: 买方BUYER
+        source: 国光发票!A6
+      - text: 买 方
+        source: 恒信合同!A8
+
+  - id: contract_no
+    aliases:
+      - text: "CONTRACT NO."
+        source: 国光总箱单!G7
+      - text: "合同号CONTRACT NO."
+        source: 国光总箱单合同号混写格
+
+  - id: shipped_per
+    aliases:
+      - text: SHIPPED PER
+        source: 国光发票!A11
+      - text: 运输工具 SHIPPED PER
+        source: "国光发票!A11「运输工具 SHIPPED PER:」"
 
 table:
   - id: gno

--- a/src/docparse/schema/loader.py
+++ b/src/docparse/schema/loader.py
@@ -74,10 +74,14 @@ class VocabGroup(BaseModel):
 class LayoutVocab(BaseModel):
     version: int = 1
     box: list[VocabGroup] = Field(default_factory=list)
+    kv: list[VocabGroup] = Field(default_factory=list)
     table: list[VocabGroup] = Field(default_factory=list)
 
     def box_labels(self) -> frozenset[str]:
         return frozenset(alias.text for group in self.box for alias in group.aliases)
+
+    def kv_labels(self) -> frozenset[str]:
+        return frozenset(alias.text for group in self.kv for alias in group.aliases)
 
     def table_tokens(self) -> tuple[str, ...]:
         seen: list[str] = []

--- a/tests/test_excel_layout.py
+++ b/tests/test_excel_layout.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import io
+from datetime import datetime
 from pathlib import Path
 
 import pytest
@@ -12,10 +13,9 @@ from openpyxl.styles import Border, Side
 
 from docparse.adapters.parsers.excel import parse_excel
 
-REAL_HENGXIN = Path(
-    "/Users/chenzecong/Documents/泰洲数据/AI识别Demo/AI识别Demo/"
-    "（恒信）一般贸易草单HDX260251BLU.xlsx"
-)
+_DEMO = Path("/Users/baldwin/Desktop/taizhou/AI识别Demo")
+REAL_HENGXIN = _DEMO / "（恒信）一般贸易草单HDX260251BLU.xlsx"
+REAL_GUOGUANG = _DEMO / "（国光）箱单发票合同26VN0502-1.xlsx"
 
 
 def _thin() -> Border:
@@ -203,6 +203,108 @@ def test_box_label_row_is_not_a_table() -> None:
     assert 17 in header_rows
 
 
+def _kv_colon_workbook() -> bytes:
+    book = Workbook()
+    packing = book.active
+    packing.title = "装箱单"
+    packing["I4"] = "Invoice No.﹕"
+    packing["J4"] = "HDX260251"
+    packing["I5"] = "Date：2026-8-6"
+    packing["A7"] = "Bill To : BLU PRECISION LIMITED"
+
+    invoice = book.create_sheet("发票")
+    invoice["A6"] = "日期DATE:"
+    invoice["B6"] = datetime(2026, 3, 15, 10, 30, 0)
+    invoice["F6"] = "发票号INVOICE NO.:"
+    invoice["G6"] = "26VN0502-1"
+    invoice["A11"] = "运输工具 SHIPPED PER:"
+    invoice["B11"] = "BY TRUCK"
+
+    for row in packing.iter_rows(min_row=4, max_row=7, min_col=1, max_col=10):
+        for cell in row:
+            cell.border = _thin()
+    for row in invoice.iter_rows(min_row=6, max_row=11, min_col=1, max_col=7):
+        for cell in row:
+            cell.border = _thin()
+
+    buffer = io.BytesIO()
+    book.save(buffer)
+    return buffer.getvalue()
+
+
+def _dual_header_workbook() -> bytes:
+    book = Workbook()
+    contract = book.active
+    contract.title = "合同"
+    contract["A14"] = "(1)货物名称"
+    contract["C14"] = "(3)数量"
+    contract["E14"] = "(5)单价"
+    contract["F14"] = "(6)总值"
+    contract["A15"] = "Description"
+    contract["C15"] = "Quantity"
+    contract["E15"] = "Unit Price(HKD)"
+    contract["F15"] = "Total Amount(HKD)"
+    contract["A16"] = 1
+    contract["C16"] = 150
+    contract["E16"] = 98
+    contract["F16"] = 14700
+    contract["A17"] = 2
+    contract["C17"] = 73
+    contract["E17"] = 1398
+    contract["F17"] = 10526.94
+
+    for row in contract.iter_rows(min_row=14, max_row=17, min_col=1, max_col=6):
+        for cell in row:
+            cell.border = _thin()
+
+    buffer = io.BytesIO()
+    book.save(buffer)
+    return buffer.getvalue()
+
+
+def test_special_colon_and_datetime_stay_in_key_values() -> None:
+    document = parse_excel(_kv_colon_workbook(), file_id="k1", filename="kv.xlsx")
+    packing = next(sheet for sheet in document.sheets if sheet.name == "装箱单")
+    pairs = _pairs(packing)
+    assert pairs["Invoice No."] == "HDX260251"
+    assert pairs["Date"] == "2026-8-6"
+    assert pairs["Bill To"] == "BLU PRECISION LIMITED"
+
+    invoice = next(sheet for sheet in document.sheets if sheet.name == "发票")
+    pairs = _pairs(invoice)
+    assert pairs["日期DATE"] == "2026-03-15 10:30:00"
+    assert pairs["发票号INVOICE NO."] == "26VN0502-1"
+    assert pairs["运输工具 SHIPPED PER"] == "BY TRUCK"
+    assert "2026-03-15 10" not in pairs
+    assert all("10:30:00" not in item.key for item in invoice.key_values)
+
+
+def test_dual_header_english_row_is_not_goods() -> None:
+    document = parse_excel(_dual_header_workbook(), file_id="d1", filename="contract.xlsx")
+    contract = document.sheets[0]
+    assert contract.tables
+    table = contract.tables[0]
+    assert table.header_row == 14
+    assert table.header_rows == [14, 15]
+    assert any("货物名称" in header for header in table.headers)
+    assert any("Description" in header for header in table.headers)
+    assert table.rows
+    first = table.rows[0]
+    assert "Description" not in first.values()
+    assert "1" in first.values()
+    assert "150" in first.values()
+
+
+def test_hengxin_draft_goods_table_still_single_header() -> None:
+    document = parse_excel(_box_workbook(), file_id="f1", filename="draft.xlsx")
+    draft = next(sheet for sheet in document.sheets if sheet.name == "一般贸易出口")
+    table = draft.tables[0]
+    assert table.header_row == 17
+    assert table.header_rows == [17]
+    assert table.rows[0]["项号"] == "1"
+    assert table.rows[0]["商品编号"] == "9111900000"
+
+
 @pytest.mark.skipif(not REAL_HENGXIN.exists(), reason="本地恒信样本不在 CI")
 def test_hengxin_sample_keeps_formulas_and_goods_table() -> None:
     document = parse_excel(
@@ -223,3 +325,40 @@ def test_hengxin_sample_keeps_formulas_and_goods_table() -> None:
     first = draft.tables[0].rows[0]
     assert first["项号"] == "1"
     assert first["商品编号"] == "9111900000"
+
+
+@pytest.mark.skipif(not REAL_HENGXIN.exists(), reason="本地恒信样本不在 CI")
+def test_hengxin_packing_and_contract_layout() -> None:
+    document = parse_excel(
+        REAL_HENGXIN.read_bytes(),
+        file_id="hx2",
+        filename=REAL_HENGXIN.name,
+    )
+    packing = next(sheet for sheet in document.sheets if "箱" in sheet.name)
+    pairs = _pairs(packing)
+    assert pairs.get("Invoice No.") == "HDX260251"
+    contract = next(sheet for sheet in document.sheets if sheet.name == "合同")
+    assert contract.tables
+    table = contract.tables[0]
+    assert table.rows
+    assert "Description" not in table.rows[0].values()
+
+
+@pytest.mark.skipif(not REAL_GUOGUANG.exists(), reason="本地国光样本不在 CI")
+def test_guoguang_invoice_number_and_date_in_kv() -> None:
+    document = parse_excel(
+        REAL_GUOGUANG.read_bytes(),
+        file_id="gg",
+        filename=REAL_GUOGUANG.name,
+    )
+    packing = next(sheet for sheet in document.sheets if "箱" in sheet.name)
+    pairs = _pairs(packing)
+    date_keys = [key for key in pairs if "DATE" in key.upper() or key.startswith("日期")]
+    assert date_keys, pairs
+    date_value = pairs[date_keys[0]]
+    assert "2026" in date_value or date_value.replace(".", "").isdigit()
+    invoice_sheet = next(sheet for sheet in document.sheets if "发票" in sheet.name)
+    invoice_pairs = _pairs(invoice_sheet)
+    invoice_keys = [key for key in invoice_pairs if "INVOICE" in key.upper() or "发票" in key]
+    assert invoice_keys, invoice_pairs
+    assert any("26VN0502" in invoice_pairs[key] for key in invoice_keys)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -239,7 +239,15 @@ def test_layout_vocab_covers_issue_aliases() -> None:
     assert "申报要素" in table
     assert "货物名称" in table
     assert "单位" not in table
-    assert all(alias.source for group in [*vocab.box, *vocab.table] for alias in group.aliases)
+    kv = vocab.kv_labels()
+    assert "Invoice No." in kv
+    assert "日期DATE" in kv
+    assert "SHIPPED PER" in kv
+    assert "Invoice No." not in box
+    assert "G.W." not in kv
+    assert all(
+        alias.source for group in [*vocab.box, *vocab.kv, *vocab.table] for alias in group.aliases
+    )
 
 
 def test_customer_originals_not_in_repo() -> None:


### PR DESCRIPTION
## 关联

Closes #15

## 改了什么

- `layout.py`：冒号变体（半角 / 全角 / U+FE55）可切 KV；整格或切完左侧像日期时间则不切，值里后续冒号保留。
- 双行表头：中文行下一行英文翻译并入 `headers`（空格拼接），英文行不当商品第 1 行。`Table.header_rows` 记下所有表头行，`header_row` 仍是第一行。
- 词表单开 `kv:`（Invoice No. / DATE / Bill To / SELLER 等），不参与「整行 BOX 不当表头」。认键用 `box ∪ kv`。
- 几何策略仍互斥（`same_cell` > `below` > `right`）。值域排除另开 #29。
- 合成 fixture 覆盖三种格子关系；恒信草单回归仍过。客户原件不入库。

## 怎么验

- [x] `ruff check src tests`
- [x] `pytest`（29 passed）
- [x] 对照 Issue 验收标准已满足