### PR TITLE
feat: 报关单对眼页（#44）

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,11 +1,12 @@
 # FastAPI：一张报关单 JSON
 
-`POST /v1/jobs` 收文件和调用方参数，走与 `cli declare` 同一条 pipeline，交出一张报关单。本层不解析、不认公司。
+`POST /v1/jobs` 收文件和调用方参数，走与 `cli declare` 同一条 pipeline，交出一张报关单。本层不解析、不认公司。对眼页见 [review.md](review.md)。
 
 本地：
 
 ```bash
-uvicorn docparse.api.app:app --host 127.0.0.1 --port 8088
+PYTHONPATH=src uvicorn docparse.api.app:app --host 127.0.0.1 --port 8088
+# 浏览器打开 http://127.0.0.1:8088/review
 python -m docparse.cli declare /绝对路径/表.xlsx --agent-code 4403180867 --agent-name 深圳市泰洲物流有限公司
 ```
 

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -36,6 +36,7 @@ docparse/
 | 包级对账 | `pipeline/steps/reconcile.py` | 同名字段冲突 | 金额、单号跨文件 |
 | 自动通过 / 待复核 | `pipeline/steps/route_review.py` | 只打状态 | 复核页另开 Issue |
 | FastAPI 交单 | `api/routes.py` + `pipeline/runner.py` | `POST /v1/jobs` 交 `declaration` + `reviews`（#21） | PDF / zip 拼单不改路由 |
+| 对眼页 | `api/static/review.html` + `GET /v1/schema` | 只画报关单 + reviews（#44） | 不渲染 IR |
 | 持久化接口 | `adapters/jobs/` `adapters/files/` | 内存实现；Postgres/S3 抛未实现 | 需要跨进程时再做 |
 | 云 LLM | `adapters/llm/openai_compat.py` | 未配 Key 则跳过 | 换供应商只改这里 |
 
@@ -70,6 +71,8 @@ sheet 角色（#16）：`schema/sheet_roles.yaml` + `extraction/sheet_role.py`�
 整单组装（#19）：`extraction/assemble.py` 按 `fields.yaml` 的 `assembly` 收成一张报关单。有 `draft` 抄草单，商业单据只补空并核件毛净；无草单只抄能确定的商业事实，`customs_only` 空着复核。名称转 code；转不出留原文。`agent*` 只来自调用参数。表头只有净重时视同重量，不抄进毛重。本地对眼：`python -m docparse.cli declare file.xlsx`。见 [assemble.md](assemble.md)。
 
 FastAPI 交单（#21）：`POST /v1/jobs` 与 `cli declare` 走同一条 pipeline。调用方参数跟 `caller_params` 走，不写死四个 agent。响应是 Job + `result.declaration` + `result.reviews`。见 [api.md](api.md)。
+
+对眼页（#44）：`GET /review` 静态页 + `GET /v1/schema`。只画报关单和复核证据，不渲染 IR。见 [review.md](review.md)。
 
 抽取后校验（#20）：规则先写在 [validate-rules.md](validate-rules.md) 给业务确认。位数 / 正则 / 容差确认后再进数据文件，引擎只执行，不编造、不改值。
 

