### PR TITLE
feat: FastAPI 交付一张报关单 JSON（#21）

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -16,7 +16,7 @@ python -m docparse.cli declare /绝对路径/表.xlsx --agent-code 4403180867 --
 | 部分 | 来源 | 说明 |
 |---|---|---|
 | `file` | 上传 | 本期 xlsx；以后同一接口接 PDF / zip |
-| `agentCode` / `agentName` / `agentScc` / `agentCiqCode` | `fields.yaml` `caller_params` | 不解析，原样进单 |
+| `agentCode` / `agentName` / `agentScc` / `agentCiqCode` | `fields.yaml` `caller_params` | 不解析。没传则用 YAML `default`（泰洲） |
 | `cusIEFlag` | `assembly.defaults` 可覆盖 | 默认 `E`；进口传 `I` |
 | `run` | 已有 | 默认 true，同步跑完 |
 
@@ -62,6 +62,7 @@ Job
 | 新表头 / 货列 | `fields.yaml` | 否（declaration / reviews 按目录收） |
 | 新字段要转 code | 字段写 `code_table` + 码表加行 | 否 |
 | 多一个申报单位字段 | `caller_params` 加一项 | 否（Form / OpenAPI 从 YAML 生成） |
+| 换默认申报单位 | `caller_params` 的 `default` | 否 |
 | 调用方要覆盖进出口标志 | 请求带 `cusIEFlag` | 否 |
 | 以后上传 PDF | #22 / #23 parser | 否（同一 `POST /v1/jobs`） |
 | zip 多文件拼一张单 | assemble / `extract_fields_step` 主文档选择 | 否（入口已是 list） |

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,71 @@
+# FastAPI：一张报关单 JSON
+
+`POST /v1/jobs` 收文件和调用方参数，走与 `cli declare` 同一条 pipeline，交出一张报关单。本层不解析、不认公司。
+
+本地：
+
+```bash
+uvicorn docparse.api.app:app --host 127.0.0.1 --port 8088
+python -m docparse.cli declare /绝对路径/表.xlsx --agent-code 4403180867 --agent-name 深圳市泰洲物流有限公司
+```
+
+## 请求
+
+`multipart/form-data`。
+
+| 部分 | 来源 | 说明 |
+|---|---|---|
+| `file` | 上传 | 本期 xlsx；以后同一接口接 PDF / zip |
+| `agentCode` / `agentName` / `agentScc` / `agentCiqCode` | `fields.yaml` `caller_params` | 不解析，原样进单 |
+| `cusIEFlag` | `assembly.defaults` 可覆盖 | 默认 `E`；进口传 `I` |
+| `run` | 已有 | 默认 true，同步跑完 |
+
+Form 字段名单从 YAML 生成。未知键忽略，不 400。
+
+每个请求生成 `X-Request-Id`（可自带），写进响应头和 Job。
+
+## 响应
+
+还是 Job 信封：
+
+```text
+Job
+  status              succeeded | needs_review | failed
+  request_id
+  caller              请求里收下的调用方参数
+  result.declaration  与 cli declare 同一份 JSON（含 _meta）
+  result.reviews      字段级 status + 证据（sheet / cell / quote）
+  result.package      IR / 旧 fields，调试用
+  result.error        仅 failed
+```
+
+`declaration` 缺的键空字符串，不删键。合单系统丢掉 `_meta` / `reviews` 即可提交。
+
+## 错误分界
+
+| HTTP | 何时 |
+|---|---|
+| 400 | 空文件、超大、没带 file |
+| 200 + `needs_review` | 缺字段、转不出 code、件毛净对不上 |
+| 200 + `failed` | 解析/组装 runner 已接住的失败 |
+| 404 | job 不存在 |
+| 500 | 没映射到的服务器异常 |
+
+业务失败不是 500。映射只在 `api/errors.py`。
+
+## 以后新 xlsx / 新叫法改哪
+
+| 你看到的现象 | 改哪里 | 动 API Python？ |
+|---|---|---|
+| 新叫法（装箱明细、形式发票） | `sheet_roles.yaml` / `layout_vocab.yaml` / anchors | 否 |
+| 新单据类型要参与拼单 | `assembly.fill` / `role_priority` | 否 |
+| 新表头 / 货列 | `fields.yaml` | 否（declaration / reviews 按目录收） |
+| 新字段要转 code | 字段写 `code_table` + 码表加行 | 否 |
+| 多一个申报单位字段 | `caller_params` 加一项 | 否（Form / OpenAPI 从 YAML 生成） |
+| 调用方要覆盖进出口标志 | 请求带 `cusIEFlag` | 否 |
+| 以后上传 PDF | #22 / #23 parser | 否（同一 `POST /v1/jobs`） |
+| zip 多文件拼一张单 | assemble / `extract_fields_step` 主文档选择 | 否（入口已是 list） |
+| 校验规则 | #20 数据文件 | 否（同一接口自动带闸） |
+| 结构化日志 / 错误码 | `api/errors.py` + request_id | 只改挂钩处 |
+
+不要 `if company == "恒信"`。不要在 `routes.py` 写死 `agent*`。

--- a/docs/assemble.md
+++ b/docs/assemble.md
@@ -17,7 +17,7 @@ python -m docparse.cli declare /绝对路径/表.xlsx --agent-code 4403180867 --
   → 有 draft：表头以草单为准；商业单据只补空，并核件毛净
   → 无 draft：商业单据能确定的抄；customs_only 空着复核，不编
   → 名称能转 code 就转；转不出留原文 + needs_review
