### PR TITLE
feat: 单 sheet 表头映射 BOX/KV → TdecHead（#17）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,7 @@ git worktree add -b feat/12-pdf-parser ../docparse-12-pdf-parser origin/main
 - 描述必须包含 `Closes #编号`。
 - 提交作者用 `1018067278@qq.com`，不加 Co-Authored-By Claude。
 - 提交说明、PR / Issue 正文和评论里**严禁**出现 `Generated with Claude Code`、机器人标记、Claude / Anthropic 署名或任何 AI 生成声明。
+- 功能 PR 必须有一节 **「以后新 xlsx / 新叫法改哪」**：用表格写清新文案、新语义、新格子关系、跨表合并分别改哪个文件、动不动 Python。不要只把扩展路径留在对话里。
 - push / 建 PR 前先确认。
 - 本仓库是个人仓：**CI 绿且确认后合并**。不要直接推 main。
 

--- a/docs/field-schema.md
+++ b/docs/field-schema.md
@@ -47,14 +47,14 @@
 |---|---|---|
 | 预录入编号 | `preEntryId` | box_kv |
 | 海关编号 | `entryId` | box_kv |
-| 境内发/收货人 | `tradeName` + `tradeCode`（同一格常粘在一起，拆分交 #17） | box_kv |
+| 境内发/收货人 | `tradeName` + `tradeCode`（同一格末尾 10 位海关代码，#17 `trailing_code`） | box_kv |
 | 出/进境关别 | `iePort` | box_kv |
 | 进口日期 / 出口日期 | `ieDate` | box_kv |
 | 申报日期 | `declDate`（json/md 未列此键，键名待确认） | box_kv |
 | 备案号 | `manualNo` | box_kv |
 | 境外收/发货人 | `consignorEname` | box_kv |
 | 运输方式 | `cusTrafMode` | box_kv |
-| 运输工具名称及航次号 | `trafName` + `cusVoyageNo`（同一格，拆分交 #17） | box_kv |
+| 运输工具名称及航次号 | `trafName`（整格）；航次拆分见 #35 | box_kv |
 | 提运单号 | `billNo` | box_kv |
 | 货物存放地点 | `goodsPlace` | box_kv |
 | 生产销售单位 / 消费使用单位 | `ownerName` + `ownerCode` | box_kv |
@@ -71,11 +71,11 @@
 | 毛重（千克） | `grossWt` | box_kv |
 | 净重（千克） | `netWt` | box_kv |
 | 成交方式 | `transMode` | box_kv |
-| 运费 | `feeMark` / `feeRate` / `feeCurr`（同一格，拆分交 #17） | box_kv |
-| 保费 | `insurMark` / `insurRate` / `insurCurr` | box_kv |
-| 杂费 | `otherMark` / `otherRate` / `otherCurr` | box_kv |
+| 运费 | `fee*` 本层 skip，拆分见 #34 | box_kv |
+| 保费 | `insur*` 本层 skip，拆分见 #34 | box_kv |
+| 杂费 | `other*` 本层 skip，拆分见 #34 | box_kv |
 | 随附单证及编号 | `attachedDocs`（原文）+ `tdecDocusVoArr`（数组，拆条交后续） | box_kv |
-| 标记唛码及备注 | `markNo` + `noteS`（同一格，拆分交 #17） | box_kv |
+| 标记唛码及备注 | `markNo`（整格）；与备注拆分见 #36。独立「备注」进 `noteS` | box_kv |
 
 json 另有、用户这次没点名但仍收的：`cusIEFlag`、`entryType`、`cutMode`、`customMaster`、`tradeScc`、`tradeCiqCode`、`ownerScc`、`ownerCiqCode`、`promiseItems`。
 
