### PR TITLE
feat: 组装一张报关单（抄草单 / 拼商业单据）（#19）

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 多格式单据解析骨架：用户上传压缩包 / PDF / Excel / 图片，最终输出一张出口报关单（表头 + 商品项）。
 
-当前阶段：Excel 框表 dump 已有；输出字段目录见 [docs/field-schema.md](docs/field-schema.md)；码表见 [docs/code-tables.md](docs/code-tables.md)；sheet 角色见 [docs/sheet-roles.md](docs/sheet-roles.md)。约束：
+当前阶段：Excel 框表 dump 已有；输出字段目录见 [docs/field-schema.md](docs/field-schema.md)；码表见 [docs/code-tables.md](docs/code-tables.md)；sheet 角色见 [docs/sheet-roles.md](docs/sheet-roles.md)；整单组装见 [docs/assemble.md](docs/assemble.md)。约束：
 
 - 主链路是确定性流水线，不是 Agent，也不引入 LangChain / LangGraph
 - 模型只通过云 API 调用，不部署本地大模型
@@ -151,6 +151,7 @@ curl http://127.0.0.1:8088/health
 ```bash
 python -m docparse.cli parse path/to/file.zip
 python -m docparse.cli layout path/to/file.xlsx   # 只看键值和表，不做字段映射
+python -m docparse.cli declare path/to/file.xlsx  # 组装一张报关单 JSON
 ```
 
 ## 文档
@@ -161,6 +162,7 @@ python -m docparse.cli layout path/to/file.xlsx   # 只看键值和表，不做�
 - [云模型调研](docs/model-survey.md)（价格均附来源链接）
 - [字段 Schema](docs/field-schema.md)
 - [码表加载](docs/code-tables.md)
+- [整单组装](docs/assemble.md)
 - [版面词表](docs/layout-vocab.md)
 - [持久化预留](docs/persistence.md)
 - [开发规范](CLAUDE.md)