-  → agent* 只来自 CLI 参数
+  → agent* 只来自调用参数（CLI / FastAPI 同一条 pipeline）
   → 一张 Declaration / 一份 dec_results 形状 JSON
 ```
 

--- a/docs/field-schema.md
+++ b/docs/field-schema.md
@@ -35,7 +35,7 @@
 
 ## 调用方传入（不解析）
 
-`agentCode` / `agentName` / `agentScc` / `agentCiqCode`：申报单位，调用时传入。
+`agentCode` / `agentName` / `agentScc` / `agentCiqCode`：申报单位，调用时传入。HTTP 没传则用 `fields.yaml` 里的 `default`（本期泰洲）。文件里不抽。换申报单位只改 YAML。
 
 生产销售单位 / 消费使用单位（`owner*`）文件里有就抽，没有就空。
 

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -6,7 +6,7 @@
 docparse/
 ├── docs/                      设计、流程、模块说明
 ├── src/docparse/
-│   ├── api/                   HTTP 入口
+│   ├── api/                   HTTP 入口（收文件 + caller → pipeline）
 │   ├── cli.py                 本地命令行
 │   ├── config.py              环境变量
 │   ├── domain/                任务 / IR / 字段（稳定契约）
@@ -35,6 +35,7 @@ docparse/
 | 标准化与校验 | `extraction/validate.py` | 骨架：格式 / 证据；业务闸未接 | 规则清单见 [validate-rules.md](validate-rules.md)，确认后由 #20 执行 |
 | 包级对账 | `pipeline/steps/reconcile.py` | 同名字段冲突 | 金额、单号跨文件 |
 | 自动通过 / 待复核 | `pipeline/steps/route_review.py` | 只打状态 | 复核页另开 Issue |
+| FastAPI 交单 | `api/routes.py` + `pipeline/runner.py` | `POST /v1/jobs` 交 `declaration` + `reviews`（#21） | PDF / zip 拼单不改路由 |
 | 持久化接口 | `adapters/jobs/` `adapters/files/` | 内存实现；Postgres/S3 抛未实现 | 需要跨进程时再做 |
 | 云 LLM | `adapters/llm/openai_compat.py` | 未配 Key 则跳过 | 换供应商只改这里 |
 
@@ -67,6 +68,8 @@ sheet 角色（#16）：`schema/sheet_roles.yaml` + `extraction/sheet_role.py`�
 商品映射（#18）：`extraction/goods_map.py` 吃已拆 `tables`，按 `fields.yaml` 的 `goods.anchors` / `goods_map` / `goods_master` 写成货行。先选主货表，其它可消费 sheet 只补空；对不上的行标来源收成补充项。`auxiliary` / `unknown` 不读。重量未区分当净重，无毛重列再抄一份到毛重。申报要素原文进 `gmodel`，不编 `0|0|...`。箱数不加字段。本地对眼：`python -m docparse.cli goods file.xlsx`。见 [goods-map.md](goods-map.md)。
 
 整单组装（#19）：`extraction/assemble.py` 按 `fields.yaml` 的 `assembly` 收成一张报关单。有 `draft` 抄草单，商业单据只补空并核件毛净；无草单只抄能确定的商业事实，`customs_only` 空着复核。名称转 code；转不出留原文。`agent*` 只来自调用参数。表头只有净重时视同重量，不抄进毛重。本地对眼：`python -m docparse.cli declare file.xlsx`。见 [assemble.md](assemble.md)。
+
+FastAPI 交单（#21）：`POST /v1/jobs` 与 `cli declare` 走同一条 pipeline。调用方参数跟 `caller_params` 走，不写死四个 agent。响应是 Job + `result.declaration` + `result.reviews`。见 [api.md](api.md)。
 
 抽取后校验（#20）：规则先写在 [validate-rules.md](validate-rules.md) 给业务确认。位数 / 正则 / 容差确认后再进数据文件，引擎只执行，不编造、不改值。
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ packages = ["src/docparse"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-pythonpath = ["src"]
+pythonpath = ["src", "tests"]
 
 [tool.ruff]
 line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,4 +43,4 @@ src = ["src", "tests"]
 select = ["E", "F", "I", "UP", "B"]
 
 [tool.ruff.lint.per-file-ignores]
-"src/docparse/api/app.py" = ["B008"]
+"src/docparse/api/routes.py" = ["B008"]

--- a/src/docparse/adapters/files/factory.py
+++ b/src/docparse/adapters/files/factory.py
@@ -5,16 +5,19 @@ from docparse.adapters.files.memory import MemoryFileStore
 from docparse.config import Settings, get_settings
 
 
-@lru_cache(maxsize=1)
 def get_file_store(settings: Settings | None = None) -> FileStore:
     cfg = settings or get_settings()
-    name = cfg.file_store.lower()
+    return _file_store(cfg.file_store.lower(), cfg.s3_bucket, cfg.s3_endpoint)
+
+
+@lru_cache(maxsize=4)
+def _file_store(name: str, s3_bucket: str | None, s3_endpoint: str | None) -> FileStore:
     if name == "memory":
         return MemoryFileStore()
     if name == "s3":
         from docparse.adapters.files.s3 import S3FileStore
 
-        if not cfg.s3_bucket:
+        if not s3_bucket:
             raise RuntimeError("DOCPARSE_FILE_STORE=s3 需要 DOCPARSE_S3_BUCKET")
-        return S3FileStore(cfg.s3_bucket, cfg.s3_endpoint)
-    raise ValueError(f"未知 file_store: {cfg.file_store}")
+        return S3FileStore(s3_bucket, s3_endpoint)
+    raise ValueError(f"未知 file_store: {name}")

--- a/src/docparse/adapters/jobs/factory.py
+++ b/src/docparse/adapters/jobs/factory.py
@@ -5,16 +5,19 @@ from docparse.adapters.jobs.memory import MemoryJobStore
 from docparse.config import Settings, get_settings
 
 
-@lru_cache(maxsize=1)
 def get_job_store(settings: Settings | None = None) -> JobStore:
     cfg = settings or get_settings()
-    name = cfg.job_store.lower()
+    return _job_store(cfg.job_store.lower(), cfg.database_url)
+
+
+@lru_cache(maxsize=4)
+def _job_store(name: str, database_url: str | None) -> JobStore:
     if name == "memory":
         return MemoryJobStore()
     if name == "postgres":
         from docparse.adapters.jobs.postgres import PostgresJobStore
 
-        if not cfg.database_url:
+        if not database_url:
             raise RuntimeError("DOCPARSE_JOB_STORE=postgres 需要 DOCPARSE_DATABASE_URL")
-        return PostgresJobStore(cfg.database_url)
-    raise ValueError(f"未知 job_store: {cfg.job_store}")
+        return PostgresJobStore(database_url)
+    raise ValueError(f"未知 job_store: {name}")

--- a/src/docparse/api/app.py
+++ b/src/docparse/api/app.py
@@ -1,54 +1,32 @@
 from __future__ import annotations
 
-from functools import lru_cache
+from uuid import uuid4
 
-from fastapi import Depends, FastAPI, File, HTTPException, UploadFile
+from fastapi import FastAPI, Request
 
+from docparse.api.errors import unhandled_error_handler
+from docparse.api.routes import REQUEST_ID_HEADER, router
 from docparse.config import get_settings
-from docparse.domain.models import Job
-from docparse.pipeline.runner import Pipeline
-
-
-@lru_cache(maxsize=1)
-def get_pipeline() -> Pipeline:
-    return Pipeline()
 
 
 def create_app() -> FastAPI:
     settings = get_settings()
-    app = FastAPI(title=settings.app_name, version="0.1.0")
+    app = FastAPI(
+        title=settings.app_name,
+        version="0.1.0",
+        description="xlsx → 一张报关单 JSON。解析走 pipeline，本层只收文件和调用方参数。",
+    )
 
-    @app.get("/health")
-    def health() -> dict[str, str]:
-        return {"status": "ok"}
+    @app.middleware("http")
+    async def request_id_mw(request: Request, call_next):
+        request_id = request.headers.get(REQUEST_ID_HEADER) or uuid4().hex
+        request.state.request_id = request_id
+        response = await call_next(request)
+        response.headers[REQUEST_ID_HEADER] = request_id
+        return response
 
-    @app.post("/v1/jobs", response_model=Job)
-    async def create_job(
-        file: UploadFile = File(...),
-        run: bool = True,
-        pipeline: Pipeline = Depends(get_pipeline),
-    ) -> Job:
-        data = await file.read()
-        filename = file.filename or "upload.bin"
-        try:
-            job = pipeline.submit(filename, data)
-        except ValueError as exc:
-            raise HTTPException(status_code=400, detail=str(exc)) from exc
-        if run:
-            job = pipeline.run_job(job.id)
-        return job
-
-    @app.get("/v1/jobs/{job_id}", response_model=Job)
-    def get_job(job_id: str, pipeline: Pipeline = Depends(get_pipeline)) -> Job:
-        job = pipeline.jobs.get(job_id)
-        if job is None:
-            raise HTTPException(status_code=404, detail="job not found")
-        return job
-
-    @app.get("/v1/jobs", response_model=list[Job])
-    def list_jobs(pipeline: Pipeline = Depends(get_pipeline)) -> list[Job]:
-        return pipeline.jobs.list()
-
+    app.add_exception_handler(Exception, unhandled_error_handler)
+    app.include_router(router)
     return app
 
 

--- a/src/docparse/api/caller.py
+++ b/src/docparse/api/caller.py
@@ -1,0 +1,33 @@
+"""调用方参数名单跟 fields.yaml 走，不写死 agent*。"""
+
+from __future__ import annotations
+
+from docparse.schema.loader import Schema, load_schema
+
+RESERVED_FORM_KEYS = frozenset({"file", "run"})
+
+
+def accepted_caller_keys(schema: Schema | None = None) -> list[str]:
+    """Form 里可以进组装的键：caller_params + assembly.defaults。"""
+    schema = schema or load_schema()
+    names = [spec.name for spec in schema.caller_params]
+    for name in schema.assembly.defaults:
+        if name not in names:
+            names.append(name)
+    return names
+
+
+def collect_caller(
+    form: dict[str, str],
+    schema: Schema | None = None,
+) -> dict[str, str]:
+    """只收目录里的键；未知键忽略，空值丢掉。"""
+    allowed = set(accepted_caller_keys(schema))
+    collected: dict[str, str] = {}
+    for key, value in form.items():
+        if key in RESERVED_FORM_KEYS or key not in allowed:
+            continue
+        text = value.strip()
+        if text:
+            collected[key] = text
+    return collected

--- a/src/docparse/api/caller.py
+++ b/src/docparse/api/caller.py
@@ -17,17 +17,29 @@ def accepted_caller_keys(schema: Schema | None = None) -> list[str]:
     return names
 
 
+def caller_defaults(schema: Schema | None = None) -> dict[str, str]:
+    """YAML 上标了 default 的调用方参数。换申报单位只改 fields.yaml。"""
+    schema = schema or load_schema()
+    values: dict[str, str] = {}
+    for spec in schema.caller_params:
+        text = (spec.default or "").strip()
+        if text:
+            values[spec.name] = text
+    return values
+
+
 def collect_caller(
     form: dict[str, str],
     schema: Schema | None = None,
 ) -> dict[str, str]:
-    """只收目录里的键；未知键忽略，空值丢掉。"""
+    """请求里有的键用请求值（可显式传空）；没出现的键补 YAML default。未知键忽略。"""
+    schema = schema or load_schema()
     allowed = set(accepted_caller_keys(schema))
     collected: dict[str, str] = {}
     for key, value in form.items():
         if key in RESERVED_FORM_KEYS or key not in allowed:
             continue
-        text = value.strip()
-        if text:
-            collected[key] = text
-    return collected
+        collected[key] = value.strip()
+    for key, value in caller_defaults(schema).items():
+        collected.setdefault(key, value)
+    return {key: value for key, value in collected.items() if value}

--- a/src/docparse/api/errors.py
+++ b/src/docparse/api/errors.py
@@ -1,0 +1,21 @@
+"""异常 → HTTP 的唯一出口。以后加错误码 / 日志只改这里。"""
+
+from __future__ import annotations
+
+from fastapi import HTTPException, Request
+from fastapi.responses import JSONResponse
+from starlette.exceptions import HTTPException as StarletteHTTPException
+
+
+def bad_request(detail: str) -> HTTPException:
+    return HTTPException(status_code=400, detail=detail)
+
+
+def not_found(detail: str) -> HTTPException:
+    return HTTPException(status_code=404, detail=detail)
+
+
+async def unhandled_error_handler(request: Request, exc: Exception) -> JSONResponse:
+    if isinstance(exc, (HTTPException, StarletteHTTPException)):
+        raise exc
+    return JSONResponse(status_code=500, content={"detail": "internal error"})

--- a/src/docparse/api/routes.py
+++ b/src/docparse/api/routes.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from functools import lru_cache
+
+from fastapi import APIRouter, Depends, Request
+
+from docparse.api.caller import RESERVED_FORM_KEYS, collect_caller
+from docparse.api.errors import bad_request, not_found
+from docparse.api.schemas import JOB_EXAMPLE, multipart_openapi
+from docparse.domain.models import Job
+from docparse.pipeline.runner import Pipeline
+
+REQUEST_ID_HEADER = "X-Request-Id"
+
+router = APIRouter()
+
+
+@lru_cache(maxsize=1)
+def get_pipeline() -> Pipeline:
+    return Pipeline()
+
+
+def _request_id(request: Request) -> str:
+    header = request.headers.get(REQUEST_ID_HEADER)
+    if header:
+        return header
+    return getattr(request.state, "request_id", "")
+
+
+def _truthy(value: object) -> bool:
+    return str(value).strip().lower() not in {"0", "false", "no", ""}
+
+
+@router.get("/health")
+def health() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@router.post(
+    "/v1/jobs",
+    response_model=Job,
+    openapi_extra=multipart_openapi(),
+    responses={200: {"content": {"application/json": {"example": JOB_EXAMPLE}}}},
+)
+async def create_job(
+    request: Request,
+    pipeline: Pipeline = Depends(get_pipeline),
+) -> Job:
+    form = await request.form()
+    upload = form.get("file")
+    if upload is None or not hasattr(upload, "read"):
+        raise bad_request("missing file")
+    data = await upload.read()
+    filename = getattr(upload, "filename", None) or "upload.bin"
+    fields = {
+        key: str(value)
+        for key, value in form.items()
+        if key not in RESERVED_FORM_KEYS and not hasattr(value, "filename")
+    }
+    caller = collect_caller(fields)
+    run_value = form.get("run", "true")
+    try:
+        job = pipeline.submit(
+            filename,
+            data,
+            caller=caller,
+            request_id=_request_id(request) or None,
+        )
+    except ValueError as exc:
+        raise bad_request(str(exc)) from exc
+    if _truthy(run_value):
+        job = pipeline.run_job(job.id)
+    return job
+
+
+@router.get("/v1/jobs/{job_id}", response_model=Job)
+def get_job(job_id: str, pipeline: Pipeline = Depends(get_pipeline)) -> Job:
+    job = pipeline.jobs.get(job_id)
+    if job is None:
+        raise not_found("job not found")
+    return job
+
+
+@router.get("/v1/jobs", response_model=list[Job])
+def list_jobs(pipeline: Pipeline = Depends(get_pipeline)) -> list[Job]:
+    return pipeline.jobs.list()

--- a/src/docparse/api/schemas.py
+++ b/src/docparse/api/schemas.py
@@ -1,0 +1,80 @@
+"""OpenAPI 请求体与示例。字段名单来自 YAML，不手写 agent*。"""
+
+from __future__ import annotations
+
+from docparse.api.caller import accepted_caller_keys
+from docparse.schema.loader import Schema, load_schema
+
+JOB_EXAMPLE = {
+    "id": "ab12cd",
+    "status": "needs_review",
+    "source_filename": "hengxin.xlsx",
+    "result": {
+        "status": "needs_review",
+        "declaration": {
+            "contrNo": "HDX2026-251",
+            "grossWt": "296.46",
+            "netWt": "218.375",
+            "agentCode": "4403180867",
+            "agentName": "深圳市泰洲物流有限公司",
+            "tdecGoodsitemsVoArr": [
+                {"gname": "表壳配件/壳体", "gqty": "150"},
+            ],
+            "_meta": {
+                "has_draft": True,
+                "source_roles": ["draft", "packing"],
+                "review_reasons": [],
+            },
+        },
+        "reviews": [
+            {
+                "path": "iePort",
+                "status": "needs_review",
+                "reasons": ["unknown_code:海关口岸代码"],
+                "evidence": [
+                    {
+                        "sheet": "一般贸易出口",
+                        "cell": "E4",
+                        "quote": "一般贸易出口!E3:出境关别",
+                    }
+                ],
+            }
+        ],
+    },
+}
+
+
+def multipart_openapi(schema: Schema | None = None) -> dict:
+    schema = schema or load_schema()
+    properties: dict = {
+        "file": {
+            "type": "string",
+            "format": "binary",
+            "description": "xlsx；以后同一接口接 PDF / zip",
+        },
+        "run": {
+            "type": "boolean",
+            "default": True,
+            "description": "true 则同步跑完并返回报关单",
+        },
+    }
+    for name in accepted_caller_keys(schema):
+        spec = schema.field(name)
+        properties[name] = {
+            "type": "string",
+            "description": spec.display_name if spec else name,
+        }
+    return {
+        "requestBody": {
+            "required": True,
+            "content": {
+                "multipart/form-data": {
+                    "schema": {
+                        "type": "object",
+                        "required": ["file"],
+                        "properties": properties,
+                    }
+                }
+            },
+        }
+    }

--- a/src/docparse/api/schemas.py
+++ b/src/docparse/api/schemas.py
@@ -60,10 +60,13 @@ def multipart_openapi(schema: Schema | None = None) -> dict:
     }
     for name in accepted_caller_keys(schema):
         spec = schema.field(name)
-        properties[name] = {
+        field = {
             "type": "string",
             "description": spec.display_name if spec else name,
         }
+        if spec is not None and spec.default:
+            field["default"] = spec.default
+        properties[name] = field
     return {
         "requestBody": {
             "required": True,

--- a/src/docparse/cli.py
+++ b/src/docparse/cli.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from uuid import uuid4
 
 from docparse.adapters.parsers.registry import parse_bytes
-from docparse.extraction.assemble import assemble_declaration, declaration_payload
 from docparse.extraction.goods_map import map_document_goods, map_sheet_goods
 from docparse.extraction.head_map import map_sheet_head
 from docparse.pipeline.runner import Pipeline
@@ -136,10 +135,11 @@ def _goods(path: Path) -> int:
 
 
 def _declare(path: Path, agent: dict[str, str]) -> int:
-    document = parse_bytes(path.read_bytes(), file_id=uuid4().hex, filename=path.name)
-    declaration = assemble_declaration(document, agent=agent)
-    print(json.dumps(declaration_payload(declaration), ensure_ascii=False, indent=2))
-    return 0
+    caller = {key: value for key, value in agent.items() if value.strip()}
+    job = Pipeline().process(path.name, path.read_bytes(), caller=caller)
+    payload = job.result.declaration if job.result else None
+    print(json.dumps(payload or {}, ensure_ascii=False, indent=2))
+    return 0 if job.status.value != "failed" else 2
 
 
 def _item_payload(item) -> dict:

--- a/src/docparse/domain/__init__.py
+++ b/src/docparse/domain/__init__.py
@@ -10,12 +10,14 @@ from docparse.domain.ir import (
 )
 from docparse.domain.models import (
     DocumentType,
+    FieldReview,
     FileKind,
     FileRef,
     Job,
     JobStatus,
     PackageResult,
     ParseJobResult,
+    ReviewEvidence,
 )
 
 __all__ = [
@@ -25,6 +27,7 @@ __all__ = [
     "DocumentType",
     "Evidence",
     "ExtractedField",
+    "FieldReview",
     "FieldStatus",
     "FileKind",
     "FileRef",
@@ -33,6 +36,7 @@ __all__ = [
     "PackageResult",
     "Page",
     "ParseJobResult",
+    "ReviewEvidence",
     "Sheet",
     "TextBlock",
 ]

--- a/src/docparse/domain/models.py
+++ b/src/docparse/domain/models.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 from enum import StrEnum
+from typing import Any
 from uuid import uuid4
 
 from pydantic import BaseModel, Field
@@ -51,9 +52,30 @@ class PackageResult(BaseModel):
     review_reasons: list[str] = Field(default_factory=list)
 
 
+class ReviewEvidence(BaseModel):
+    """字段级证据。xlsx 用 sheet/cell；PDF 以后补 page。"""
+
+    sheet: str | None = None
+    cell: str | None = None
+    page: int | None = None
+    quote: str = ""
+    filename: str | None = None
+
+
+class FieldReview(BaseModel):
+    """一个报关单字段（或货行字段）的复核项。path 跟目录走，不手写字段表。"""
+
+    path: str
+    status: str
+    reasons: list[str] = Field(default_factory=list)
+    evidence: list[ReviewEvidence] = Field(default_factory=list)
+
+
 class ParseJobResult(BaseModel):
     status: JobStatus
     package: PackageResult = Field(default_factory=PackageResult)
+    declaration: dict[str, Any] | None = None
+    reviews: list[FieldReview] = Field(default_factory=list)
     error: str | None = None
 
 
@@ -64,6 +86,8 @@ class Job(BaseModel):
     updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
     source_filename: str
     source_file_id: str | None = None
+    request_id: str | None = None
+    caller: dict[str, str] = Field(default_factory=dict)
     result: ParseJobResult | None = None
     error: str | None = None
 

--- a/src/docparse/extraction/__init__.py
+++ b/src/docparse/extraction/__init__.py
@@ -1,4 +1,8 @@
-from docparse.extraction.assemble import assemble_declaration, declaration_payload
+from docparse.extraction.assemble import (
+    assemble_declaration,
+    declaration_payload,
+    declaration_reviews,
+)
 from docparse.extraction.classify import classify_document
 from docparse.extraction.fields import extract_fields
 from docparse.extraction.goods_map import map_document_goods, map_sheet_goods
@@ -12,6 +16,7 @@ __all__ = [
     "classify_sheet",
     "classify_sheets",
     "declaration_payload",
+    "declaration_reviews",
     "extract_fields",
     "map_document_goods",
     "map_document_head",

--- a/src/docparse/extraction/assemble.py
+++ b/src/docparse/extraction/assemble.py
@@ -6,6 +6,7 @@ from copy import deepcopy
 
 from docparse.domain.fields import Declaration, ExtractedField, FieldStatus, GoodsItem
 from docparse.domain.ir import DocumentIR, Evidence, Sheet
+from docparse.domain.models import FieldReview, ReviewEvidence
 from docparse.extraction.goods_map import map_document_goods
 from docparse.extraction.head_map import map_sheet_head
 from docparse.schema.loader import (
@@ -40,6 +41,7 @@ def assemble_declaration(
     sheets = _ordered_sheets(document, policy)
     head = _merge_head(sheets, document, schema)
     _apply_defaults(head, schema)
+    _apply_caller_overrides(head, schema, agent)
     _apply_weight_policy(head, schema)
     _reconcile_head(head, sheets, document, schema)
     _note_invoice_numbers(head, sheets, vocab, document, schema)
@@ -76,6 +78,55 @@ def declaration_payload(declaration: Declaration, schema: Schema | None = None) 
         },
     }
     return payload
+
+
+_REVIEW_STATUSES = {FieldStatus.NEEDS_REVIEW, FieldStatus.INVALID, FieldStatus.CONFLICT}
+
+
+def declaration_reviews(
+    declaration: Declaration, schema: Schema | None = None
+) -> list[FieldReview]:
+    """字段级复核清单。path 跟目录走；新字段进 YAML 后自动出现。"""
+    schema = schema or load_schema()
+    reviews: list[FieldReview] = []
+    seen: set[str] = set()
+    for name, field in declaration.head.items():
+        item = _field_review(name, field)
+        if item is None:
+            continue
+        reviews.append(item)
+        seen.add(name)
+    for index, goods in enumerate(declaration.goods):
+        prefix = f"{schema.goods_array}[{index}]"
+        for name, field in goods.fields.items():
+            path = f"{prefix}.{name}"
+            item = _field_review(path, field)
+            if item is None:
+                continue
+            reviews.append(item)
+            seen.add(path)
+        if goods.review_reasons and prefix not in seen:
+            reviews.append(
+                FieldReview(
+                    path=prefix,
+                    status=FieldStatus.NEEDS_REVIEW.value,
+                    reasons=list(goods.review_reasons),
+                )
+            )
+            seen.add(prefix)
+    for reason in declaration.review_reasons:
+        name, sep, detail = reason.partition(":")
+        if not sep or name in seen or name.startswith("goods["):
+            continue
+        reviews.append(
+            FieldReview(
+                path=name,
+                status=FieldStatus.NEEDS_REVIEW.value,
+                reasons=[detail],
+            )
+        )
+        seen.add(name)
+    return reviews
 
 
 def _ordered_sheets(document: DocumentIR, policy: Assembly) -> list[Sheet]:
@@ -276,6 +327,57 @@ def _apply_lookup(field: ExtractedField, spec: FieldSpec, codes: CodeTables) -> 
         return
     field.value = code
     field.normalized_value = code
+
+
+def _apply_caller_overrides(
+    head: dict[str, ExtractedField],
+    schema: Schema,
+    caller: dict[str, str] | None,
+) -> None:
+    """覆盖组装默认值（如 cusIEFlag）。只吃 assembly.defaults 里的键，未知键忽略。"""
+    values = caller or {}
+    for name in schema.assembly.defaults:
+        text = (values.get(name) or "").strip()
+        if not text:
+            continue
+        spec = schema.field(name)
+        head[name] = ExtractedField(
+            name=name,
+            display_name=spec.display_name if spec else name,
+            value=text,
+            normalized_value=text,
+            confidence=1.0,
+            status=FieldStatus.ACCEPTED,
+            extraction_method="caller",
+        )
+
+
+def _field_review(path: str, field: ExtractedField) -> FieldReview | None:
+    blocking = field.status in _REVIEW_STATUSES
+    missing = field.status == FieldStatus.MISSING and bool(field.validation_errors)
+    if not blocking and not missing:
+        return None
+    reasons = list(field.validation_errors) or [field.status.value]
+    return FieldReview(
+        path=path,
+        status=field.status.value,
+        reasons=reasons,
+        evidence=[_review_evidence(item) for item in field.evidence],
+    )
+
+
+def _review_evidence(item: Evidence) -> ReviewEvidence:
+    sheet = None
+    cell = item.cell
+    if cell and "!" in cell:
+        sheet, cell = cell.split("!", 1)
+    return ReviewEvidence(
+        sheet=sheet,
+        cell=cell,
+        page=item.page,
+        quote=item.quote,
+        filename=item.filename,
+    )
 
 
 def _apply_agent(

--- a/src/docparse/pipeline/context.py
+++ b/src/docparse/pipeline/context.py
@@ -4,6 +4,7 @@ from docparse.adapters.files.base import FileStore
 from docparse.adapters.jobs.base import JobStore
 from docparse.adapters.llm.openai_compat import OpenAICompatClient
 from docparse.config import Settings
+from docparse.domain.fields import Declaration
 from docparse.domain.ir import DocumentIR
 from docparse.domain.models import FileRef, Job, PackageResult
 from docparse.schema.loader import Schema
@@ -18,6 +19,8 @@ class PipelineContext:
     llm: OpenAICompatClient
     schema: Schema
     raw: FileRef
+    caller: dict[str, str] = field(default_factory=dict)
     members: list[FileRef] = field(default_factory=list)
     documents: list[DocumentIR] = field(default_factory=list)
     package: PackageResult = field(default_factory=PackageResult)
+    declaration: Declaration | None = None

--- a/src/docparse/pipeline/runner.py
+++ b/src/docparse/pipeline/runner.py
@@ -10,6 +10,7 @@ from docparse.adapters.llm.openai_compat import OpenAICompatClient
 from docparse.config import Settings, get_settings
 from docparse.domain.fields import FieldStatus
 from docparse.domain.models import Job, JobStatus, ParseJobResult
+from docparse.extraction.assemble import declaration_payload, declaration_reviews
 from docparse.pipeline.context import PipelineContext
 from docparse.pipeline.steps.classify import classify_step
 from docparse.pipeline.steps.extract_content import extract_content_step
@@ -51,10 +52,23 @@ class Pipeline:
         self.llm = llm or OpenAICompatClient(self.settings)
         self.steps = steps or DEFAULT_STEPS
 
-    def submit(self, filename: str, data: bytes) -> Job:
+    def submit(
+        self,
+        filename: str,
+        data: bytes,
+        *,
+        caller: dict[str, str] | None = None,
+        request_id: str | None = None,
+    ) -> Job:
         if len(data) > self.settings.max_upload_mb * 1024 * 1024:
             raise ValueError(f"文件超过 {self.settings.max_upload_mb} MB")
-        job = self.jobs.create(Job(source_filename=filename))
+        job = self.jobs.create(
+            Job(
+                source_filename=filename,
+                request_id=request_id,
+                caller=dict(caller or {}),
+            )
+        )
         raw = self.files.put(
             data,
             job_id=job.id,
@@ -62,8 +76,7 @@ class Pipeline:
             content_type="application/octet-stream",
             kind="raw",
         )
-        job = self.jobs.update(job.id, source_file_id=raw.id, status=JobStatus.QUEUED)
-        return job
+        return self.jobs.update(job.id, source_file_id=raw.id, status=JobStatus.QUEUED)
 
     def run_job(self, job_id: str) -> Job:
         job = self.jobs.get(job_id)
@@ -79,24 +92,47 @@ class Pipeline:
             llm=self.llm,
             schema=load_schema(),
             raw=raw,
+            caller=dict(job.caller),
         )
         try:
             for _name, step in self.steps:
                 step(ctx)
             status = _status_from_package(ctx)
-            result = ParseJobResult(status=status, package=ctx.package)
+            result = ParseJobResult(
+                status=status,
+                package=ctx.package,
+                declaration=_declaration_json(ctx),
+                reviews=declaration_reviews(ctx.declaration, ctx.schema)
+                if ctx.declaration is not None
+                else [],
+            )
             return self.jobs.update(job_id, status=status, result=result)
         except Exception as exc:
             result = ParseJobResult(status=JobStatus.FAILED, error=str(exc))
             return self.jobs.update(job_id, status=JobStatus.FAILED, result=result, error=str(exc))
 
-    def process(self, filename: str, data: bytes) -> Job:
-        job = self.submit(filename, data)
+    def process(
+        self,
+        filename: str,
+        data: bytes,
+        *,
+        caller: dict[str, str] | None = None,
+        request_id: str | None = None,
+    ) -> Job:
+        job = self.submit(filename, data, caller=caller, request_id=request_id)
         return self.run_job(job.id)
+
+
+def _declaration_json(ctx: PipelineContext) -> dict | None:
+    if ctx.declaration is None:
+        return None
+    return declaration_payload(ctx.declaration, ctx.schema)
 
 
 def _status_from_package(ctx: PipelineContext) -> JobStatus:
     if ctx.package.review_reasons:
+        return JobStatus.NEEDS_REVIEW
+    if ctx.declaration is not None and ctx.declaration.review_reasons:
         return JobStatus.NEEDS_REVIEW
     blocking = {FieldStatus.INVALID, FieldStatus.CONFLICT, FieldStatus.NEEDS_REVIEW}
     if any(field.status in blocking for field in ctx.package.fields):

--- a/src/docparse/pipeline/steps/extract_fields.py
+++ b/src/docparse/pipeline/steps/extract_fields.py
@@ -1,6 +1,36 @@
+from docparse.domain.fields import Declaration, ExtractedField
+from docparse.domain.ir import DocumentIR
+from docparse.extraction.assemble import assemble_declaration
 from docparse.extraction.fields import extract_fields
 from docparse.pipeline.context import PipelineContext
 
 
 def extract_fields_step(ctx: PipelineContext) -> None:
+    """有 sheet 的文档走组装；无 sheet（txt）保留旧锚点。"""
+    primary = _primary_document(ctx.documents)
+    if primary is not None and primary.sheets:
+        declaration = assemble_declaration(
+            primary,
+            schema=ctx.schema,
+            agent=ctx.caller,
+        )
+        ctx.declaration = declaration
+        ctx.package.fields = _flatten_declaration(declaration)
+        ctx.package.review_reasons.extend(declaration.review_reasons)
+        return
     ctx.package.fields = extract_fields(ctx.documents, schema=ctx.schema, llm=ctx.llm)
+
+
+def _primary_document(documents: list[DocumentIR]) -> DocumentIR | None:
+    """本期一张单只吃主文档。zip 多文件拼单以后改这里，不改路由。"""
+    for document in documents:
+        if document.sheets:
+            return document
+    return documents[0] if documents else None
+
+
+def _flatten_declaration(declaration: Declaration) -> list[ExtractedField]:
+    fields = list(declaration.head.values())
+    for item in declaration.goods:
+        fields.extend(item.fields.values())
+    return fields

--- a/src/docparse/pipeline/steps/reconcile.py
+++ b/src/docparse/pipeline/steps/reconcile.py
@@ -5,7 +5,13 @@ from docparse.pipeline.context import PipelineContext
 
 
 def reconcile_step(ctx: PipelineContext) -> None:
-    """同一压缩包内，同名字段出现多个不同值则标冲突。"""
+    """同一压缩包内，同名字段出现多个不同值则标冲突。
+
+    已组装的一张单里货行会重复 gname / gqty，不能按字段名对账。
+    zip 多文件拼单以后改 assemble，不在这里按扁列表对。
+    """
+    if ctx.declaration is not None:
+        return
     grouped: dict[str, set[str]] = defaultdict(set)
     for field in ctx.package.fields:
         if field.normalized_value:

--- a/src/docparse/pipeline/steps/validate.py
+++ b/src/docparse/pipeline/steps/validate.py
@@ -3,5 +3,8 @@ from docparse.pipeline.context import PipelineContext
 
 
 def validate_step(ctx: PipelineContext) -> None:
+    # 已组装的报关单由 #20 闸 Declaration；旧锚点路径仍走字段级骨架校验。
+    if ctx.declaration is not None:
+        return
     ctx.package.fields = validate_fields(ctx.package.fields, schema=ctx.schema)
     ctx.package.review_reasons.extend(review_reasons(ctx.package.fields))

--- a/src/docparse/schema/fields.yaml
+++ b/src/docparse/schema/fields.yaml
@@ -113,13 +113,15 @@ caller_params:
     group: caller
     layout: caller
     parse: false
-    notes: 申报单位不解析，调用方传入。
+    default: "4403180867"
+    notes: 申报单位不解析，调用方传入。默认深圳市泰洲物流有限公司。
 
   - name: agentName
     display_name: 申报单位名称
     group: caller
     layout: caller
     parse: false
+    default: 深圳市泰洲物流有限公司
     notes: 申报单位不解析，调用方传入。
 
   - name: agentScc
@@ -127,6 +129,7 @@ caller_params:
     group: caller
     layout: caller
     parse: false
+    default: "914403000539716870"
     notes: 申报单位不解析，调用方传入。
 
   - name: agentCiqCode
@@ -134,6 +137,7 @@ caller_params:
     group: caller
     layout: caller
     parse: false
+    default: "4700910159"
     notes: md 有、json 字段说明无；同属申报单位，外传不解析。
 
 ignored:

--- a/src/docparse/schema/loader.py
+++ b/src/docparse/schema/loader.py
@@ -32,6 +32,7 @@ class FieldSpec(BaseModel):
     # 商品列映射（#18）。keep=原样；skip=本层不映射；
     # leading_hs=取列值前缀税则号；raw_review=原文 + needs_review。
     goods_map: str = "keep"
+    default: str | None = None
 
     @model_validator(mode="after")
     def check_maps(self) -> "FieldSpec":

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -78,10 +78,25 @@ def test_missing_gross_is_needs_review_not_500() -> None:
     declaration = body["result"]["declaration"]
     assert declaration["grossWt"] == ""
     assert declaration["netWt"] == "2825.47"
-    assert declaration["agentCode"] == ""
+    assert declaration["agentCode"] == "4403180867"
+    assert declaration["agentName"] == "深圳市泰洲物流有限公司"
+    assert declaration["agentScc"] == "914403000539716870"
+    assert declaration["agentCiqCode"] == "4700910159"
     paths = {item["path"]: item for item in body["result"]["reviews"]}
     assert "grossWt" in paths
     assert "net_is_not_gross" in paths["grossWt"]["reasons"]
+
+
+def test_explicit_empty_agent_skips_yaml_default() -> None:
+    response = _client().post(
+        "/v1/jobs",
+        files={"file": _xlsx({"一般贸易出口": _draft}, "hengxin.xlsx")},
+        data={"agentCode": "", "agentName": "", "agentScc": "", "agentCiqCode": ""},
+    )
+    assert response.status_code == 200
+    declaration = response.json()["result"]["declaration"]
+    assert declaration["agentCode"] == ""
+    assert declaration["agentName"] == ""
 
 
 def test_default_pipeline_upload_does_not_500() -> None:
@@ -109,6 +124,7 @@ def test_openapi_shows_caller_and_goods_array() -> None:
     spec = _client().get("/openapi.json").json()
     text = str(spec)
     assert "agentCode" in text
+    assert "4403180867" in text
     assert "tdecGoodsitemsVoArr" in text
     assert "/v1/jobs" in spec["paths"]
     assert "/health" in spec["paths"]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import io
+
+import pytest
+
+pytest.importorskip("openpyxl")
+
+from fastapi.testclient import TestClient
+from tests.test_assemble import _draft, _net_only_packing, _workbook
+
+from docparse.adapters.files.memory import MemoryFileStore
+from docparse.adapters.jobs.memory import MemoryJobStore
+from docparse.api.app import create_app
+from docparse.api.routes import get_pipeline
+from docparse.config import Settings
+from docparse.pipeline.runner import Pipeline
+
+
+def _client() -> TestClient:
+    settings = Settings(job_store="memory", file_store="memory", llm_api_key="")
+    pipeline = Pipeline(settings=settings, jobs=MemoryJobStore(), files=MemoryFileStore())
+    app = create_app()
+    app.dependency_overrides[get_pipeline] = lambda: pipeline
+    return TestClient(app)
+
+
+def _xlsx(builders: dict, filename: str) -> tuple[str, io.BytesIO, str]:
+    return filename, io.BytesIO(_workbook(builders)), (
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    )
+
+
+def test_health() -> None:
+    response = _client().get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+    assert response.headers.get("X-Request-Id")
+
+
+def test_upload_hengxin_fixture_returns_declaration() -> None:
+    client = _client()
+    response = client.post(
+        "/v1/jobs",
+        files={"file": _xlsx({"一般贸易出口": _draft}, "hengxin.xlsx")},
+        data={
+            "agentCode": "4403180867",
+            "agentName": "深圳市泰洲物流有限公司",
+            "ignoredExtra": "should-be-ignored",
+        },
+        headers={"X-Request-Id": "req-21"},
+    )
+    assert response.status_code == 200
+    assert response.headers.get("X-Request-Id") == "req-21"
+    body = response.json()
+    assert body["request_id"] == "req-21"
+    declaration = body["result"]["declaration"]
+    assert declaration["contrNo"] == "HDX2026-251"
+    assert declaration["grossWt"] == "296.46"
+    assert declaration["tdecGoodsitemsVoArr"]
+    assert declaration["tdecGoodsitemsVoArr"][0]["gname"] == "表壳配件/壳体"
+    assert declaration["agentCode"] == "4403180867"
+    assert declaration["agentName"] == "深圳市泰洲物流有限公司"
+    assert declaration["_meta"]["has_draft"] is True
+    assert "ignoredExtra" not in body["caller"]
+
+
+def test_missing_gross_is_needs_review_not_500() -> None:
+    response = _client().post(
+        "/v1/jobs",
+        files={"file": _xlsx({"总箱单": _net_only_packing}, "net-only.xlsx")},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "needs_review"
+    declaration = body["result"]["declaration"]
+    assert declaration["grossWt"] == ""
+    assert declaration["netWt"] == "2825.47"
+    assert declaration["agentCode"] == ""
+    paths = {item["path"]: item for item in body["result"]["reviews"]}
+    assert "grossWt" in paths
+    assert "net_is_not_gross" in paths["grossWt"]["reasons"]
+
+
+def test_missing_file_is_400() -> None:
+    response = _client().post("/v1/jobs", data={"agentCode": "4403180867"})
+    assert response.status_code == 400
+
+
+def test_openapi_shows_caller_and_goods_array() -> None:
+    spec = _client().get("/openapi.json").json()
+    text = str(spec)
+    assert "agentCode" in text
+    assert "tdecGoodsitemsVoArr" in text
+    assert "/v1/jobs" in spec["paths"]
+    assert "/health" in spec["paths"]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -8,7 +8,9 @@ pytest.importorskip("openpyxl")
 
 from fastapi.testclient import TestClient
 
+from docparse.adapters.files.factory import _file_store
 from docparse.adapters.files.memory import MemoryFileStore
+from docparse.adapters.jobs.factory import _job_store
 from docparse.adapters.jobs.memory import MemoryJobStore
 from docparse.api.app import create_app
 from docparse.api.routes import get_pipeline
@@ -80,6 +82,22 @@ def test_missing_gross_is_needs_review_not_500() -> None:
     paths = {item["path"]: item for item in body["result"]["reviews"]}
     assert "grossWt" in paths
     assert "net_is_not_gross" in paths["grossWt"]["reasons"]
+
+
+def test_default_pipeline_upload_does_not_500() -> None:
+    """Swagger / uvicorn 走 get_pipeline()，不能把 Settings 丢进 lru_cache。"""
+    get_pipeline.cache_clear()
+    _job_store.cache_clear()
+    _file_store.cache_clear()
+    app = create_app()
+    response = TestClient(app).post(
+        "/v1/jobs",
+        files={"file": _xlsx({"一般贸易出口": _draft}, "hengxin.xlsx")},
+        data={"agentCode": "4403180867"},
+    )
+    assert response.status_code == 200
+    assert response.json()["result"]["declaration"]["contrNo"] == "HDX2026-251"
+    get_pipeline.cache_clear()
 
 
 def test_missing_file_is_400() -> None:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -7,7 +7,6 @@ import pytest
 pytest.importorskip("openpyxl")
 
 from fastapi.testclient import TestClient
-from tests.test_assemble import _draft, _net_only_packing, _workbook
 
 from docparse.adapters.files.memory import MemoryFileStore
 from docparse.adapters.jobs.memory import MemoryJobStore
@@ -15,6 +14,7 @@ from docparse.api.app import create_app
 from docparse.api.routes import get_pipeline
 from docparse.config import Settings
 from docparse.pipeline.runner import Pipeline
+from xlsx_fixtures import _draft, _net_only_packing, _workbook
 
 
 def _client() -> TestClient:

--- a/tests/test_assemble.py
+++ b/tests/test_assemble.py
@@ -1,14 +1,8 @@
 from __future__ import annotations
 
-import io
 from pathlib import Path
 
 import pytest
-
-pytest.importorskip("openpyxl")
-
-from openpyxl import Workbook
-from openpyxl.styles import Border, Side
 
 from docparse.adapters.parsers.excel import parse_excel
 from docparse.extraction.assemble import (
@@ -16,192 +10,19 @@ from docparse.extraction.assemble import (
     declaration_payload,
     declaration_reviews,
 )
+from xlsx_fixtures import (
+    _auxiliary,
+    _draft,
+    _invoice,
+    _mismatch_packing,
+    _net_only_packing,
+    _packing,
+    _workbook,
+)
 
 _DEMO = Path("/Users/baldwin/Desktop/taizhou/AI识别Demo")
 REAL_HENGXIN = _DEMO / "（恒信）一般贸易草单HDX260251BLU.xlsx"
 REAL_GUOGUANG = _DEMO / "（国光）箱单发票合同26VN0502-1.xlsx"
-
-
-def _thin() -> Border:
-    line = Side(style="thin")
-    return Border(left=line, right=line, top=line, bottom=line)
-
-
-def _workbook(builders: dict) -> bytes:
-    book = Workbook()
-    first = True
-    for title, fill in builders.items():
-        sheet = book.active if first else book.create_sheet(title)
-        if first:
-            sheet.title = title
-            first = False
-        fill(sheet)
-    buffer = io.BytesIO()
-    book.save(buffer)
-    return buffer.getvalue()
-
-
-def _draft(sheet) -> None:
-    sheet["A1"] = "中华人民共和国海关出口货物报关单"
-    sheet.merge_cells("A3:D3")
-    sheet["A3"] = "境内发货人"
-    sheet.merge_cells("A4:D4")
-    sheet["A4"] = "惠州市恒德信精密科技有限公司441394164D"
-    sheet["E3"] = "出境关别"
-    sheet["E4"] = "莲塘口岸"
-    sheet.merge_cells("A5:D5")
-    sheet["A5"] = "境外收货人"
-    sheet.merge_cells("A6:D6")
-    sheet["A6"] = "BLU PRECISION LIMITED"
-    sheet.merge_cells("A7:D7")
-    sheet["A7"] = "生产销售单位"
-    sheet.merge_cells("A8:D8")
-    sheet["A8"] = "惠州市恒德信精密科技有限公司"
-    sheet["E5"] = "运输方式"
-    sheet["E6"] = "公路运输"
-    sheet["E7"] = "监管方式"
-    sheet["E8"] = "一般贸易"
-    sheet.merge_cells("A9:D9")
-    sheet["A9"] = "合同协议号"
-    sheet.merge_cells("A10:D10")
-    sheet["A10"] = "HDX2026-251"
-    sheet.merge_cells("A11:C11")
-    sheet["A11"] = "包装种类"
-    sheet["D11"] = "件数"
-    sheet["E11"] = "毛重（千克）"
-    sheet["F11"] = "净重（千克）"
-    sheet.merge_cells("G11:H11")
-    sheet["G11"] = "成交方式"
-    sheet.merge_cells("A12:C12")
-    sheet["A12"] = "其它"
-    sheet["D12"] = 40
-    sheet["E12"] = 296.46
-    sheet["F12"] = 218.375
-    sheet.merge_cells("G12:H12")
-    sheet["G12"] = "FOB"
-    headers = [
-        ("A17", "项号"),
-        ("B17", "商品编号"),
-        ("C17", "商品名称及规格型号"),
-        ("D17", "申报要素"),
-        ("E17", "数量PCS"),
-        ("F17", "计价单位"),
-        ("G17", "重量KG"),
-        ("H17", "单价"),
-        ("I17", "总价"),
-        ("J17", "币制"),
-        ("K17", "原产国（地区）"),
-        ("L17", "最终目的国（地区）"),
-        ("M17", "境内货源地"),
-    ]
-    for address, text in headers:
-        sheet[address] = text
-    sheet["A18"] = 1
-    sheet["B18"] = "9111900000"
-    sheet["C18"] = "表壳配件/壳体"
-    sheet["D18"] = "不锈钢/无中文品牌、无外文品牌/无型号"
-    sheet["E18"] = 150
-    sheet["F18"] = "只"
-    sheet["G18"] = 5.74
-    sheet["H18"] = 98
-    sheet["I18"] = 14700
-    sheet["J18"] = "港币"
-    sheet["K18"] = "中国"
-    sheet["L18"] = "中国香港"
-    sheet["M18"] = "惠州其他"
-    for row in sheet.iter_rows(min_row=1, max_row=18, min_col=1, max_col=13):
-        for cell in row:
-            cell.border = _thin()
-
-
-def _packing(sheet) -> None:
-    sheet["A1"] = "PACKING LIST"
-    sheet["I4"] = "Invoice No.﹕"
-    sheet["J4"] = "HDX260251"
-    sheet["A7"] = "Bill To : BLU PRECISION LIMITED"
-    sheet["C11"] = "Description (货物名称)"
-    sheet["E11"] = "Ship Q'ty (数量/PCS)"
-    sheet["G11"] = "Packing (箱)"
-    sheet["H11"] = "N.W. (Kg) (净重)"
-    sheet["I11"] = "G.W .(Kg) (毛重)"
-    sheet["C12"] = "表壳配件/壳体"
-    sheet["E12"] = 150
-    sheet["G12"] = 40
-    sheet["H12"] = 5.74
-    sheet["I12"] = 7.35
-    for row in sheet.iter_rows(min_row=1, max_row=12, min_col=1, max_col=10):
-        for cell in row:
-            cell.border = _thin()
-
-
-def _mismatch_packing(sheet) -> None:
-    _packing(sheet)
-    sheet["A3"] = "件数"
-    sheet["B3"] = 99
-
-
-def _net_only_packing(sheet) -> None:
-    sheet["A1"] = "PACKING LIST"
-    sheet["A3"] = "净重"
-    sheet["B3"] = 2825.47
-    sheet["A6"] = "合同号CONTRACT NO.:"
-    sheet["B6"] = "26VN0502"
-    sheet["A8"] = "卖方SELLER"
-    sheet["A9"] = "GUOGUANG ELECTRIC COMPANY LIMITED."
-    sheet["F8"] = "买方BUYER"
-    sheet["F9"] = "GUOGUANG ACOUSTICS (VIETNAM) COMPANY LIMITED"
-    sheet["B12"] = "物料名称"
-    sheet["C12"] = "单位"
-    sheet["D12"] = "出货数量"
-    sheet["H12"] = "总净重 NW"
-    sheet["Q12"] = "HS CODE海关编码"
-    sheet["B13"] = "贴纸"
-    sheet["C13"] = "个"
-    sheet["D13"] = 100
-    sheet["H13"] = 0.0013
-    sheet["Q13"] = "4821900000纸或纸板的其他各种标签"
-    for row in sheet.iter_rows(min_row=1, max_row=13, min_col=1, max_col=19):
-        for cell in row:
-            cell.border = _thin()
-
-
-def _invoice(sheet) -> None:
-    sheet["A1"] = "INVOICE"
-    sheet["F6"] = "发票号INVOICE NO.:"
-    sheet["G6"] = "26VN0502-1"
-    sheet["A8"] = "买方BUYER"
-    sheet["A9"] = "GUOGUANG ACOUSTICS (VIETNAM) COMPANY LIMITED"
-    sheet["G7"] = "合同号CONTRACT NO.:"
-    sheet["H7"] = "26VN0502"
-    sheet["B16"] = "物料名称"
-    sheet["D16"] = "出货数量"
-    sheet["E16"] = "币别"
-    sheet["F16"] = "单价"
-    sheet["G16"] = "汇总价"
-    sheet["B17"] = "贴纸"
-    sheet["D17"] = 100
-    sheet["E17"] = "USD"
-    sheet["F17"] = 0.0181
-    sheet["G17"] = 1.81
-    for row in sheet.iter_rows(min_row=1, max_row=17, min_col=1, max_col=8):
-        for cell in row:
-            cell.border = _thin()
-
-
-def _auxiliary(sheet) -> None:
-    sheet["B1"] = "报关单号"
-    sheet["C1"] = "报关日期"
-    sheet["E1"] = "恒信编号"
-    sheet["K1"] = "SAP编号"
-    sheet["H1"] = "商品编码"
-    sheet["M1"] = "商品名称"
-    sheet["A3"] = "合同协议号"
-    sheet["A4"] = "SHOULD-NOT-ASSEMBLE"
-    sheet["H2"] = "9999999999"
-    sheet["M2"] = "内部料号壳体"
-    for row in sheet.iter_rows(min_row=1, max_row=4, min_col=1, max_col=13):
-        for cell in row:
-            cell.border = _thin()
 
 
 def _parse(builders: dict, filename: str):

--- a/tests/test_assemble.py
+++ b/tests/test_assemble.py
@@ -11,7 +11,11 @@ from openpyxl import Workbook
 from openpyxl.styles import Border, Side
 
 from docparse.adapters.parsers.excel import parse_excel
-from docparse.extraction.assemble import assemble_declaration, declaration_payload
+from docparse.extraction.assemble import (
+    assemble_declaration,
+    declaration_payload,
+    declaration_reviews,
+)
 
 _DEMO = Path("/Users/baldwin/Desktop/taizhou/AI识别Demo")
 REAL_HENGXIN = _DEMO / "（恒信）一般贸易草单HDX260251BLU.xlsx"
@@ -244,6 +248,16 @@ def test_draft_is_copied_and_codes_are_looked_up() -> None:
     assert payload["tdecContasVoArr"] == []
     assert payload["_meta"]["source_roles"] == ["draft", "packing"]
     assert "SHOULD-NOT-ASSEMBLE" not in payload.values()
+    reviews = {item.path: item for item in declaration_reviews(declaration)}
+    assert reviews["iePort"].status == "needs_review"
+    assert any("unknown_code" in reason for reason in reviews["iePort"].reasons)
+    assert reviews["iePort"].evidence
+
+
+def test_caller_overrides_default_ie_flag() -> None:
+    document = _parse({"一般贸易出口": _draft}, "draft-only.xlsx")
+    payload = declaration_payload(assemble_declaration(document, agent={"cusIEFlag": "I"}))
+    assert payload["cusIEFlag"] == "I"
 
 
 def test_commercial_mismatch_keeps_draft_value() -> None:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -210,6 +210,7 @@ def test_agent_fields_are_caller_params() -> None:
         assert spec.parse is False
         assert spec.layout == "caller"
         assert spec.group == "caller"
+        assert spec.default
 
 
 def test_ignored_items_listed() -> None:

--- a/tests/xlsx_fixtures.py
+++ b/tests/xlsx_fixtures.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import io
+
+import pytest
+
+pytest.importorskip("openpyxl")
+
+from openpyxl import Workbook
+from openpyxl.styles import Border, Side
+
+
+def _thin() -> Border:
+    line = Side(style="thin")
+    return Border(left=line, right=line, top=line, bottom=line)
+
+
+def _workbook(builders: dict) -> bytes:
+    book = Workbook()
+    first = True
+    for title, fill in builders.items():
+        sheet = book.active if first else book.create_sheet(title)
+        if first:
+            sheet.title = title
+            first = False
+        fill(sheet)
+    buffer = io.BytesIO()
+    book.save(buffer)
+    return buffer.getvalue()
+
+
+def _draft(sheet) -> None:
+    sheet["A1"] = "中华人民共和国海关出口货物报关单"
+    sheet.merge_cells("A3:D3")
+    sheet["A3"] = "境内发货人"
+    sheet.merge_cells("A4:D4")
+    sheet["A4"] = "惠州市恒德信精密科技有限公司441394164D"
+    sheet["E3"] = "出境关别"
+    sheet["E4"] = "莲塘口岸"
+    sheet.merge_cells("A5:D5")
+    sheet["A5"] = "境外收货人"
+    sheet.merge_cells("A6:D6")
+    sheet["A6"] = "BLU PRECISION LIMITED"
+    sheet.merge_cells("A7:D7")
+    sheet["A7"] = "生产销售单位"
+    sheet.merge_cells("A8:D8")
+    sheet["A8"] = "惠州市恒德信精密科技有限公司"
+    sheet["E5"] = "运输方式"
+    sheet["E6"] = "公路运输"
+    sheet["E7"] = "监管方式"
+    sheet["E8"] = "一般贸易"
+    sheet.merge_cells("A9:D9")
+    sheet["A9"] = "合同协议号"
+    sheet.merge_cells("A10:D10")
+    sheet["A10"] = "HDX2026-251"
+    sheet.merge_cells("A11:C11")
+    sheet["A11"] = "包装种类"
+    sheet["D11"] = "件数"
+    sheet["E11"] = "毛重（千克）"
+    sheet["F11"] = "净重（千克）"
+    sheet.merge_cells("G11:H11")
+    sheet["G11"] = "成交方式"
+    sheet.merge_cells("A12:C12")
+    sheet["A12"] = "其它"
+    sheet["D12"] = 40
+    sheet["E12"] = 296.46
+    sheet["F12"] = 218.375
+    sheet.merge_cells("G12:H12")
+    sheet["G12"] = "FOB"
+    headers = [
+        ("A17", "项号"),
+        ("B17", "商品编号"),
+        ("C17", "商品名称及规格型号"),
+        ("D17", "申报要素"),
+        ("E17", "数量PCS"),
+        ("F17", "计价单位"),
+        ("G17", "重量KG"),
+        ("H17", "单价"),
+        ("I17", "总价"),
+        ("J17", "币制"),
+        ("K17", "原产国（地区）"),
+        ("L17", "最终目的国（地区）"),
+        ("M17", "境内货源地"),
+    ]
+    for address, text in headers:
+        sheet[address] = text
+    sheet["A18"] = 1
+    sheet["B18"] = "9111900000"
+    sheet["C18"] = "表壳配件/壳体"
+    sheet["D18"] = "不锈钢/无中文品牌、无外文品牌/无型号"
+    sheet["E18"] = 150
+    sheet["F18"] = "只"
+    sheet["G18"] = 5.74
+    sheet["H18"] = 98
+    sheet["I18"] = 14700
+    sheet["J18"] = "港币"
+    sheet["K18"] = "中国"
+    sheet["L18"] = "中国香港"
+    sheet["M18"] = "惠州其他"
+    for row in sheet.iter_rows(min_row=1, max_row=18, min_col=1, max_col=13):
+        for cell in row:
+            cell.border = _thin()
+
+
+def _packing(sheet) -> None:
+    sheet["A1"] = "PACKING LIST"
+    sheet["I4"] = "Invoice No.﹕"
+    sheet["J4"] = "HDX260251"
+    sheet["A7"] = "Bill To : BLU PRECISION LIMITED"
+    sheet["C11"] = "Description (货物名称)"
+    sheet["E11"] = "Ship Q'ty (数量/PCS)"
+    sheet["G11"] = "Packing (箱)"
+    sheet["H11"] = "N.W. (Kg) (净重)"
+    sheet["I11"] = "G.W .(Kg) (毛重)"
+    sheet["C12"] = "表壳配件/壳体"
+    sheet["E12"] = 150
+    sheet["G12"] = 40
+    sheet["H12"] = 5.74
+    sheet["I12"] = 7.35
+    for row in sheet.iter_rows(min_row=1, max_row=12, min_col=1, max_col=10):
+        for cell in row:
+            cell.border = _thin()
+
+
+def _mismatch_packing(sheet) -> None:
+    _packing(sheet)
+    sheet["A3"] = "件数"
+    sheet["B3"] = 99
+
+
+def _net_only_packing(sheet) -> None:
+    sheet["A1"] = "PACKING LIST"
+    sheet["A3"] = "净重"
+    sheet["B3"] = 2825.47
+    sheet["A6"] = "合同号CONTRACT NO.:"
+    sheet["B6"] = "26VN0502"
+    sheet["A8"] = "卖方SELLER"
+    sheet["A9"] = "GUOGUANG ELECTRIC COMPANY LIMITED."
+    sheet["F8"] = "买方BUYER"
+    sheet["F9"] = "GUOGUANG ACOUSTICS (VIETNAM) COMPANY LIMITED"
+    sheet["B12"] = "物料名称"
+    sheet["C12"] = "单位"
+    sheet["D12"] = "出货数量"
+    sheet["H12"] = "总净重 NW"
+    sheet["Q12"] = "HS CODE海关编码"
+    sheet["B13"] = "贴纸"
+    sheet["C13"] = "个"
+    sheet["D13"] = 100
+    sheet["H13"] = 0.0013
+    sheet["Q13"] = "4821900000纸或纸板的其他各种标签"
+    for row in sheet.iter_rows(min_row=1, max_row=13, min_col=1, max_col=19):
+        for cell in row:
+            cell.border = _thin()
+
+
+def _invoice(sheet) -> None:
+    sheet["A1"] = "INVOICE"
+    sheet["F6"] = "发票号INVOICE NO.:"
+    sheet["G6"] = "26VN0502-1"
+    sheet["A8"] = "买方BUYER"
+    sheet["A9"] = "GUOGUANG ACOUSTICS (VIETNAM) COMPANY LIMITED"
+    sheet["G7"] = "合同号CONTRACT NO.:"
+    sheet["H7"] = "26VN0502"
+    sheet["B16"] = "物料名称"
+    sheet["D16"] = "出货数量"
+    sheet["E16"] = "币别"
+    sheet["F16"] = "单价"
+    sheet["G16"] = "汇总价"
+    sheet["B17"] = "贴纸"
+    sheet["D17"] = 100
+    sheet["E17"] = "USD"
+    sheet["F17"] = 0.0181
+    sheet["G17"] = 1.81
+    for row in sheet.iter_rows(min_row=1, max_row=17, min_col=1, max_col=8):
+        for cell in row:
+            cell.border = _thin()
+
+
+def _auxiliary(sheet) -> None:
+    sheet["B1"] = "报关单号"
+    sheet["C1"] = "报关日期"
+    sheet["E1"] = "恒信编号"
+    sheet["K1"] = "SAP编号"
+    sheet["H1"] = "商品编码"
+    sheet["M1"] = "商品名称"
+    sheet["A3"] = "合同协议号"
+    sheet["A4"] = "SHOULD-NOT-ASSEMBLE"
+    sheet["H2"] = "9999999999"
+    sheet["M2"] = "内部料号壳体"
+    for row in sheet.iter_rows(min_row=1, max_row=4, min_col=1, max_col=13):
+        for cell in row:
+            cell.border = _thin()


### PR DESCRIPTION
Closes #21

## 做了什么

`POST /v1/jobs` 交出一张报关单 JSON。与 `cli declare` 走同一条 pipeline，接口不写解析。

- 上传 xlsx + `agent*`（及可选 `cusIEFlag`）→ `result.declaration` + `result.reviews`
- `declaration` 形状与 CLI 一致，继续带 `_meta`；字段级证据另挂 `reviews`（sheet / cell / quote）
- 调用方参数跟 `fields.yaml` `caller_params` 走，不写死四个 agent；未知 Form 键忽略
- 缺字段 / 转不出 code → HTTP 200 + `needs_review`，不 500
- `cli declare` 改为 `Pipeline.process`，不再自己 `parse_bytes` + assemble
- zip 这期不拼多文件；`documents` 仍是 list，以后拼单只改 assemble / 主文档选择，不改路由

API 分层：`routes` 只搬运，`errors` 是异常出口，`caller` 从 YAML 生成 Form 名单。每个请求带 `X-Request-Id`。不接日志库、不接 Postgres。

## 验收

- 合成恒信夹具：响应含 `contrNo`、`grossWt`、`tdecGoodsitemsVoArr`
- 请求里的 `agent*` 出现在 declaration，不来自文件
- 只有净重时 HTTP 200、`needs_review`、reviews 含 `grossWt`
- `/health` 仍 200
- OpenAPI 能看到 `agentCode` 和 `tdecGoodsitemsVoArr`
- ruff / pytest 通过（74 passed）
- 客户原件不进仓库

## 以后新 xlsx / 新叫法改哪

| 你看到的现象 | 改哪里 | 动 API Python？ |
|---|---|---|
| 新叫法（装箱明细、形式发票） | `sheet_roles.yaml` / `layout_vocab.yaml` / anchors | 否 |
| 新单据类型要参与拼单 | `assembly.fill` / `role_priority` | 否 |
| 新表头 / 货列 | `fields.yaml` | 否（declaration / reviews 按目录收） |
| 新字段要转 code | 字段写 `code_table` + 码表加行 | 否 |
| 多一个申报单位字段 | `caller_params` 加一项 | 否（Form / OpenAPI 从 YAML 生成） |
| 调用方要覆盖进出口标志 | 请求带 `cusIEFlag` | 否 |
| 以后上传 PDF | #22 / #23 parser | 否（同一 `POST /v1/jobs`） |
| zip 多文件拼一张单 | assemble / `extract_fields_step` 主文档选择 | 否 |
| 校验规则 | #20 数据文件 | 否（同一接口自动带闸） |
| 结构化日志 / 错误码 | `api/errors.py` + request_id | 只改挂钩处 |

不要 `if company == "恒信"`。不要在 `routes.py` 写死 `agent*`。