@@ -139,7 +139,8 @@ json 另有、用户这次没点名但仍收的：`qty1` / `unit1` / `qty2` / `u
 - 必填 / 选填
 - BOX / TABLE 同义词、列名别名（#13，已抽到 `schema/layout_vocab.yaml`）
 - 名称转 code（#14，已抽到 `schema/code_tables.yaml`）
-- 同一格拆成多个字段、跨表补充（#17 / #18）
+- 同一格稳拆（名称+海关代码）在 #17；运费 / 航次 / 唛码见 #34–#36
+- 跨表补充、拼整单（#18 / #19）
 - 集装箱 / VIN 等块：空数组
 - `gmodel` 规范编码（`0|0|...`）先留原文
 - json 未列的 `*Name` 名称镜像字段不收

--- a/docs/head-map.md
+++ b/docs/head-map.md
@@ -1,0 +1,76 @@
+# 表头映射（BOX / KV → TdecHead）
+
+运行时：`extraction/head_map.py`。目录在 [`fields.yaml`](../src/docparse/schema/fields.yaml) 的 `head`。本地对眼：
+
+```bash
+python -m docparse.cli head /绝对路径/表.xlsx
+```
+
+本文件只回答「一张已经打好角色的 sheet，原文 KV 怎么变成表头字段」。不切格子（layout）、不认角色（#16）、不拼整单（#19）、不转 code（#14）。
+
+## 输入 / 输出
+
+```text
+Sheet.key_values + consume
+  → 只处理 consume ≠ exclude
+  → key 对 fields.yaml head.anchors（去空白、大小写不敏感）
+  → ExtractedField（值先留原文，证据 = sheet 名 + 格子）
+```
+
+一份 xlsx 有几张合格 sheet，就调用几次，结果**并排**。草单 `packNo=40` 和箱单上的件数不会在这一层互相覆盖。谁是主、谁补空是 #19。
+
+`auxiliary` / `unknown` 的 KV 留在 IR，本层不读。
+
+## `head_map`
+
+挂在字段上，不写公司分支。
+
+| 值 | 含义 |
+|---|---|
+| `keep`（默认） | 整格进该字段 |
+| `skip` | 本层不映射。`agent*`、由别的字段拆出的 code、不稳拆分 |
+| `trailing_code` | 值末尾 10 位海关代码（字母数字）拆给 `split_target`，前面进本字段 |
+
+稳拆只做这一种：`tradeName` / `ownerName`。没有 10 位尾巴就整格当名称，不编造代码。
+
+## 出口商业单据（不是某家公司）
+
+报关单没有 seller / buyer 槽。本期只做出口：
+
+| 商业单据键 | 进哪个字段 |
+|---|---|
+| 卖方 / SELLER / 卖 方 | `tradeName` 补充候选 |
+| 买方 / BUYER / 买 方 / Bill To | `consignorEname` 补充候选 |
+| 合同号 / CONTRACT NO. | `contrNo` |
+| Invoice No. | **不进表头**（目录无槽，见 #37） |
+
+新叫法加 `anchors`，不要 `if 国光`。进口对调另开范围。
+
+## 刻意不做（记账 Issue）
+
+| 格子 | 本层 | 以后 |
+|---|---|---|
+| 运费 / 保费 / 杂费 | skip | #34 |
+| 运输工具名称及航次号 | 整格 `trafName` | #35 |
+| 标记唛码及备注 | 整格 `markNo`；独立「备注」进 `noteS` | #36 |
+| 发票号 | 不映射 | #37 |
+| FOB / 公路运输 / 莲塘口岸 | 留中文 | #14 / #19 / #27 |
+| 申报单位 `agent*` | 不从文件填 | #21 |
+
+## 以后新 xlsx / 新叫法改哪
+
+对照 [#31](https://github.com/Baldwinzc/docparse/issues/31)。先 `cli layout`，再 `cli head`。
+
+| 你看到的现象 | 改哪里 | 动 Python？ |
+|---|---|---|
+| 键的叫法没见过，layout 都没拆出 | `layout_vocab.yaml` alias | 否 |
+| layout 有了，对不上报关字段 | 已有字段的 `anchors` | 否 |
+| 语义是新表头字段 | `fields.yaml` 新字段 + anchors | 否（映射器按目录走） |
+| 名称+代码粘在一起 | 已有 `trailing_code` | 否 |
+| 新的稳拆规则（例如 18 位信用代码） | 新 `head_map` 值 + 拆分函数 | 是，通用规则，不按公司 |
+| 运费 / 航次 / 唛码要拆 | #34–#36 | 派工后再动 |
+| 跨表谁覆盖谁 | #19 | 否 |
+| 名称要变成海关 code | #14 / #27 / #19 | 否 |
+| 发票号要进报关单 | #37 先定落点 | 视目录 |
+
+不要 `if company == "恒信"`。不要在这一层 `lookup(code_tables)`。不要把 key 在 layout 里改写成 `contrNo`。

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -31,7 +31,7 @@ docparse/
 | 按文件类型解析 | `adapters/parsers/` | 文本可用；Excel 全 sheet + 框表/冒号/双行表头/KV/值域（#9 #15 #29）；PDF 需可选依赖；图片未接 OCR | PDF / 扫描件 OCR |
 | 统一文档 IR | `domain/ir.py` | Cell 含合并/边框/公式；Sheet 含 key_values / tables / role | 非必要不改契约名 |
 | 文档分类 | `extraction/classify.py` + `sheet_role.py` | 文件类型仍占位；sheet 角色看标题/KV/表头（#16） | 新角色加 YAML |
-| 字段抽取 | `extraction/fields.py` | 锚点规则 + LLM 接口 | 目录已在 #12，映射交 #17/#18 |
+| 字段抽取 | `extraction/head_map.py` + `fields.py` | 单 sheet BOX/KV → 表头（#17）；旧锚点仍给无 sheet 的文本 | 商品映射交 #18 |
 | 标准化与校验 | `extraction/validate.py` | 格式 / 必填 / 证据 | 金额、日期、跨字段 |
 | 包级对账 | `pipeline/steps/reconcile.py` | 同名字段冲突 | 金额、单号跨文件 |
 | 自动通过 / 待复核 | `pipeline/steps/route_review.py` | 只打状态 | 复核页另开 Issue |
@@ -61,6 +61,8 @@ Excel 框表拆分（#9 / #15 / #29）：`adapters/parsers/layout.py` 从格子�
 名称转 code（#14）：`schema/code_tables.yaml` 全量转录 + `load_code_tables().lookup(表, 名称)`。精确匹配，未知返回空。海关口岸（四位）与港口代码分开。xlsx 原件不入库。俗称别名交 #27。
 
 sheet 角色（#16）：`schema/sheet_roles.yaml` + `extraction/sheet_role.py`。每张 sheet 标 `draft` / `packing` / `invoice` / `contract` / `auxiliary` / `unknown`，并带 `consume`（primary / supplement / exclude）。辅助表和 unknown 的 KV / table 留在 IR，不进下一张报关单。新叫法加 YAML，不按公司写分支。见 [sheet-roles.md](sheet-roles.md)。
+
+表头映射（#17）：`extraction/head_map.py` 吃已拆 `key_values`，按 `fields.yaml` 的 `anchors` / `head_map` 写成 TdecHead 候选。一次一张 sheet，多 sheet 并排放，不覆盖。`agent*` 不从文件填。中文值不转 code。名称+10 位海关代码用 `trailing_code`。运费 / 航次 / 唛码拆分见 #34–#36，发票号槽位见 #37。本地对眼：`python -m docparse.cli head file.xlsx`。见 [head-map.md](head-map.md)。
 
 每个 parser 只做一件事：`bytes + filename → DocumentIR`。
 

--- a/docs/sheet-roles.md
+++ b/docs/sheet-roles.md
@@ -52,7 +52,8 @@
 
 ## 本阶段不做
 
-- BOX → TdecHead（#17）
 - 跨表补货（#18）
 - 拼一张报关单（#19）
 - unknown 自动降级补空
+
+BOX → TdecHead 见 [head-map.md](head-map.md)（#17）。

--- a/src/docparse/cli.py
+++ b/src/docparse/cli.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from uuid import uuid4
 
 from docparse.adapters.parsers.registry import parse_bytes
+from docparse.extraction.head_map import map_sheet_head
 from docparse.pipeline.runner import Pipeline
 
 
@@ -19,11 +20,16 @@ def main(argv: list[str] | None = None) -> int:
     layout_cmd = sub.add_parser("layout", help="只打印解析 IR 的键值和表，不做字段映射")
     layout_cmd.add_argument("path", type=Path)
 
+    head_cmd = sub.add_parser("head", help="按 sheet 打印表头映射，不合并多 sheet")
+    head_cmd.add_argument("path", type=Path)
+
     args = parser.parse_args(argv)
     if args.command == "parse":
         return _parse(args.path)
     if args.command == "layout":
         return _layout(args.path)
+    if args.command == "head":
+        return _head(args.path)
     return 1
 
 
@@ -56,6 +62,32 @@ def _layout(path: Path) -> int:
     }
     print(json.dumps(payload, ensure_ascii=False, indent=2))
     return 0 if not document.warnings or document.sheets else 2
+
+
+def _head(path: Path) -> int:
+    document = parse_bytes(path.read_bytes(), file_id=uuid4().hex, filename=path.name)
+    payload = {
+        "filename": document.filename,
+        "sheets": [
+            {
+                "name": sheet.name,
+                "role": sheet.role,
+                "consume": sheet.consume,
+                "fields": [
+                    {
+                        "name": field.name,
+                        "value": field.value,
+                        "status": field.status.value,
+                        "evidence": [item.model_dump() for item in field.evidence],
+                    }
+                    for field in map_sheet_head(sheet, document)
+                ],
+            }
+            for sheet in document.sheets
+        ],
+    }
+    print(json.dumps(payload, ensure_ascii=False, indent=2))
+    return 0
 
 
 if __name__ == "__main__":

--- a/src/docparse/extraction/__init__.py
+++ b/src/docparse/extraction/__init__.py
@@ -1,5 +1,6 @@
 from docparse.extraction.classify import classify_document
 from docparse.extraction.fields import extract_fields
+from docparse.extraction.head_map import map_document_head, map_sheet_head
 from docparse.extraction.sheet_role import classify_sheet, classify_sheets
 from docparse.extraction.validate import validate_fields
 
@@ -8,5 +9,7 @@ __all__ = [
     "classify_sheet",
     "classify_sheets",
     "extract_fields",
+    "map_document_head",
+    "map_sheet_head",
     "validate_fields",
 ]

--- a/src/docparse/extraction/fields.py
+++ b/src/docparse/extraction/fields.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import re
+from collections import defaultdict
 
 from docparse.adapters.llm.openai_compat import LLMNotConfiguredError, OpenAICompatClient
 from docparse.domain.fields import ExtractedField, FieldStatus
 from docparse.domain.ir import DocumentIR, Evidence
+from docparse.extraction.head_map import map_document_head
 from docparse.schema.loader import FieldSpec, Schema, load_schema
 
 
@@ -15,10 +17,31 @@ def extract_fields(
 ) -> list[ExtractedField]:
     schema = schema or load_schema()
     client = llm or OpenAICompatClient()
+    mapped: list[ExtractedField] = []
+    for document in documents:
+        mapped.extend(map_document_head(document, schema))
+    by_name: dict[str, list[ExtractedField]] = defaultdict(list)
+    for field in mapped:
+        by_name[field.name].append(field)
+    used_sheet_kv = any(
+        sheet.key_values for document in documents for sheet in document.sheets
+    )
     results: list[ExtractedField] = []
     for spec in schema.fields:
-        field = _extract_one(spec, documents, client)
-        results.append(field)
+        hits = by_name.get(spec.name)
+        if hits:
+            results.extend(hits)
+            continue
+        if used_sheet_kv and spec.group == "head":
+            results.append(
+                ExtractedField(
+                    name=spec.name,
+                    display_name=spec.display_name,
+                    status=FieldStatus.MISSING,
+                )
+            )
+            continue
+        results.append(_extract_one(spec, documents, client))
     return results
 
 

--- a/src/docparse/extraction/head_map.py
+++ b/src/docparse/extraction/head_map.py
@@ -1,0 +1,131 @@
+"""单 sheet：版面 KV → 表头字段。不合并多 sheet，不转 code，不填 agent*。"""
+
+from __future__ import annotations
+
+import re
+
+from docparse.domain.fields import ExtractedField, FieldStatus
+from docparse.domain.ir import DocumentIR, Evidence, KeyValue, Sheet
+from docparse.schema.loader import FieldSpec, Schema, load_schema
+
+_SPACE = re.compile(r"\s+")
+_TRAILING_CUSTOMS_CODE = re.compile(r"^(.*?)([A-Za-z0-9]{10})$")
+_SKIP_CONSUME = frozenset({"exclude"})
+_HEAD_LAYOUTS = frozenset({"box_kv"})
+_CALLER_PREFIX = "agent"
+
+
+def map_document_head(
+    document: DocumentIR,
+    schema: Schema | None = None,
+) -> list[ExtractedField]:
+    """对文档里每张可消费 sheet 各映射一次，结果并排，不覆盖。"""
+    schema = schema or load_schema()
+    fields: list[ExtractedField] = []
+    for sheet in document.sheets:
+        fields.extend(map_sheet_head(sheet, document, schema))
+    return fields
+
+
+def map_sheet_head(
+    sheet: Sheet,
+    document: DocumentIR,
+    schema: Schema | None = None,
+) -> list[ExtractedField]:
+    schema = schema or load_schema()
+    if sheet.consume in _SKIP_CONSUME:
+        return []
+    index = _anchor_index(schema)
+    found: dict[str, ExtractedField] = {}
+    for pair in sheet.key_values:
+        if not pair.value.strip():
+            continue
+        specs = index.get(_fold_key(pair.key), [])
+        for spec in specs:
+            if spec.name in found:
+                continue
+            for field in _emit(spec, pair, sheet, document, schema):
+                if field.name not in found:
+                    found[field.name] = field
+    return list(found.values())
+
+
+def _anchor_index(schema: Schema) -> dict[str, list[FieldSpec]]:
+    index: dict[str, list[FieldSpec]] = {}
+    for spec in schema.head:
+        if not _mappable(spec):
+            continue
+        for anchor in spec.anchors:
+            index.setdefault(_fold_key(anchor), []).append(spec)
+    return index
+
+
+def _mappable(spec: FieldSpec) -> bool:
+    if spec.parse is False or spec.ignore:
+        return False
+    if spec.layout not in _HEAD_LAYOUTS:
+        return False
+    if spec.head_map == "skip":
+        return False
+    if spec.name.lower().startswith(_CALLER_PREFIX):
+        return False
+    return bool(spec.anchors)
+
+
+def _emit(
+    spec: FieldSpec,
+    pair: KeyValue,
+    sheet: Sheet,
+    document: DocumentIR,
+    schema: Schema,
+) -> list[ExtractedField]:
+    raw = pair.value.strip()
+    if spec.head_map == "trailing_code":
+        name, code = _split_trailing_code(raw)
+        fields = [_accepted(spec, name, pair, sheet, document)]
+        target = schema.field(spec.split_target or "")
+        if code and target is not None:
+            fields.append(_accepted(target, code, pair, sheet, document))
+        return fields
+    return [_accepted(spec, raw, pair, sheet, document)]
+
+
+def _split_trailing_code(value: str) -> tuple[str, str | None]:
+    compact = value.replace(" ", "")
+    match = _TRAILING_CUSTOMS_CODE.fullmatch(compact)
+    if match is None or not match.group(1):
+        return value, None
+    return match.group(1), match.group(2)
+
+
+def _accepted(
+    spec: FieldSpec,
+    value: str,
+    pair: KeyValue,
+    sheet: Sheet,
+    document: DocumentIR,
+) -> ExtractedField:
+    quote = f"{sheet.name}!{pair.key_cell}:{pair.key}"
+    return ExtractedField(
+        name=spec.name,
+        display_name=spec.display_name,
+        value=value,
+        normalized_value=value.strip(),
+        confidence=0.9,
+        status=FieldStatus.ACCEPTED,
+        extraction_method="head_map",
+        source_document_id=document.document_id,
+        evidence=[
+            Evidence(
+                document_id=document.document_id,
+                file_id=document.file_id,
+                filename=document.filename,
+                cell=f"{sheet.name}!{pair.value_cell}",
+                quote=quote[:500],
+            )
+        ],
+    )
+
+
+def _fold_key(text: str) -> str:
+    return _SPACE.sub(" ", text.strip()).casefold()

--- a/src/docparse/schema/fields.yaml
+++ b/src/docparse/schema/fields.yaml
@@ -291,8 +291,10 @@ head:
     group: head
     layout: box_kv
     sources: [customs_declaration]
-    anchors: [境内发货人, 境内收发货人]
-    notes: 框表常与海关代码写在同一格，名称/代码拆分交 #17。
+    anchors: [境内发货人, 境内收发货人, 卖方SELLER, 卖方, SELLER, 卖 方]
+    head_map: trailing_code
+    split_target: tradeCode
+    notes: 框表常与海关代码写在同一格，末尾 10 位拆给 tradeCode。出口商业单据卖方只补充。
 
   - name: tradeCode
     display_name: 10位境内收发货人海关代码
@@ -300,7 +302,8 @@ head:
     layout: box_kv
     sources: [customs_declaration]
     anchors: [境内发货人, 境内收发货人]
-    notes: 常嵌在「境内发货人」同一格末尾。
+    head_map: skip
+    notes: 由 tradeName 的 trailing_code 拆出，不单独按锚点收。
 
   - name: tradeScc
     display_name: 18位境内收发货人信用代码
@@ -323,8 +326,8 @@ head:
     group: head
     layout: box_kv
     sources: [customs_declaration]
-    anchors: [境外收货人, 境外收发货人]
-    notes: 出口草单「境外收货人」。
+    anchors: [境外收货人, 境外收发货人, 买方BUYER, 买方, BUYER, 买 方, Bill To]
+    notes: 出口草单「境外收货人」。出口商业单据买方 / Bill To 只补充。
 
   - name: ownerName
     display_name: 生产销售单位名称
@@ -332,7 +335,9 @@ head:
     layout: box_kv
     sources: [customs_declaration]
     anchors: [生产销售单位, 消费使用单位]
-    notes: 文件里有就抽，没有就空。
+    head_map: trailing_code
+    split_target: ownerCode
+    notes: 文件里有就抽，没有就空。与代码同一格时末尾 10 位拆给 ownerCode。
 
   - name: ownerCode
     display_name: 生产销售单位代码
@@ -340,7 +345,8 @@ head:
     layout: box_kv
     sources: [customs_declaration]
     anchors: [生产销售单位, 消费使用单位]
-    notes: 文件里有就抽。常与名称同一格。
+    head_map: skip
+    notes: 由 ownerName 的 trailing_code 拆出，不单独按锚点收。
 
   - name: ownerScc
     display_name: 18位生产销售单位信用代码
@@ -348,7 +354,8 @@ head:
     layout: box_kv
     sources: [customs_declaration]
     anchors: [生产销售单位]
-    notes: 文件里有就抽。
+    head_map: skip
+    notes: 文件里有就抽。不要把名称格整段当成信用代码。
 
   - name: ownerCiqCode
     display_name: 生产销售单位检验检疫代码
@@ -356,7 +363,8 @@ head:
     layout: box_kv
     sources: [customs_declaration]
     anchors: [生产销售单位]
-    notes: 文件里有就抽。
+    head_map: skip
+    notes: 文件里有就抽。不要把名称格整段当成检验检疫代码。
 
   - name: customMaster
     display_name: 申报地海关代码
@@ -427,7 +435,7 @@ head:
     layout: box_kv
     sources: [customs_declaration]
     anchors: [运输工具名称及航次号, 运输工具名称]
-    notes: md 补。草单常与航次号同一格，拆分交 #17。
+    notes: md 补。与航次同一格时整格先挂本字段；拆航次见 #35。
 
   - name: cusVoyageNo
     display_name: 航次号
@@ -435,7 +443,8 @@ head:
     layout: box_kv
     sources: [customs_declaration]
     anchors: [运输工具名称及航次号, 航次号]
-    notes: md / json 漏标。与 trafName 同一格。
+    head_map: skip
+    notes: md / json 漏标。与 trafName 同一格。拆分见 #35。
 
   - name: billNo
     display_name: 提运单号
@@ -466,8 +475,8 @@ head:
     group: head
     layout: box_kv
     sources: [customs_declaration, contract]
-    anchors: [合同协议号, 合同号, Contract No]
-    notes: 框表优先；合同 sheet 只补充。
+    anchors: [合同协议号, 合同号, Contract No, CONTRACT NO., 合同号CONTRACT NO.]
+    notes: 框表优先；合同 / 箱单只补充。多 sheet 不在本层合并。
 
   - name: supvModeCdde
     display_name: 监管方式/贸易方式
@@ -556,7 +565,8 @@ head:
     layout: box_kv
     sources: [customs_declaration]
     anchors: [运费]
-    notes: 与 feeRate / feeCurr 同一格，拆分交 #17。无则空。
+    head_map: skip
+    notes: 与 feeRate / feeCurr 同一格，拆分见 #34。无则空。
 
   - name: feeRate
     display_name: 运费值
@@ -565,7 +575,8 @@ head:
     value_type: number
     sources: [customs_declaration]
     anchors: [运费]
-    notes: 与运费标志同一格。
+    head_map: skip
+    notes: 与运费标志同一格。拆分见 #34。
 
   - name: feeCurr
     display_name: 运费货币类型
@@ -574,7 +585,8 @@ head:
     sources: [customs_declaration]
     anchors: [运费]
     code_table: 币制
-    notes: 与运费标志同一格。
+    head_map: skip
+    notes: 与运费标志同一格。拆分见 #34。
 
   - name: insurMark
     display_name: 保险费标志
@@ -582,7 +594,8 @@ head:
     layout: box_kv
     sources: [customs_declaration]
     anchors: [保费, 保险费]
-    notes: 与 insurRate / insurCurr 同一格。无则空。
+    head_map: skip
+    notes: 与 insurRate / insurCurr 同一格。拆分见 #34。无则空。
 
   - name: insurRate
     display_name: 保费值
@@ -591,7 +604,8 @@ head:
     value_type: number
     sources: [customs_declaration]
     anchors: [保费, 保险费]
-    notes: 与保费标志同一格。
+    head_map: skip
+    notes: 与保费标志同一格。拆分见 #34。
 
   - name: insurCurr
     display_name: 保费货币类型
@@ -600,7 +614,8 @@ head:
     sources: [customs_declaration]
     anchors: [保费, 保险费]
     code_table: 币制
-    notes: 与保费标志同一格。
+    head_map: skip
+    notes: 与保费标志同一格。拆分见 #34。
 
   - name: otherMark
     display_name: 杂费标志
@@ -608,7 +623,8 @@ head:
     layout: box_kv
     sources: [customs_declaration]
     anchors: [杂费]
-    notes: 与 otherRate / otherCurr 同一格。无则空。
+    head_map: skip
+    notes: 与 otherRate / otherCurr 同一格。拆分见 #34。无则空。
 
   - name: otherRate
     display_name: 杂费值
@@ -617,7 +633,8 @@ head:
     value_type: number
     sources: [customs_declaration]
     anchors: [杂费]
-    notes: 与杂费标志同一格。
+    head_map: skip
+    notes: 与杂费标志同一格。拆分见 #34。
 
   - name: otherCurr
     display_name: 杂费货币类型
@@ -626,7 +643,8 @@ head:
     sources: [customs_declaration]
     anchors: [杂费]
     code_table: 币制
-    notes: 与杂费标志同一格。
+    head_map: skip
+    notes: 与杂费标志同一格。拆分见 #34。
 
   - name: markNo
     display_name: 标记唛码
@@ -634,15 +652,15 @@ head:
     layout: box_kv
     sources: [customs_declaration, packing_list]
     anchors: [标记唛码及备注, 标记唛码]
-    notes: json 默认 N/M。草单常与备注同一格，拆分交 #17。抽不到不编造 N/M（那是接口侧默认，校验 #20 再定）。
+    notes: json 默认 N/M。与备注同一格时整格先挂本字段；拆分见 #36。抽不到不编造 N/M。
 
   - name: noteS
     display_name: 备注
     group: head
     layout: box_kv
     sources: [customs_declaration]
-    anchors: [备注, 标记唛码及备注]
-    notes: 与唛码可能同一格。
+    anchors: [备注]
+    notes: 独立「备注」键可收。与唛码同一格的拆分见 #36。
 
   - name: attachedDocs
     display_name: 随附单证及编号

--- a/src/docparse/schema/loader.py
+++ b/src/docparse/schema/loader.py
@@ -25,6 +25,19 @@ class FieldSpec(BaseModel):
     ignore: bool = False
     notes: str = ""
     code_table: str | None = None
+    # 单 sheet 表头映射（#17）。keep=原样；skip=本层不映射；
+    # trailing_code=末尾海关代码拆给 split_target。
+    head_map: str = "keep"
+    split_target: str | None = None
+
+    @model_validator(mode="after")
+    def check_head_map(self) -> "FieldSpec":
+        allowed = {"keep", "skip", "trailing_code"}
+        if self.head_map not in allowed:
+            raise ValueError(f"unknown head_map: {self.head_map}")
+        if self.head_map == "trailing_code" and not self.split_target:
+            raise ValueError(f"{self.name} trailing_code requires split_target")
+        return self
 
 
 class PortMapping(BaseModel):

--- a/tests/test_head_map.py
+++ b/tests/test_head_map.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("openpyxl")
+
+from openpyxl import Workbook
+from openpyxl.styles import Border, Side
+
+from docparse.adapters.parsers.excel import parse_excel
+from docparse.extraction.head_map import map_document_head, map_sheet_head
+from docparse.schema.loader import load_schema
+
+_DEMO = Path("/Users/baldwin/Desktop/taizhou/AI识别Demo")
+REAL_HENGXIN = _DEMO / "（恒信）一般贸易草单HDX260251BLU.xlsx"
+REAL_GUOGUANG = _DEMO / "（国光）箱单发票合同26VN0502-1.xlsx"
+
+
+def _thin() -> Border:
+    line = Side(style="thin")
+    return Border(left=line, right=line, top=line, bottom=line)
+
+
+def _workbook(builders: dict) -> bytes:
+    book = Workbook()
+    first = True
+    for title, fill in builders.items():
+        sheet = book.active if first else book.create_sheet(title)
+        if first:
+            sheet.title = title
+            first = False
+        fill(sheet)
+    buffer = io.BytesIO()
+    book.save(buffer)
+    return buffer.getvalue()
+
+
+def _draft(sheet) -> None:
+    sheet["A1"] = "中华人民共和国海关出口货物报关单"
+    sheet.merge_cells("A3:D3")
+    sheet["A3"] = "境内发货人"
+    sheet.merge_cells("A4:D4")
+    sheet["A4"] = "惠州市恒德信精密科技有限公司441394164D"
+    sheet["E3"] = "出境关别"
+    sheet["E4"] = "莲塘口岸"
+    sheet.merge_cells("A5:D5")
+    sheet["A5"] = "境外收货人"
+    sheet.merge_cells("A6:D6")
+    sheet["A6"] = "BLU PRECISION LIMITED"
+    sheet.merge_cells("A7:D7")
+    sheet["A7"] = "生产销售单位"
+    sheet.merge_cells("A8:D8")
+    sheet["A8"] = "惠州市恒德信精密科技有限公司"
+    sheet.merge_cells("A9:D9")
+    sheet["A9"] = "合同协议号"
+    sheet.merge_cells("A10:D10")
+    sheet["A10"] = "HDX2026-251"
+    sheet.merge_cells("A11:C11")
+    sheet["A11"] = "包装种类"
+    sheet["D11"] = "件数"
+    sheet["E11"] = "毛重（千克）"
+    sheet["F11"] = "净重（千克）"
+    sheet.merge_cells("G11:H11")
+    sheet["G11"] = "成交方式"
+    sheet.merge_cells("A12:C12")
+    sheet["A12"] = "其它"
+    sheet["D12"] = 40
+    sheet["E12"] = 296.46
+    sheet["F12"] = 218.375
+    sheet.merge_cells("G12:H12")
+    sheet["G12"] = "FOB"
+    sheet["I11"] = "运费"
+    sheet["I12"] = "3 USD"
+    sheet["A17"] = "项号"
+    sheet["B17"] = "商品编号"
+    sheet["C17"] = "商品名称及规格型号"
+    sheet["D17"] = "申报要素"
+    sheet["A18"] = 1
+    sheet["B18"] = "9111900000"
+    for row in sheet.iter_rows(min_row=1, max_row=18, min_col=1, max_col=9):
+        for cell in row:
+            cell.border = _thin()
+
+
+def _guoguang_packing(sheet) -> None:
+    sheet["E5"] = "装箱单 PACKING LIST"
+    sheet["A6"] = "日期DATE:"
+    sheet["B6"] = "2026-03-15"
+    sheet["A7"] = "发票/INVOICE NO.:"
+    sheet["B7"] = "26VN0502-1"
+    sheet["G7"] = "合同号CONTRACT NO.:"
+    sheet["H7"] = "26VN0502"
+    sheet["A8"] = "卖方SELLER"
+    sheet["A9"] = "GUOGUANG ELECTRIC COMPANY LIMITED."
+    sheet["F8"] = "买方BUYER"
+    sheet["F9"] = "GUOGUANG ACOUSTICS (VIETNAM) COMPANY LIMITED"
+    sheet["B12"] = "物料名称"
+    sheet["D12"] = "出货数量"
+    sheet["F12"] = "总箱数"
+    sheet["B13"] = "贴纸"
+    sheet["D13"] = 100
+    for row in sheet.iter_rows(min_row=5, max_row=13, min_col=1, max_col=10):
+        for cell in row:
+            cell.border = _thin()
+
+
+def _auxiliary_with_contract(sheet) -> None:
+    sheet["B1"] = "报关单号"
+    sheet["C1"] = "报关日期"
+    sheet["K1"] = "SAP编号"
+    sheet["A3"] = "合同协议号"
+    sheet["A4"] = "SHOULD-NOT-MAP"
+    for row in sheet.iter_rows(min_row=1, max_row=4, min_col=1, max_col=11):
+        for cell in row:
+            cell.border = _thin()
+
+
+def _by_name(fields) -> dict[str, object]:
+    grouped: dict[str, list] = {}
+    for field in fields:
+        grouped.setdefault(field.name, []).append(field)
+    return grouped
+
+
+def test_schema_head_map_flags() -> None:
+    schema = load_schema()
+    assert schema.field("tradeName").head_map == "trailing_code"
+    assert schema.field("tradeName").split_target == "tradeCode"
+    assert schema.field("tradeCode").head_map == "skip"
+    assert schema.field("ownerName").head_map == "trailing_code"
+    assert schema.field("feeMark").head_map == "skip"
+    assert schema.field("cusVoyageNo").head_map == "skip"
+    assert schema.field("agentCode").parse is False
+    assert "卖方SELLER" in schema.field("tradeName").anchors
+    assert "Bill To" in schema.field("consignorEname").anchors
+    assert "合同号CONTRACT NO." in schema.field("contrNo").anchors
+
+
+def test_hengxin_draft_head_fields() -> None:
+    document = parse_excel(
+        _workbook({"一般贸易出口": _draft}),
+        file_id="hx",
+        filename="hengxin-draft.xlsx",
+    )
+    draft = document.sheets[0]
+    assert draft.role == "draft"
+    fields = map_sheet_head(draft, document)
+    by_name = {item.name: item for item in fields}
+
+    assert by_name["contrNo"].value == "HDX2026-251"
+    assert by_name["consignorEname"].value == "BLU PRECISION LIMITED"
+    assert by_name["packNo"].value == "40"
+    assert by_name["grossWt"].value == "296.46"
+    assert by_name["netWt"].value == "218.375"
+    assert by_name["transMode"].value == "FOB"
+    assert by_name["tradeName"].value == "惠州市恒德信精密科技有限公司"
+    assert by_name["tradeCode"].value == "441394164D"
+    assert by_name["ownerName"].value == "惠州市恒德信精密科技有限公司"
+    assert "ownerCode" not in by_name
+    assert "feeMark" not in by_name
+    assert "feeRate" not in by_name
+    assert "agentCode" not in by_name
+    assert "agentName" not in by_name
+
+    for name in (
+        "contrNo",
+        "consignorEname",
+        "packNo",
+        "grossWt",
+        "netWt",
+        "transMode",
+        "tradeName",
+        "tradeCode",
+    ):
+        field = by_name[name]
+        assert field.status.value == "accepted"
+        assert field.evidence
+        assert field.evidence[0].cell.startswith("一般贸易出口!")
+        assert field.evidence[0].quote.startswith("一般贸易出口!")
+
+
+def test_guoguang_packing_contract_and_parties() -> None:
+    document = parse_excel(
+        _workbook({"总箱单": _guoguang_packing}),
+        file_id="gg",
+        filename="guoguang-packing.xlsx",
+    )
+    packing = document.sheets[0]
+    assert packing.role == "packing"
+    fields = map_sheet_head(packing, document)
+    by_name = {item.name: item for item in fields}
+
+    assert by_name["contrNo"].value == "26VN0502"
+    assert by_name["tradeName"].value == "GUOGUANG ELECTRIC COMPANY LIMITED."
+    assert by_name["consignorEname"].value == "GUOGUANG ACOUSTICS (VIETNAM) COMPANY LIMITED"
+    assert all(item.evidence for item in fields)
+    assert "billNo" not in by_name
+    assert not any(item.value == "26VN0502-1" for item in fields)
+
+
+def test_exclude_sheet_is_not_mapped() -> None:
+    document = parse_excel(
+        _workbook({"Sheet3": _auxiliary_with_contract}),
+        file_id="aux",
+        filename="aux.xlsx",
+    )
+    sheet = document.sheets[0]
+    assert sheet.consume == "exclude"
+    assert map_sheet_head(sheet, document) == []
+    assert map_document_head(document) == []
+
+
+def test_multi_sheet_keeps_separate_candidates() -> None:
+    document = parse_excel(
+        _workbook({"一般贸易出口": _draft, "总箱单": _guoguang_packing}),
+        file_id="mix",
+        filename="mix.xlsx",
+    )
+    fields = map_document_head(document)
+    grouped = _by_name(fields)
+    contracts = {item.value for item in grouped["contrNo"]}
+    assert contracts == {"HDX2026-251", "26VN0502"}
+    cells = {item.evidence[0].cell for item in grouped["contrNo"]}
+    assert any(cell.startswith("一般贸易出口!") for cell in cells)
+    assert any(cell.startswith("总箱单!") for cell in cells)
+
+
+@pytest.mark.skipif(not REAL_HENGXIN.exists(), reason="本地恒信样本不在 CI")
+def test_hengxin_sample_head() -> None:
+    document = parse_excel(
+        REAL_HENGXIN.read_bytes(),
+        file_id="hx-real",
+        filename=REAL_HENGXIN.name,
+    )
+    draft = next(sheet for sheet in document.sheets if sheet.role == "draft")
+    by_name = {item.name: item for item in map_sheet_head(draft, document)}
+    assert by_name["contrNo"].value == "HDX2026-251"
+    assert by_name["consignorEname"].value == "BLU PRECISION LIMITED"
+    assert by_name["packNo"].value == "40"
+    assert by_name["grossWt"].value == "296.46"
+    assert by_name["netWt"].value == "218.375"
+    assert by_name["transMode"].value == "FOB"
+    assert by_name["tradeCode"].value == "441394164D"
+    assert all(item.evidence for item in by_name.values())
+
+
+@pytest.mark.skipif(not REAL_GUOGUANG.exists(), reason="本地国光样本不在 CI")
+def test_guoguang_sample_head() -> None:
+    document = parse_excel(
+        REAL_GUOGUANG.read_bytes(),
+        file_id="gg-real",
+        filename=REAL_GUOGUANG.name,
+    )
+    packing = next(sheet for sheet in document.sheets if sheet.role == "packing")
+    by_name = {item.name: item for item in map_sheet_head(packing, document)}
+    assert by_name["contrNo"].value == "26VN0502"
+    assert by_name["tradeName"].value == "GUOGUANG ELECTRIC COMPANY LIMITED."
+    assert by_name["consignorEname"].value == "GUOGUANG ACOUSTICS (VIETNAM) COMPANY LIMITED"
+    assert not any(item.value == "26VN0502-1" for item in by_name.values())
+    assert all(item.evidence for item in by_name.values())

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -162,6 +162,16 @@ def test_no_required_distinction_this_issue() -> None:
         assert spec.required is False, spec.name
 
 
+def test_head_map_split_and_skip() -> None:
+    schema = load_schema()
+    assert schema.field("tradeName").head_map == "trailing_code"
+    assert schema.field("tradeCode").head_map == "skip"
+    assert schema.field("ownerName").head_map == "trailing_code"
+    assert schema.field("feeRate").head_map == "skip"
+    assert schema.field("cusVoyageNo").head_map == "skip"
+    assert schema.field("noteS").anchors == ["备注"]
+
+
 def test_agent_fields_are_caller_params() -> None:
     schema = load_schema()
     by_name = {item.name: item for item in schema.caller_params}


### PR DESCRIPTION
Closes #17

## 做了什么

按字段目录把一张 sheet 已拆的 BOX / KV 收成 TdecHead 候选。一次只看一张 sheet，多 sheet 并排放，不覆盖。

- 吃 `sheet.key_values`，不回头扫格子
- `consume=exclude`（辅助表 / unknown）不读
- `agent*` 不从文件填
- 中文值不转 code（FOB / 莲塘口岸原样）
- 稳拆：名称末尾 10 位海关代码 → `tradeCode` / `ownerCode`（`head_map: trailing_code`）
- 出口商业单据卖方 / 买方 / Bill To → `tradeName` / `consignorEname`（不是某家公司特例）
- 发票号不进表头（目录无槽，见 #37）
- 不稳拆分记账，不开发：运费 #34、航次 #35、唛码 #36

本地对眼：`python -m docparse.cli head file.xlsx`

不改：商品行、跨表合并、组装、PDF、API。客户原件不入库。

## 验收

- 恒信草单夹具：合同协议号、境外收货人、件数 40、毛重 296.46、净重、成交方式 FOB；境内发货人拆出名称 + `441394164D`
- 国光箱单夹具：合同号、卖方、买方能进；发票号不塞进 `contrNo` / `billNo`
- 每个填上的值带 `sheet!格子` 证据
- 辅助表上的「合同协议号」不映射
- 多 sheet 同一字段保留多条候选
- ruff / pytest 通过（50 passed）

## 以后新 xlsx / 新叫法改哪

| 你看到的现象 | 改哪里 | 动 Python？ |
|---|---|---|
| 键的叫法没见过，layout 都没拆出 | `layout_vocab.yaml` alias | 否 |
| layout 有了，对不上报关字段 | 已有字段的 `anchors` | 否 |
| 语义是新表头字段 | `fields.yaml` 新字段 + anchors | 否（映射器按目录走） |
| 名称+代码粘在一起 | 已有 `trailing_code` | 否 |
| 新的稳拆规则（例如 18 位信用代码） | 新 `head_map` 值 + 拆分函数 | 是，通用规则，不按公司 |
| 运费 / 航次 / 唛码要拆 | #34 / #35 / #36 | 派工后再动 |
| 跨表谁覆盖谁 | #19 | 否 |
| 名称要变成海关 code | #14 / #27 / #19 | 否 |
| 发票号要进报关单 | #37 先定落点 | 视目录 |

不要 `if company == "恒信"`。不要在这一层 `lookup(code_tables)`。