--- a/docs/assemble.md
+++ b/docs/assemble.md
@@ -1,0 +1,69 @@
+# 组装一张报关单
+
+运行时：`extraction/assemble.py`。策略在 [`fields.yaml`](../src/docparse/schema/fields.yaml) 的 `assembly`。本地对眼：
+
+```bash
+python -m docparse.cli declare /绝对路径/表.xlsx
+python -m docparse.cli declare /绝对路径/表.xlsx --agent-code 4403180867 --agent-name 深圳市泰洲物流有限公司
+```
+
+本文件只回答「多摊表头 + 一张货表怎么收成一张报关单」。不切格子（layout）、不认角色（#16）、不改货表对行（#18）。
+
+## 输入 / 输出
+
+```text
+已打角色的 sheets
+  → 只处理 consume ≠ exclude
+  → 有 draft：表头以草单为准；商业单据只补空，并核件毛净
+  → 无 draft：商业单据能确定的抄；customs_only 空着复核，不编
+  → 名称能转 code 就转；转不出留原文 + needs_review
+  → agent* 只来自 CLI 参数
+  → 一张 Declaration / 一份 dec_results 形状 JSON
+```
+
+`auxiliary` / `unknown` 的 KV / table 留在 IR，本层不读，不另开一张单。
+
+## `assembly`
+
+按角色，不写公司分支。
+
+| 键 | 含义 |
+|---|---|
+| `primary_role` | 有这张角色就当草单抄。默认 `draft` |
+| `role_priority` | 多摊候选时的先后。默认 draft → packing → invoice → contract |
+| `fill` | `overwrite` 覆盖 / `fill` 只补空 / `ignore` 不吃 |
+| `reconcile` | 主源已有值时，其它可消费 sheet 对一下。不一致保留主源，打 `needs_review` |
+| `customs_only` | 无草单时不从商业单据编。监管方式、征免、口岸、包装种类等 |
+| `defaults` | 组装默认值。本期只有出口 `cusIEFlag=E` |
+| `weight.net_as_weight` | 只有净重、没有毛重时，净重视同重量，进 `netWt` |
+| `weight.copy_net_to_gross` | 必须为 false。净重 ≠ 毛重，不要抄进 `grossWt` |
+| `invoice_vocab` | 发票号词表 id。目录无槽（#37），只核对，不映射 |
+
+## 重量
+
+| 表头格子 | 结果 |
+|---|---|
+| 同时有毛重、净重 | `grossWt` / `netWt` 各填各的 |
+| 只有净重 / N.W. | `netWt` 填上；`grossWt` 空 + `net_is_not_gross` |
+| 未区分的「重量」 | 视同重量，进 `netWt`；仍不进 `grossWt` |
+
+商品行 `customNetWt` / `customGrossWet` 仍归 #18，本层不改货表。
+
+## 以后新 xlsx / 新叫法改哪
+
+对照 [#31](https://github.com/Baldwinzc/docparse/issues/31)。先 `cli layout`，再 `cli head` / `cli goods`，最后 `cli declare`。
+
+| 你看到的现象 | 改哪里 | 动 Python？ |
+|---|---|---|
+| 新叫法（装箱明细、形式发票） | `sheet_roles.yaml` / `layout_vocab.yaml` / `fields.yaml` anchors | 否 |
+| 新单据类型要参与拼单 | `sheet_roles.yaml` 加 role；`assembly.fill` / `role_priority` | 否 |
+| 新辅助表 | `auxiliary` + `consume: exclude` | 否 |
+| 新表头字段 | `fields.yaml` 新字段 + anchors | 否（组装器按目录收） |
+| 新字段要转 code | 字段上写 `code_table`；码表加行 | 否 |
+| 无草单时不要编的海关项 | `assembly.customs_only` | 否 |
+| 要对一下的件毛净 / 单号 | `assembly.reconcile` | 否 |
+| 发票号要进报关单 | #37 先定落点 | 视目录 |
+| 俗称（莲塘口岸、纸箱）要转码 | #27 | 否 |
+| 货表净重抄毛重 | #18，不在这里改 | 否 |
+
+不要 `if company == "恒信"`。不要把商业单据上的监管方式 / 口岸编进无草单的单。

--- a/docs/field-schema.md
+++ b/docs/field-schema.md
@@ -4,7 +4,7 @@
 
 形状对齐 Demo `字段说明.json`；草单上看得到、json 没有的从 `报关字段说明.md` 补。客户原件不进仓库。
 
-本目录只回答「输出什么、从哪类版面来」。名称转 code 见 [code-tables.md](code-tables.md)（#14），BOX/TABLE 别名见 [layout-vocab.md](layout-vocab.md)（#13），表头映射见 [head-map.md](head-map.md)（#17），商品映射见 [goods-map.md](goods-map.md)（#18），整单组装是 #19。
+本目录只回答「输出什么、从哪类版面来」。名称转 code 见 [code-tables.md](code-tables.md)（#14），BOX/TABLE 别名见 [layout-vocab.md](layout-vocab.md)（#13），表头映射见 [head-map.md](head-map.md)（#17），商品映射见 [goods-map.md](goods-map.md)（#18），整单组装见 [assemble.md](assemble.md)（#19）。
 
 本期**不区分必填 / 选填**，YAML 里 `required` 一律未标。后期再优化。
 

--- a/docs/goods-map.md
+++ b/docs/goods-map.md
@@ -88,7 +88,7 @@ Sheet.tables + consume
 | 主表判定要加信号（备案序号） | `goods_master.signals` | 否 |
 | 对行钥匙要加（合同货号） | `goods_master.match_keys` | 否 |
 | 一列变两字段（新的稳拆） | 新 `goods_map` 值 + 拆分函数 | 是，通用规则，不按公司 |
-| 谁覆盖谁（表头件数 vs 货表加总） | #19 | 否 |
+| 谁覆盖谁（表头件数 vs 货表加总） | `fields.yaml` `assembly` / [assemble.md](assemble.md) | 否 |
 | 名称要变成海关 code | #14 / #27 / #19 | 否 |
 | 申报要素要编 `0\|0\|...` | 以后另开；本层只留原文 | 视规则 |
 

--- a/docs/head-map.md
+++ b/docs/head-map.md
@@ -69,7 +69,7 @@ Sheet.key_values + consume
 | 名称+代码粘在一起 | 已有 `trailing_code` | 否 |
 | 新的稳拆规则（例如 18 位信用代码） | 新 `head_map` 值 + 拆分函数 | 是，通用规则，不按公司 |
 | 运费 / 航次 / 唛码要拆 | #34–#36 | 派工后再动 |
-| 跨表谁覆盖谁（表头） | #19 | 否 |
+| 跨表谁覆盖谁（表头） | `fields.yaml` `assembly` / [assemble.md](assemble.md) | 否 |
 | 商品行跨表补空 | #18 / [goods-map.md](goods-map.md) | 否 |
 | 名称要变成海关 code | #14 / #27 / #19 | 否 |
 | 发票号要进报关单 | #37 先定落点 | 视目录 |

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -31,7 +31,7 @@ docparse/
 | 按文件类型解析 | `adapters/parsers/` | 文本可用；Excel 全 sheet + 框表/冒号/双行表头/KV/值域（#9 #15 #29）；PDF 需可选依赖；图片未接 OCR | PDF / 扫描件 OCR |
 | 统一文档 IR | `domain/ir.py` | Cell 含合并/边框/公式；Sheet 含 key_values / tables / role | 非必要不改契约名 |
 | 文档分类 | `extraction/classify.py` + `sheet_role.py` | 文件类型仍占位；sheet 角色看标题/KV/表头（#16） | 新角色加 YAML |
-| 字段抽取 | `extraction/head_map.py` + `goods_map.py` + `fields.py` | 单 sheet BOX/KV → 表头（#17）；TABLE → 货行并跨表补空（#18）；旧锚点仍给无 sheet 的文本 | 整单组装交 #19 |
+| 字段抽取 | `extraction/head_map.py` + `goods_map.py` + `assemble.py` + `fields.py` | 单 sheet BOX/KV → 表头（#17）；TABLE → 货行并跨表补空（#18）；多摊收成一张报关单（#19）；旧锚点仍给无 sheet 的文本 | PDF 同组装交 #23 |
 | 标准化与校验 | `extraction/validate.py` | 格式 / 必填 / 证据 | 金额、日期、跨字段 |
 | 包级对账 | `pipeline/steps/reconcile.py` | 同名字段冲突 | 金额、单号跨文件 |
 | 自动通过 / 待复核 | `pipeline/steps/route_review.py` | 只打状态 | 复核页另开 Issue |
@@ -65,6 +65,8 @@ sheet 角色（#16）：`schema/sheet_roles.yaml` + `extraction/sheet_role.py`�
 表头映射（#17）：`extraction/head_map.py` 吃已拆 `key_values`，按 `fields.yaml` 的 `anchors` / `head_map` 写成 TdecHead 候选。一次一张 sheet，多 sheet 并排放，不覆盖。`agent*` 不从文件填。中文值不转 code。名称+10 位海关代码用 `trailing_code`。运费 / 航次 / 唛码拆分见 #34–#36，发票号槽位见 #37。本地对眼：`python -m docparse.cli head file.xlsx`。见 [head-map.md](head-map.md)。
 
 商品映射（#18）：`extraction/goods_map.py` 吃已拆 `tables`，按 `fields.yaml` 的 `goods.anchors` / `goods_map` / `goods_master` 写成货行。先选主货表，其它可消费 sheet 只补空；对不上的行标来源收成补充项。`auxiliary` / `unknown` 不读。重量未区分当净重，无毛重列再抄一份到毛重。申报要素原文进 `gmodel`，不编 `0|0|...`。箱数不加字段。本地对眼：`python -m docparse.cli goods file.xlsx`。见 [goods-map.md](goods-map.md)。
+
+整单组装（#19）：`extraction/assemble.py` 按 `fields.yaml` 的 `assembly` 收成一张报关单。有 `draft` 抄草单，商业单据只补空并核件毛净；无草单只抄能确定的商业事实，`customs_only` 空着复核。名称转 code；转不出留原文。`agent*` 只来自调用参数。表头只有净重时视同重量，不抄进毛重。本地对眼：`python -m docparse.cli declare file.xlsx`。见 [assemble.md](assemble.md)。
 
 每个 parser 只做一件事：`bytes + filename → DocumentIR`。
 

--- a/docs/sheet-roles.md
+++ b/docs/sheet-roles.md
@@ -2,7 +2,7 @@
 
 运行时读取 [`src/docparse/schema/sheet_roles.yaml`](../src/docparse/schema/sheet_roles.yaml)。打分器在 `extraction/sheet_role.py`。Excel 拆完 KV / table 后贴标签；`cli layout` 一并打出。
 
-本文件只回答「这张 sheet 在业务上是什么、下一张报关单吃不吃」。不映射 `contrNo`（#17）/ 商品行（#18），不拼整单（#19）。
+本文件只回答「这张 sheet 在业务上是什么、下一张报关单吃不吃」。不映射 `contrNo`（#17）/ 商品行（#18）。拼整单见 [assemble.md](assemble.md)（#19）。
 
 ## 角色与消费
 

--- a/src/docparse/cli.py
+++ b/src/docparse/cli.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from uuid import uuid4
 
 from docparse.adapters.parsers.registry import parse_bytes
+from docparse.extraction.assemble import assemble_declaration, declaration_payload
 from docparse.extraction.goods_map import map_document_goods, map_sheet_goods
 from docparse.extraction.head_map import map_sheet_head
 from docparse.pipeline.runner import Pipeline
@@ -27,6 +28,13 @@ def main(argv: list[str] | None = None) -> int:
     goods_cmd = sub.add_parser("goods", help="按 sheet 打印商品映射，并打出合并后的一张货表")
     goods_cmd.add_argument("path", type=Path)
 
+    declare_cmd = sub.add_parser("declare", help="组装一张报关单 JSON，不另开第二张")
+    declare_cmd.add_argument("path", type=Path)
+    declare_cmd.add_argument("--agent-code", default="")
+    declare_cmd.add_argument("--agent-name", default="")
+    declare_cmd.add_argument("--agent-scc", default="")
+    declare_cmd.add_argument("--agent-ciq-code", default="")
+
     args = parser.parse_args(argv)
     if args.command == "parse":
         return _parse(args.path)
@@ -36,6 +44,16 @@ def main(argv: list[str] | None = None) -> int:
         return _head(args.path)
     if args.command == "goods":
         return _goods(args.path)
+    if args.command == "declare":
+        return _declare(
+            args.path,
+            {
+                "agentCode": args.agent_code,
+                "agentName": args.agent_name,
+                "agentScc": args.agent_scc,
+                "agentCiqCode": args.agent_ciq_code,
+            },
+        )
     return 1
 
 
@@ -114,6 +132,13 @@ def _goods(path: Path) -> int:
         "merged": [_item_payload(item) for item in map_document_goods(document)],
     }
     print(json.dumps(payload, ensure_ascii=False, indent=2))