--- a/docs/review.md
+++ b/docs/review.md
@@ -1,0 +1,25 @@
+# 报关单对眼页
+
+本地一眼看组装结果，不把 IR 格子摊开。依赖现有 `POST /v1/jobs`，本页不解析。
+
+```bash
+cd /Users/baldwin/Desktop/taizhou/docparse-44-review-page
+source /Users/baldwin/Desktop/taizhou/docparse/.venv/bin/activate
+PYTHONPATH=src uvicorn docparse.api.app:app --host 127.0.0.1 --port 8088
+```
+
+打开 [http://127.0.0.1:8088/review](http://127.0.0.1:8088/review)（`/` 同一页）。
+
+页先拉 `GET /v1/schema`（`fields.yaml` 的 display_name / default），再上传走 `POST /v1/jobs`。只画 `declaration` + `reviews`。
+
+## 以后新 xlsx / 新叫法改哪
+
+| 你看到的现象 | 改哪里 | 动 HTML / 路由？ |
+|---|---|---|
+| 新表头 / 货列中文名 | `fields.yaml` display_name | 否 |
+| 新申报单位字段 | `caller_params` | 否（页按 schema 画输入框） |
+| 换默认申报单位 | `caller_params.default` | 否 |
+| 复核原因更多 | #20 规则文件 | 否（reviews 原样展示） |
+| PDF | #22 / #23 | 否（同一上传口） |
+
+不要在 `review.html` 里写死 `contrNo` / 境内发货人。

--- a/src/docparse/api/catalog.py
+++ b/src/docparse/api/catalog.py
@@ -1,0 +1,23 @@
+"""给对眼页用的字段目录。名单只来自 fields.yaml。"""
+
+from __future__ import annotations
+
+from docparse.schema.loader import Schema, load_schema
+
+
+def _field(spec) -> dict:
+    return {
+        "name": spec.name,
+        "display_name": spec.display_name,
+        "default": spec.default,
+    }
+
+
+def schema_catalog(schema: Schema | None = None) -> dict:
+    schema = schema or load_schema()
+    return {
+        "goods_array": schema.goods_array,
+        "head": [_field(spec) for spec in schema.head],
+        "caller": [_field(spec) for spec in schema.caller_params],
+        "goods": [_field(spec) for spec in schema.goods if not spec.ignore],
+    }

--- a/src/docparse/api/routes.py
+++ b/src/docparse/api/routes.py
@@ -1,14 +1,19 @@
 from __future__ import annotations
 
 from functools import lru_cache
+from pathlib import Path
 
 from fastapi import APIRouter, Depends, Request
+from fastapi.responses import FileResponse
 
 from docparse.api.caller import RESERVED_FORM_KEYS, collect_caller
+from docparse.api.catalog import schema_catalog
 from docparse.api.errors import bad_request, not_found
 from docparse.api.schemas import JOB_EXAMPLE, multipart_openapi
 from docparse.domain.models import Job
 from docparse.pipeline.runner import Pipeline
+
+_REVIEW_PAGE = Path(__file__).with_name("static") / "review.html"
 
 REQUEST_ID_HEADER = "X-Request-Id"
 
@@ -34,6 +39,17 @@ def _truthy(value: object) -> bool:
 @router.get("/health")
 def health() -> dict[str, str]:
     return {"status": "ok"}
+
+
+@router.get("/")
+@router.get("/review")
+def review_page() -> FileResponse:
+    return FileResponse(_REVIEW_PAGE, media_type="text/html; charset=utf-8")
+
+
+@router.get("/v1/schema")
+def get_schema() -> dict:
+    return schema_catalog()
 
 
 @router.post(

--- a/src/docparse/api/static/review.html
+++ b/src/docparse/api/static/review.html
@@ -1,0 +1,198 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>报关单对眼</title>
+<style>
+  :root {
+    --paper: #e7eeea;
+    --ink: #182226;
+    --muted: #4d5c58;
+    --line: #b6c4be;
+    --card: #f4f8f5;
+    --teal: #0b5f66;
+    --hold: #8a5a12;
+    --hold-soft: #f3e4c8;
+    --pass: #1f6b4a;
+    --pass-soft: #d5eadc;
+    --empty: #8a9692;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    background: var(--paper);
+    color: var(--ink);
+    font: 15px/1.55 "PingFang SC", "Hiragino Sans GB", sans-serif;
+  }
+  .wrap { width: min(1080px, calc(100% - 32px)); margin: 0 auto; padding: 28px 0 64px; }
+  h1 { font-size: 22px; margin: 0 0 8px; }
+  .sub { color: var(--muted); margin: 0 0 20px; }
+  form, .panel {
+    background: var(--card);
+    border: 1px solid var(--line);
+    border-radius: 10px;
+    padding: 16px;
+    margin-bottom: 16px;
+  }
+  .row { display: flex; flex-wrap: wrap; gap: 10px 16px; align-items: end; }
+  label { display: flex; flex-direction: column; gap: 4px; font-size: 12px; color: var(--muted); }
+  input[type="text"], input[type="file"] { min-width: 180px; }
+  button {
+    background: var(--teal);
+    color: #fff;
+    border: 0;
+    border-radius: 6px;
+    padding: 8px 14px;
+    cursor: pointer;
+  }
+  button:disabled { opacity: .6; cursor: wait; }
+  .status { font-weight: 600; }
+  .status.needs_review { color: var(--hold); }
+  .status.succeeded { color: var(--pass); }
+  .status.failed { color: #b42318; }
+  table { width: 100%; border-collapse: collapse; font-size: 13px; }
+  th, td { border-bottom: 1px solid var(--line); padding: 6px 8px; text-align: left; vertical-align: top; }
+  th { width: 28%; color: var(--muted); font-weight: 500; }
+  tr.review { background: var(--hold-soft); }
+  .empty { color: var(--empty); }
+  .ev { color: var(--muted); font-size: 12px; margin-top: 4px; }
+  .err { color: #b42318; }
+  h2 { font-size: 16px; margin: 0 0 10px; }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <h1>报关单对眼</h1>
+  <p class="sub">只看 declaration + reviews，不摊 IR。字段名单来自 YAML。</p>
+  <form id="form">
+    <div class="row" id="fields"></div>
+    <div class="row" style="margin-top:12px">
+      <button type="submit" id="go">上传并组装</button>
+      <span id="hint" class="sub"></span>
+    </div>
+  </form>
+  <div id="out"></div>
+</div>
+<script>
+const $ = (id) => document.getElementById(id);
+let catalog = { head: [], caller: [], goods: [], goods_array: "tdecGoodsitemsVoArr" };
+
+function fieldInput(spec, file) {
+  const label = document.createElement("label");
+  label.textContent = spec.display_name || spec.name;
+  const input = document.createElement("input");
+  input.name = spec.name;
+  if (file) {
+    input.type = "file";
+    input.accept = ".xlsx,.xls,.xlsm";
+    input.required = true;
+  } else {
+    input.type = "text";
+    input.value = spec.default || "";
+  }
+  label.appendChild(input);
+  return label;
+}
+
+function reviewMap(reviews) {
+  const map = {};
+  for (const item of reviews || []) map[item.path] = item;
+  return map;
+}
+
+function evidenceHtml(item) {
+  if (!item || !item.evidence || !item.evidence.length) return "";
+  return item.evidence.map((ev) => {
+    const where = [ev.sheet, ev.cell].filter(Boolean).join("!");
+    const bits = [where, ev.quote].filter(Boolean).join(" · ");
+    return `<div class="ev">${escapeHtml(bits)}</div>`;
+  }).join("");
+}
+
+function escapeHtml(text) {
+  return String(text ?? "").replace(/[&<>"']/g, (ch) => ({
+    "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;"
+  }[ch]));
+}
+
+function cell(value, review) {
+  const empty = value === "" || value == null;
+  const shown = empty ? "（空）" : String(value);
+  const cls = empty ? "empty" : "";
+  const why = review ? `<div class="ev">${escapeHtml((review.reasons || []).join("；"))}</div>${evidenceHtml(review)}` : "";
+  return `<td class="${cls}">${escapeHtml(shown)}${why}</td>`;
+}
+
+function renderHead(declaration, reviews) {
+  const rows = [...catalog.head, ...catalog.caller].map((spec) => {
+    const review = reviews[spec.name];
+    const mark = review ? " class=\"review\"" : "";
+    return `<tr${mark}><th>${escapeHtml(spec.display_name)} <span class="empty">${escapeHtml(spec.name)}</span></th>${cell(declaration[spec.name], review)}</tr>`;
+  }).join("");
+  return `<div class="panel"><h2>表头</h2><table>${rows}</table></div>`;
+}
+
+function renderGoods(declaration, reviews) {
+  const key = catalog.goods_array;
+  const items = declaration[key] || [];
+  if (!items.length) return `<div class="panel"><h2>商品</h2><p class="empty">无货行</p></div>`;
+  const head = catalog.goods.map((spec) => `<th>${escapeHtml(spec.display_name)}</th>`).join("");
+  const body = items.map((item, index) => {
+    const tds = catalog.goods.map((spec) => {
+      const path = `${key}[${index}].${spec.name}`;
+      return cell(item[spec.name], reviews[path]);
+    }).join("");
+    return `<tr>${tds}</tr>`;
+  }).join("");
+  return `<div class="panel"><h2>商品 ${items.length} 行</h2><table><thead><tr>${head}</tr></thead><tbody>${body}</tbody></table></div>`;
+}
+
+function render(job) {
+  const result = job.result || {};
+  const declaration = result.declaration || {};
+  const reviews = reviewMap(result.reviews);
+  const status = job.status || "";
+  $("out").innerHTML = `
+    <div class="panel">
+      <div>状态 <span class="status ${escapeHtml(status)}">${escapeHtml(status)}</span>
+      · 文件 ${escapeHtml(job.source_filename || "")}
+      · job ${escapeHtml(job.id || "")}</div>
+    </div>
+    ${renderHead(declaration, reviews)}
+    ${renderGoods(declaration, reviews)}
+  `;
+}
+
+async function boot() {
+  const spec = await fetch("/v1/schema").then((r) => r.json());
+  catalog = spec;
+  const box = $("fields");
+  box.appendChild(fieldInput({ name: "file", display_name: "xlsx" }, true));
+  for (const item of spec.caller) box.appendChild(fieldInput(item, false));
+}
+
+$("form").addEventListener("submit", async (event) => {
+  event.preventDefault();
+  const btn = $("go");
+  btn.disabled = true;
+  $("hint").textContent = "组装中…";
+  $("out").innerHTML = "";
+  try {
+    const body = new FormData(event.target);
+    const resp = await fetch("/v1/jobs", { method: "POST", body });
+    const job = await resp.json();
+    if (!resp.ok) throw new Error(job.detail || resp.statusText);
+    render(job);
+    $("hint").textContent = "";
+  } catch (err) {
+    $("out").innerHTML = `<p class="err">${escapeHtml(err.message || err)}</p>`;
+  } finally {
+    btn.disabled = false;
+  }
+});
+
+boot().catch((err) => { $("hint").textContent = err.message; });
+</script>
+</body>
+</html>

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -128,3 +128,31 @@ def test_openapi_shows_caller_and_goods_array() -> None:
     assert "tdecGoodsitemsVoArr" in text
     assert "/v1/jobs" in spec["paths"]
     assert "/health" in spec["paths"]
+
+
+def test_schema_catalog_follows_yaml() -> None:
+    body = _client().get("/v1/schema").json()
+    names = {item["name"] for item in body["head"]}
+    assert "contrNo" in names
+    assert "grossWt" in names
+    assert body["goods_array"] == "tdecGoodsitemsVoArr"
+    caller = {item["name"]: item for item in body["caller"]}
+    assert caller["agentCode"]["default"] == "4403180867"
+    assert caller["agentName"]["display_name"]
+    goods = {item["name"] for item in body["goods"]}
+    assert "gname" in goods
+    assert "package" not in body
+
+
+def test_review_page_has_no_ir_and_no_hardcoded_field_list() -> None:
+    page = _client().get("/review")
+    root = _client().get("/")
+    assert page.status_code == 200
+    assert root.status_code == 200
+    html = page.text
+    assert "报关单对眼" in html
+    assert "/v1/schema" in html
+    assert "/v1/jobs" in html
+    assert "package.documents" not in html
+    assert "contrNo" not in html
+    assert "境内发货人" not in html


### PR DESCRIPTION
Closes #44

基线：#21 的 `feat/21-fastapi-declaration`（PR #43 尚未合入 main）。#21 合入后再把本分支 rebase / 改 base 到 main。

## 做了什么

测算法时不再在七万行 IR 里找合同号。同进程一页静态 HTML：

- `GET /review`（`/` 同一页）
- `GET /v1/schema` 吐 `fields.yaml` 的表头 / 申报单位 / 货列（display_name + default）
- 页上上传走现有 `POST /v1/jobs`，只画 `declaration` + `reviews`
- `needs_review` 行标黄，带 sheet / cell / quote
- 空字段显示「（空）」
- HTML 不写死 `contrNo` / 境内发货人；新字段进 YAML 后自动多一行

不改版面、映射、组装、校验引擎。不渲染 `package.documents`。

## 怎么看

```bash
cd ../docparse-44-review-page
source ../docparse/.venv/bin/activate
PYTHONPATH=src uvicorn docparse.api.app:app --host 127.0.0.1 --port 8088
```

打开 http://127.0.0.1:8088/review

## 验收

- 页上能看到合同号、毛重、货表品名（上传恒信夹具 / 本地样本）
- 没填 agent 时是 YAML 默认泰洲
- 缺毛重标复核
- `/health`、`POST /v1/jobs` 不变
- ruff / pytest 通过（78 passed）

## 以后新 xlsx / 新叫法改哪

| 你看到的现象 | 改哪里 | 动 HTML / 路由？ |
|---|---|---|
| 新表头 / 货列中文名 | `fields.yaml` display_name | 否 |
| 新申报单位字段 | `caller_params` | 否 |
| 换默认申报单位 | `caller_params.default` | 否 |
| 复核原因更多 | #20 规则文件 | 否 |
| PDF | #22 / #23 | 否 |

不要在 `review.html` 里写死字段名。