+    return 0
+
+
+def _declare(path: Path, agent: dict[str, str]) -> int:
+    document = parse_bytes(path.read_bytes(), file_id=uuid4().hex, filename=path.name)
+    declaration = assemble_declaration(document, agent=agent)
+    print(json.dumps(declaration_payload(declaration), ensure_ascii=False, indent=2))
     return 0
 
 

--- a/src/docparse/domain/fields.py
+++ b/src/docparse/domain/fields.py
@@ -40,3 +40,20 @@ class GoodsItem(BaseModel):
             return None
         text = (field.value or "").strip()
         return text or None
+
+
+class Declaration(BaseModel):
+    """一张报关单。多 sheet 收成这一份，不按公司另开。"""
+
+    head: dict[str, ExtractedField] = Field(default_factory=dict)
+    goods: list[GoodsItem] = Field(default_factory=list)
+    review_reasons: list[str] = Field(default_factory=list)
+    has_draft: bool = False
+    source_roles: list[str] = Field(default_factory=list)
+
+    def value_of(self, name: str) -> str | None:
+        field = self.head.get(name)
+        if field is None:
+            return None
+        text = (field.value or "").strip()
+        return text or None

--- a/src/docparse/extraction/__init__.py
+++ b/src/docparse/extraction/__init__.py
@@ -1,3 +1,4 @@
+from docparse.extraction.assemble import assemble_declaration, declaration_payload
 from docparse.extraction.classify import classify_document
 from docparse.extraction.fields import extract_fields
 from docparse.extraction.goods_map import map_document_goods, map_sheet_goods
@@ -6,9 +7,11 @@ from docparse.extraction.sheet_role import classify_sheet, classify_sheets
 from docparse.extraction.validate import validate_fields
 
 __all__ = [
+    "assemble_declaration",
     "classify_document",
     "classify_sheet",
     "classify_sheets",
+    "declaration_payload",
     "extract_fields",
     "map_document_goods",
     "map_document_head",

--- a/src/docparse/extraction/assemble.py
+++ b/src/docparse/extraction/assemble.py
@@ -1,0 +1,361 @@
+"""多摊表头 + 一张货表 → 一张报关单。按角色，不按公司。"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+from docparse.domain.fields import Declaration, ExtractedField, FieldStatus, GoodsItem
+from docparse.domain.ir import DocumentIR, Evidence, Sheet
+from docparse.extraction.goods_map import map_document_goods
+from docparse.extraction.head_map import map_sheet_head
+from docparse.schema.loader import (
+    Assembly,
+    CodeTables,
+    FieldSpec,
+    LayoutVocab,
+    Schema,
+    load_code_tables,
+    load_layout_vocab,
+    load_schema,
+)
+
+_NET_FIELD = "netWt"
+_GROSS_FIELD = "grossWt"
+_SKIP_CONSUME = frozenset({"exclude"})
+
+
+def assemble_declaration(
+    document: DocumentIR,
+    *,
+    schema: Schema | None = None,
+    codes: CodeTables | None = None,
+    vocab: LayoutVocab | None = None,
+    agent: dict[str, str] | None = None,
+) -> Declaration:
+    """有草单抄草单；无草单拼商业单据。辅助 / unknown 不读，不另开一张单。"""
+    schema = schema or load_schema()
+    codes = codes or load_code_tables()
+    vocab = vocab or load_layout_vocab()
+    policy = schema.assembly
+    sheets = _ordered_sheets(document, policy)
+    head = _merge_head(sheets, document, schema)
+    _apply_defaults(head, schema)
+    _apply_weight_policy(head, schema)
+    _reconcile_head(head, sheets, document, schema)
+    _note_invoice_numbers(head, sheets, vocab, document, schema)
+    _lookup_codes(head, schema, codes)
+    _apply_agent(head, schema, agent)
+    goods = _lookup_goods(map_document_goods(document, schema), schema, codes)
+    reasons = _collect_reasons(head, goods, schema, sheets)
+    return Declaration(
+        head=head,
+        goods=goods,
+        review_reasons=reasons,
+        has_draft=any(sheet.role == policy.primary_role for sheet in sheets),
+        source_roles=[sheet.role for sheet in sheets],
+    )
+
+
+def declaration_payload(declaration: Declaration, schema: Schema | None = None) -> dict:
+    """人眼验收用的一张报关单 JSON。缺的键空着，数组字段给 []。"""
+    schema = schema or load_schema()
+    payload: dict = {}
+    for spec in schema.head:
+        payload[spec.name] = _json_value(declaration.head.get(spec.name))
+    for spec in schema.caller_params:
+        payload[spec.name] = _json_value(declaration.head.get(spec.name))
+    for spec in schema.empty_arrays:
+        payload[spec.name] = []
+    payload[schema.goods_array] = [_goods_payload(item, schema) for item in declaration.goods]
+    payload["_meta"] = {
+        "has_draft": declaration.has_draft,
+        "source_roles": declaration.source_roles,
+        "review_reasons": declaration.review_reasons,
+        "head_status": {
+            name: field.status.value for name, field in declaration.head.items() if field.value
+        },
+    }
+    return payload
+
+
+def _ordered_sheets(document: DocumentIR, policy: Assembly) -> list[Sheet]:
+    eligible = [sheet for sheet in document.sheets if sheet.consume not in _SKIP_CONSUME]
+    rank = {role: index for index, role in enumerate(policy.role_priority)}
+    return sorted(eligible, key=lambda sheet: (rank.get(sheet.role, len(rank)), sheet.name))
+
+
+def _merge_head(
+    sheets: list[Sheet],
+    document: DocumentIR,
+    schema: Schema,
+) -> dict[str, ExtractedField]:
+    policy = schema.assembly
+    has_draft = any(sheet.role == policy.primary_role for sheet in sheets)
+    merged: dict[str, ExtractedField] = {}
+    for sheet in sheets:
+        mode = policy.fill.get(sheet.role, "fill")
+        if mode == "ignore":
+            continue
+        for field in map_sheet_head(sheet, document, schema):
+            skip_customs = (
+                has_draft
+                and sheet.role != policy.primary_role
+                and field.name in policy.customs_only
+            )
+            if skip_customs:
+                continue
+            current = merged.get(field.name)
+            if current is None or not (current.value or "").strip():
+                merged[field.name] = deepcopy(field)
+                continue
+            if mode == "overwrite":
+                merged[field.name] = deepcopy(field)
+    return merged
+
+
+def _apply_defaults(head: dict[str, ExtractedField], schema: Schema) -> None:
+    for name, value in schema.assembly.defaults.items():
+        if (head.get(name) and head[name].value) or not value:
+            continue
+        spec = schema.field(name)
+        head[name] = ExtractedField(
+            name=name,
+            display_name=spec.display_name if spec else name,
+            value=value,
+            normalized_value=value,
+            confidence=1.0,
+            status=FieldStatus.ACCEPTED,
+            extraction_method="assembly_default",
+        )
+
+
+def _apply_weight_policy(head: dict[str, ExtractedField], schema: Schema) -> None:
+    """只有净重时视同重量，不把净重抄进毛重。"""
+    policy = schema.assembly.weight
+    if policy.copy_net_to_gross:
+        return
+    net = head.get(_NET_FIELD)
+    gross = head.get(_GROSS_FIELD)
+    if net is None or not (net.value or "").strip():
+        return
+    if gross is not None and (gross.value or "").strip():
+        return
+    if not policy.net_as_weight:
+        return
+    spec = schema.field(_GROSS_FIELD)
+    head[_GROSS_FIELD] = ExtractedField(
+        name=_GROSS_FIELD,
+        display_name=spec.display_name if spec else _GROSS_FIELD,
+        status=FieldStatus.NEEDS_REVIEW,
+        extraction_method="assembly",
+        validation_errors=["net_is_not_gross"],
+    )
+
+
+def _reconcile_head(
+    head: dict[str, ExtractedField],
+    sheets: list[Sheet],
+    document: DocumentIR,
+    schema: Schema,
+) -> None:
+    names = set(schema.assembly.reconcile)
+    if not names:
+        return
+    by_name: dict[str, dict[str, str]] = {name: {} for name in names}
+    for sheet in sheets:
+        for field in map_sheet_head(sheet, document, schema):
+            if field.name not in names:
+                continue
+            text = (field.value or "").strip()
+            if text:
+                by_name[field.name][sheet.name] = text
+    for name, values in by_name.items():
+        unique = {_fold_number(value) for value in values.values()}
+        if len(unique) <= 1:
+            continue
+        field = head.get(name)
+        if field is None:
+            continue
+        field.status = FieldStatus.NEEDS_REVIEW
+        field.validation_errors = [*field.validation_errors, "head_mismatch"]
+        field.evidence = [
+            *field.evidence,
+            Evidence(
+                document_id=document.document_id,
+                file_id=document.file_id,
+                filename=document.filename,
+                quote=f"{name}: {values}",
+            ),
+        ]
+
+
+def _note_invoice_numbers(
+    head: dict[str, ExtractedField],
+    sheets: list[Sheet],
+    vocab: LayoutVocab,
+    document: DocumentIR,
+    schema: Schema,
+) -> None:
+    """发票号目录无槽（#37）。对得上只记账；对不上复核，不塞进现有字段。"""
+    vocab_id = schema.assembly.invoice_vocab
+    found: dict[str, str] = {}
+    for sheet in sheets:
+        for pair in sheet.key_values:
+            group = vocab.group_for_key(pair.key)
+            if group is None or group.id != vocab_id:
+                continue
+            text = pair.value.strip()
+            if text:
+                found[sheet.name] = text
+    if len({_fold_text(value) for value in found.values()}) <= 1:
+        return
+    head.setdefault(
+        "_invoiceNo",
+        ExtractedField(
+            name="_invoiceNo",
+            display_name="发票号",
+            status=FieldStatus.NEEDS_REVIEW,
+            extraction_method="assembly",
+            source_document_id=document.document_id,
+            validation_errors=["invoice_mismatch"],
+            evidence=[
+                Evidence(
+                    document_id=document.document_id,
+                    file_id=document.file_id,
+                    filename=document.filename,
+                    quote=str(found),
+                )
+            ],
+        ),
+    )
+
+
+def _lookup_codes(
+    head: dict[str, ExtractedField],
+    schema: Schema,
+    codes: CodeTables,
+) -> None:
+    for spec in schema.head:
+        field = head.get(spec.name)
+        if field is None or not (field.value or "").strip():
+            continue
+        if not spec.code_table:
+            continue
+        _apply_lookup(field, spec, codes)
+
+
+def _lookup_goods(
+    items: list[GoodsItem],
+    schema: Schema,
+    codes: CodeTables,
+) -> list[GoodsItem]:
+    mapped: list[GoodsItem] = []
+    for item in items:
+        clone = deepcopy(item)
+        for spec in schema.goods:
+            field = clone.fields.get(spec.name)
+            if field is None or not (field.value or "").strip() or not spec.code_table:
+                continue
+            _apply_lookup(field, spec, codes)
+        mapped.append(clone)
+    return mapped
+
+
+def _apply_lookup(field: ExtractedField, spec: FieldSpec, codes: CodeTables) -> None:
+    table = spec.code_table or ""
+    raw = (field.value or "").strip()
+    try:
+        code = codes.lookup(table, raw)
+    except ValueError:
+        field.status = FieldStatus.NEEDS_REVIEW
+        field.validation_errors = [*field.validation_errors, f"code_table_pending:{table}"]
+        return
+    if code is None:
+        field.status = FieldStatus.NEEDS_REVIEW
+        field.validation_errors = [*field.validation_errors, f"unknown_code:{table}"]
+        return
+    field.value = code
+    field.normalized_value = code
+
+
+def _apply_agent(
+    head: dict[str, ExtractedField],
+    schema: Schema,
+    agent: dict[str, str] | None,
+) -> None:
+    values = agent or {}
+    for spec in schema.caller_params:
+        text = (values.get(spec.name) or "").strip()
+        if not text:
+            continue
+        head[spec.name] = ExtractedField(
+            name=spec.name,
+            display_name=spec.display_name,
+            value=text,
+            normalized_value=text,
+            confidence=1.0,
+            status=FieldStatus.ACCEPTED,
+            extraction_method="caller",
+        )
+
+
+def _collect_reasons(
+    head: dict[str, ExtractedField],
+    goods: list[GoodsItem],
+    schema: Schema,
+    sheets: list[Sheet],
+) -> list[str]:
+    reasons: list[str] = []
+    has_draft = any(sheet.role == schema.assembly.primary_role for sheet in sheets)
+    if not has_draft:
+        for name in schema.assembly.customs_only:
+            field = head.get(name)
+            if field is None or not (field.value or "").strip():
+                reasons.append(f"{name}:customs_empty")
+    for name, field in head.items():
+        if field.status == FieldStatus.NEEDS_REVIEW:
+            detail = ";".join(field.validation_errors) or field.status.value
+            reasons.append(f"{name}:{detail}")
+    for index, item in enumerate(goods, start=1):
+        reasons.extend(f"goods[{index}]:{reason}" for reason in item.review_reasons)
+        for name, field in item.fields.items():
+            if field.status == FieldStatus.NEEDS_REVIEW:
+                detail = ";".join(field.validation_errors) or field.status.value
+                reasons.append(f"goods[{index}].{name}:{detail}")
+    return reasons
+
+
+def _goods_payload(item: GoodsItem, schema: Schema) -> dict:
+    payload: dict[str, str] = {}
+    for spec in schema.goods:
+        if spec.ignore:
+            continue
+        payload[spec.name] = _json_value(item.fields.get(spec.name))
+    payload["_source"] = {
+        "role": item.source_role,
+        "sheet": item.source_sheet,
+        "kind": item.source_kind,
+        "review_reasons": item.review_reasons,
+    }
+    return payload
+
+
+def _json_value(field: ExtractedField | None) -> str:
+    if field is None or field.value is None:
+        return ""
+    return field.value
+
+
+def _fold_text(text: str) -> str:
+    return " ".join(text.split()).casefold()
+
+
+def _fold_number(text: str) -> str:
+    compact = text.replace(",", "").strip()
+    try:
+        number = float(compact)
+    except ValueError:
+        return _fold_text(text)
+    if number.is_integer():
+        return str(int(number))
+    return format(number, "g")

--- a/src/docparse/schema/__init__.py
+++ b/src/docparse/schema/__init__.py
@@ -1,4 +1,6 @@
 from docparse.schema.loader import (
+    Assembly,
+    AssemblyWeight,
     CodeEntry,
     CodeTable,
     CodeTables,
@@ -21,6 +23,8 @@ from docparse.schema.loader import (
 )
 
 __all__ = [
+    "Assembly",
+    "AssemblyWeight",
     "CodeEntry",
     "CodeTable",
     "CodeTables",

--- a/src/docparse/schema/fields.yaml
+++ b/src/docparse/schema/fields.yaml
@@ -40,6 +40,33 @@ goods_master:
     - field: districtCode
       weight: 2
 
+# 整单组装（#19）。按角色，不按公司。有 draft 抄草单；无 draft 拼商业单据。
+# 新角色加 role_priority / fill；新核对字段加 reconcile；海关专用项加 customs_only。
+assembly:
+  primary_role: draft
+  role_priority: [draft, packing, invoice, contract]
+  fill:
+    draft: overwrite
+    packing: fill
+    invoice: fill
+    contract: fill
+  reconcile: [packNo, grossWt, netWt]
+  customs_only:
+    - customMaster
+    - iePort
+    - ciqEntyPortCode
+    - supvModeCdde
+    - cutMode
+    - wrapType
+    - licenseNo
+    - manualNo
+  defaults:
+    cusIEFlag: E
+  weight:
+    net_as_weight: true
+    copy_net_to_gross: false
+  invoice_vocab: invoice_no
+
 document_types:
   - customs_declaration
   - invoice
@@ -575,7 +602,7 @@ head:
     value_type: number
     sources: [customs_declaration, packing_list]
     anchors: [毛重（千克）, 毛重(千克), 毛重]
-    notes: 框表优先。别名 G.W. 交 #13。
+    notes: "框表优先。别名 G.W. 交 #13。只有净重时不把净重抄进本字段，见 assembly.weight。"
 
   - name: netWt
     display_name: 净重(公斤)
@@ -584,7 +611,7 @@ head:
     value_type: number
     sources: [customs_declaration, packing_list]
     anchors: [净重（千克）, 净重(千克), 净重]
-    notes: 框表优先。别名 N.W. 交 #13。
+    notes: "框表优先。别名 N.W. 交 #13。只有净重、没有毛重时视同重量，只进本字段。"
 
   - name: transMode
     display_name: 成交方式

--- a/src/docparse/schema/loader.py
+++ b/src/docparse/schema/loader.py
@@ -68,11 +68,44 @@ class GoodsMaster(BaseModel):
     signals: list[GoodsMasterSignal] = Field(default_factory=list)
 
 
+_FILL_MODES = frozenset({"overwrite", "fill", "ignore"})
+
+
+class AssemblyWeight(BaseModel):
+    """表头重量。净重视同重量，不等于毛重。"""
+
+    net_as_weight: bool = True
+    copy_net_to_gross: bool = False
+
+
+class Assembly(BaseModel):
+    """整单组装策略。按角色，不按公司。"""
+
+    primary_role: str = "draft"
+    role_priority: list[str] = Field(
+        default_factory=lambda: ["draft", "packing", "invoice", "contract"]
+    )
+    fill: dict[str, str] = Field(default_factory=dict)
+    reconcile: list[str] = Field(default_factory=lambda: ["packNo", "grossWt", "netWt"])
+    customs_only: list[str] = Field(default_factory=list)
+    defaults: dict[str, str] = Field(default_factory=dict)
+    weight: AssemblyWeight = Field(default_factory=AssemblyWeight)
+    invoice_vocab: str = "invoice_no"
+
+    @model_validator(mode="after")
+    def check_fill(self) -> "Assembly":
+        for role, mode in self.fill.items():
+            if mode not in _FILL_MODES:
+                raise ValueError(f"unknown assembly fill: {role}={mode}")
+        return self
+
+
 class Schema(BaseModel):
     version: int = 2
     document_types: list[str] = Field(default_factory=list)
     goods_array: str = "tdecGoodsitemsVoArr"
     goods_master: GoodsMaster = Field(default_factory=GoodsMaster)
+    assembly: Assembly = Field(default_factory=Assembly)
     port_mapping: list[PortMapping] = Field(default_factory=list)
     caller_params: list[FieldSpec] = Field(default_factory=list)
     ignored: list[FieldSpec] = Field(default_factory=list)

--- a/tests/test_assemble.py
+++ b/tests/test_assemble.py
@@ -1,0 +1,335 @@
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("openpyxl")
+
+from openpyxl import Workbook
+from openpyxl.styles import Border, Side
+
+from docparse.adapters.parsers.excel import parse_excel
+from docparse.extraction.assemble import assemble_declaration, declaration_payload
+
+_DEMO = Path("/Users/baldwin/Desktop/taizhou/AI识别Demo")
+REAL_HENGXIN = _DEMO / "（恒信）一般贸易草单HDX260251BLU.xlsx"
+REAL_GUOGUANG = _DEMO / "（国光）箱单发票合同26VN0502-1.xlsx"
+
+
+def _thin() -> Border:
+    line = Side(style="thin")
+    return Border(left=line, right=line, top=line, bottom=line)
+
+
+def _workbook(builders: dict) -> bytes:
+    book = Workbook()
+    first = True
+    for title, fill in builders.items():
+        sheet = book.active if first else book.create_sheet(title)
+        if first:
+            sheet.title = title
+            first = False
+        fill(sheet)
+    buffer = io.BytesIO()
+    book.save(buffer)
+    return buffer.getvalue()
+
+
+def _draft(sheet) -> None:
+    sheet["A1"] = "中华人民共和国海关出口货物报关单"
+    sheet.merge_cells("A3:D3")
+    sheet["A3"] = "境内发货人"
+    sheet.merge_cells("A4:D4")
+    sheet["A4"] = "惠州市恒德信精密科技有限公司441394164D"
+    sheet["E3"] = "出境关别"
+    sheet["E4"] = "莲塘口岸"
+    sheet.merge_cells("A5:D5")
+    sheet["A5"] = "境外收货人"
+    sheet.merge_cells("A6:D6")
+    sheet["A6"] = "BLU PRECISION LIMITED"
+    sheet.merge_cells("A7:D7")
+    sheet["A7"] = "生产销售单位"
+    sheet.merge_cells("A8:D8")
+    sheet["A8"] = "惠州市恒德信精密科技有限公司"
+    sheet["E5"] = "运输方式"
+    sheet["E6"] = "公路运输"
+    sheet["E7"] = "监管方式"
+    sheet["E8"] = "一般贸易"
+    sheet.merge_cells("A9:D9")
+    sheet["A9"] = "合同协议号"
+    sheet.merge_cells("A10:D10")
+    sheet["A10"] = "HDX2026-251"
+    sheet.merge_cells("A11:C11")
+    sheet["A11"] = "包装种类"
+    sheet["D11"] = "件数"
+    sheet["E11"] = "毛重（千克）"
+    sheet["F11"] = "净重（千克）"
+    sheet.merge_cells("G11:H11")
+    sheet["G11"] = "成交方式"
+    sheet.merge_cells("A12:C12")
+    sheet["A12"] = "其它"
+    sheet["D12"] = 40
+    sheet["E12"] = 296.46
+    sheet["F12"] = 218.375
+    sheet.merge_cells("G12:H12")
+    sheet["G12"] = "FOB"
+    headers = [
+        ("A17", "项号"),
+        ("B17", "商品编号"),
+        ("C17", "商品名称及规格型号"),
+        ("D17", "申报要素"),
+        ("E17", "数量PCS"),
+        ("F17", "计价单位"),
+        ("G17", "重量KG"),
+        ("H17", "单价"),
+        ("I17", "总价"),
+        ("J17", "币制"),
+        ("K17", "原产国（地区）"),
+        ("L17", "最终目的国（地区）"),
+        ("M17", "境内货源地"),
+    ]
+    for address, text in headers:
+        sheet[address] = text
+    sheet["A18"] = 1
+    sheet["B18"] = "9111900000"
+    sheet["C18"] = "表壳配件/壳体"
+    sheet["D18"] = "不锈钢/无中文品牌、无外文品牌/无型号"
+    sheet["E18"] = 150
+    sheet["F18"] = "只"
+    sheet["G18"] = 5.74
+    sheet["H18"] = 98
+    sheet["I18"] = 14700
+    sheet["J18"] = "港币"
+    sheet["K18"] = "中国"
+    sheet["L18"] = "中国香港"
+    sheet["M18"] = "惠州其他"
+    for row in sheet.iter_rows(min_row=1, max_row=18, min_col=1, max_col=13):
+        for cell in row:
+            cell.border = _thin()
+
+
+def _packing(sheet) -> None:
+    sheet["A1"] = "PACKING LIST"
+    sheet["I4"] = "Invoice No.﹕"
+    sheet["J4"] = "HDX260251"
+    sheet["A7"] = "Bill To : BLU PRECISION LIMITED"
+    sheet["C11"] = "Description (货物名称)"
+    sheet["E11"] = "Ship Q'ty (数量/PCS)"
+    sheet["G11"] = "Packing (箱)"
+    sheet["H11"] = "N.W. (Kg) (净重)"
+    sheet["I11"] = "G.W .(Kg) (毛重)"
+    sheet["C12"] = "表壳配件/壳体"
+    sheet["E12"] = 150
+    sheet["G12"] = 40
+    sheet["H12"] = 5.74
+    sheet["I12"] = 7.35
+    for row in sheet.iter_rows(min_row=1, max_row=12, min_col=1, max_col=10):
+        for cell in row:
+            cell.border = _thin()
+
+
+def _mismatch_packing(sheet) -> None:
+    _packing(sheet)
+    sheet["A3"] = "件数"
+    sheet["B3"] = 99
+
+
+def _net_only_packing(sheet) -> None:
+    sheet["A1"] = "PACKING LIST"
+    sheet["A3"] = "净重"
+    sheet["B3"] = 2825.47
+    sheet["A6"] = "合同号CONTRACT NO.:"
+    sheet["B6"] = "26VN0502"
+    sheet["A8"] = "卖方SELLER"
+    sheet["A9"] = "GUOGUANG ELECTRIC COMPANY LIMITED."
+    sheet["F8"] = "买方BUYER"
+    sheet["F9"] = "GUOGUANG ACOUSTICS (VIETNAM) COMPANY LIMITED"
+    sheet["B12"] = "物料名称"
+    sheet["C12"] = "单位"
+    sheet["D12"] = "出货数量"
+    sheet["H12"] = "总净重 NW"
+    sheet["Q12"] = "HS CODE海关编码"
+    sheet["B13"] = "贴纸"
+    sheet["C13"] = "个"
+    sheet["D13"] = 100
+    sheet["H13"] = 0.0013
+    sheet["Q13"] = "4821900000纸或纸板的其他各种标签"
+    for row in sheet.iter_rows(min_row=1, max_row=13, min_col=1, max_col=19):
+        for cell in row:
+            cell.border = _thin()
+
+
+def _invoice(sheet) -> None:
+    sheet["A1"] = "INVOICE"
+    sheet["F6"] = "发票号INVOICE NO.:"
+    sheet["G6"] = "26VN0502-1"
+    sheet["A8"] = "买方BUYER"
+    sheet["A9"] = "GUOGUANG ACOUSTICS (VIETNAM) COMPANY LIMITED"
+    sheet["G7"] = "合同号CONTRACT NO.:"
+    sheet["H7"] = "26VN0502"
+    sheet["B16"] = "物料名称"
+    sheet["D16"] = "出货数量"
+    sheet["E16"] = "币别"
+    sheet["F16"] = "单价"
+    sheet["G16"] = "汇总价"
+    sheet["B17"] = "贴纸"
+    sheet["D17"] = 100
+    sheet["E17"] = "USD"
+    sheet["F17"] = 0.0181
+    sheet["G17"] = 1.81
+    for row in sheet.iter_rows(min_row=1, max_row=17, min_col=1, max_col=8):
+        for cell in row:
+            cell.border = _thin()
+
+
+def _auxiliary(sheet) -> None:
+    sheet["B1"] = "报关单号"
+    sheet["C1"] = "报关日期"
+    sheet["E1"] = "恒信编号"
+    sheet["K1"] = "SAP编号"
+    sheet["H1"] = "商品编码"
+    sheet["M1"] = "商品名称"
+    sheet["A3"] = "合同协议号"
+    sheet["A4"] = "SHOULD-NOT-ASSEMBLE"
+    sheet["H2"] = "9999999999"
+    sheet["M2"] = "内部料号壳体"
+    for row in sheet.iter_rows(min_row=1, max_row=4, min_col=1, max_col=13):
+        for cell in row:
+            cell.border = _thin()
+
+
+def _parse(builders: dict, filename: str):
+    return parse_excel(_workbook(builders), file_id="asm", filename=filename)
+
+
+def test_draft_is_copied_and_codes_are_looked_up() -> None:
+    document = _parse(
+        {"一般贸易出口": _draft, "装箱单": _packing, "Sheet3": _auxiliary},
+        "hengxin.xlsx",
+    )
+    declaration = assemble_declaration(
+        document,
+        agent={"agentCode": "4403180867", "agentName": "深圳市泰洲物流有限公司"},
+    )
+    payload = declaration_payload(declaration)
+
+    assert declaration.has_draft is True
+    assert declaration.source_roles == ["draft", "packing"]
+    assert payload["contrNo"] == "HDX2026-251"
+    assert payload["consignorEname"] == "BLU PRECISION LIMITED"
+    assert payload["packNo"] == "40"
+    assert payload["grossWt"] == "296.46"
+    assert payload["netWt"] == "218.375"
+    assert payload["cusTrafMode"] == "4"
+    assert payload["transMode"] == "3"
+    assert payload["supvModeCdde"] == "0110"
+    assert payload["cusIEFlag"] == "E"
+    assert payload["agentCode"] == "4403180867"
+    assert payload["agentName"] == "深圳市泰洲物流有限公司"
+    assert payload["agentScc"] == ""
+    assert payload["iePort"] == "莲塘口岸"
+    assert declaration.head["iePort"].status.value == "needs_review"
+    assert payload["wrapType"] == "其它"
+    assert declaration.head["wrapType"].status.value == "needs_review"
+    assert len(payload["tdecGoodsitemsVoArr"]) == 1
+    goods = payload["tdecGoodsitemsVoArr"][0]
+    assert goods["gno"] == "1"
+    assert goods["gname"] == "表壳配件/壳体"
+    assert goods["gunit"] == "008"
+    assert goods["cusOriginCountry"] == "CHN"
+    assert goods["destinationCountry"] == "HKG"
+    assert goods["districtCode"] == "44139"
+    assert payload["tdecContasVoArr"] == []
+    assert payload["_meta"]["source_roles"] == ["draft", "packing"]
+    assert "SHOULD-NOT-ASSEMBLE" not in payload.values()
+
+
+def test_commercial_mismatch_keeps_draft_value() -> None:
+    document = _parse({"一般贸易出口": _draft, "装箱单": _mismatch_packing}, "mismatch.xlsx")
+    declaration = assemble_declaration(document)
+    assert declaration.value_of("packNo") == "40"
+    assert declaration.head["packNo"].status.value == "needs_review"
+    assert "packNo:head_mismatch" in declaration.review_reasons
+
+
+def test_net_only_does_not_copy_to_gross() -> None:
+    document = _parse({"总箱单": _net_only_packing}, "net-only.xlsx")
+    declaration = assemble_declaration(document)
+    assert declaration.has_draft is False
+    assert declaration.value_of("netWt") == "2825.47"
+    assert declaration.value_of("grossWt") in {None, ""}
+    assert declaration.head["grossWt"].status.value == "needs_review"
+    assert "grossWt:net_is_not_gross" in declaration.review_reasons
+    payload = declaration_payload(declaration)
+    assert payload["grossWt"] == ""
+    assert payload["netWt"] == "2825.47"
+    assert payload["supvModeCdde"] == ""
+    assert payload["cutMode"] == ""
+    assert payload["iePort"] == ""
+    assert "supvModeCdde:customs_empty" in declaration.review_reasons
+
+
+def test_no_draft_fills_commercial_and_leaves_customs_empty() -> None:
+    document = _parse(
+        {"总箱单": _net_only_packing, "发票": _invoice, "Sheet3": _auxiliary},
+        "guoguang.xlsx",
+    )
+    declaration = assemble_declaration(document)
+    payload = declaration_payload(declaration)
+    assert declaration.has_draft is False
+    assert payload["contrNo"] == "26VN0502"
+    assert payload["consignorEname"] == "GUOGUANG ACOUSTICS (VIETNAM) COMPANY LIMITED"
+    assert payload["tradeName"] == "GUOGUANG ELECTRIC COMPANY LIMITED."
+    assert payload["supvModeCdde"] == ""
+    assert payload["cutMode"] == ""
+    assert payload["customMaster"] == ""
+    assert payload["wrapType"] == ""
+    assert payload["agentCode"] == ""
+    assert len(payload["tdecGoodsitemsVoArr"]) == 1
+    assert payload["tdecGoodsitemsVoArr"][0]["gname"] == "贴纸"
+    assert payload["tdecGoodsitemsVoArr"][0]["gqty"] == "100"
+    assert "SHOULD-NOT-ASSEMBLE" not in payload.values()
+    assert "auxiliary" not in declaration.source_roles
+
+
+def test_agent_not_taken_from_file() -> None:
+    document = _parse({"一般贸易出口": _draft}, "draft-only.xlsx")
+    declaration = assemble_declaration(document)
+    assert declaration.value_of("agentCode") is None
+    assert declaration.value_of("agentName") is None
+
+
+@pytest.mark.skipif(not REAL_HENGXIN.exists(), reason="本地恒信样本不在 CI")
+def test_hengxin_sample_one_declaration() -> None:
+    document = parse_excel(
+        REAL_HENGXIN.read_bytes(),
+        file_id="hx-real",
+        filename=REAL_HENGXIN.name,
+    )
+    payload = declaration_payload(assemble_declaration(document))
+    assert payload["contrNo"] == "HDX2026-251"
+    assert payload["packNo"] == "40"
+    assert payload["grossWt"] == "296.46"
+    assert payload["transMode"] == "3"
+    assert payload["cusTrafMode"] == "4"
+    assert payload["supvModeCdde"] == "0110"
+    assert len(payload["tdecGoodsitemsVoArr"]) >= 1
+    assert payload["tdecGoodsitemsVoArr"][0]["gname"]
+
+
+@pytest.mark.skipif(not REAL_GUOGUANG.exists(), reason="本地国光样本不在 CI")
+def test_guoguang_sample_one_declaration() -> None:
+    document = parse_excel(
+        REAL_GUOGUANG.read_bytes(),
+        file_id="gg-real",
+        filename=REAL_GUOGUANG.name,
+    )
+    payload = declaration_payload(assemble_declaration(document))
+    assert payload["contrNo"] == "26VN0502"
+    assert payload["consignorEname"] == "GUOGUANG ACOUSTICS (VIETNAM) COMPANY LIMITED"
+    assert payload["supvModeCdde"] == ""
+    assert payload["cutMode"] == ""
+    assert len(payload["tdecGoodsitemsVoArr"]) >= 1
+    assert payload["tdecGoodsitemsVoArr"][0]["gname"]

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -187,6 +187,21 @@ def test_goods_map_flags_and_master_signals() -> None:
     assert schema.goods_master.role_bonus["draft"] > schema.goods_master.role_bonus["packing"]
 
 
+def test_assembly_policy_is_role_based() -> None:
+    schema = load_schema()
+    policy = schema.assembly
+    assert policy.primary_role == "draft"
+    assert policy.fill["draft"] == "overwrite"
+    assert policy.fill["packing"] == "fill"
+    assert "packNo" in policy.reconcile
+    assert "supvModeCdde" in policy.customs_only
+    assert policy.weight.copy_net_to_gross is False
+    assert policy.weight.net_as_weight is True
+    assert policy.defaults["cusIEFlag"] == "E"
+    assert "不把净重抄进本字段" in schema.field("grossWt").notes
+    assert "视同重量" in schema.field("netWt").notes
+
+
 def test_agent_fields_are_caller_params() -> None:
     schema = load_schema()
     by_name = {item.name: item for item in schema.caller_params}


### PR DESCRIPTION
Closes #19

## 做了什么

把多摊表头候选和一张货表收成 **一张** 报关单 JSON。按 sheet 角色，不按公司。

- 有 `draft`：表头抄草单；箱单 / 发票 / 合同只补空
- 商业单据和草单的件数 / 毛 / 净不一致：保留草单值，打 `needs_review`
- 无草单：合同号、收货人、品名、数量、净重能确定就抄；监管方式 / 征免 / 口岸 / 包装种类空着复核，不编
- 名称能转 code 就转（公路运输 → `4`，FOB → `3`，一般贸易 → `0110`）；转不出留原文 + 复核
- `agent*` 只来自 CLI 参数，不从文件填
- 辅助 / unknown 不读，不另开第二张单
- 表头只有净重时视同重量，只进 `netWt`；**净重 ≠ 毛重**，不抄进 `grossWt`
- 发票号目录无槽（#37）：只核对，不塞进现有字段

策略在 `fields.yaml` 的 `assembly`。本地对眼：`python -m docparse.cli declare file.xlsx`

不改：PDF、FastAPI、zip、货表净重抄毛重（#18）。客户原件不入库。

## 验收

- 恒信夹具 / 本地样本：一张单；合同号、件数 40、毛重 296.46、净重、FOB→`3`、公路运输→`4`、一般贸易→`0110`；商品行在 `tdecGoodsitemsVoArr`
- 国光夹具 / 本地样本：同一形状；合同号 / 买方 / 货表能进；监管方式等空 + `needs_review`
- 只有净重时 `grossWt` 空，不填成净重
- 草单件数与箱单不一致时保留草单值
- 辅助表上的合同号不进单
- ruff / pytest 通过（68 passed）

## 以后新 xlsx / 新叫法改哪

| 你看到的现象 | 改哪里 | 动 Python？ |
|---|---|---|
| 新叫法（装箱明细、形式发票） | `sheet_roles.yaml` / `layout_vocab.yaml` / `fields.yaml` anchors | 否 |
| 新单据类型要参与拼单 | `sheet_roles.yaml` 加 role；`assembly.fill` / `role_priority` | 否 |
| 新辅助表 | `auxiliary` + `consume: exclude` | 否 |
| 新表头字段 | `fields.yaml` 新字段 + anchors | 否（组装器按目录收） |
| 新字段要转 code | 字段上写 `code_table`；码表加行 | 否 |
| 无草单时不要编的海关项 | `assembly.customs_only` | 否 |
| 要对一下的件毛净 / 单号 | `assembly.reconcile` | 否 |
| 发票号要进报关单 | #37 先定落点 | 视目录 |
| 俗称（莲塘口岸、纸箱）要转码 | #27 | 否 |
| 货表净重抄毛重 | #18，不在这里改 | 否 |

不要 `if company == "恒信"`。不要把商业单据上的监管方式 / 口岸编进无草单的单。