### PR TITLE
feat: 码表字段展示名称，code 不覆盖（#46）

### DIFF
--- a/docs/assemble.md
+++ b/docs/assemble.md
@@ -16,7 +16,7 @@ python -m docparse.cli declare /绝对路径/表.xlsx --agent-code 4403180867 --
   → 只处理 consume ≠ exclude
   → 有 draft：表头以草单为准；商业单据只补空，并核件毛净
   → 无 draft：商业单据能确定的抄；customs_only 空着复核，不编
-  → 名称能转 code 就转；转不出留原文 + needs_review
+  → 名称能转 code：value 留名称，code 进 normalized_value / _meta.codes；转不出留原文 + needs_review
   → agent* 只来自调用参数（CLI / FastAPI 同一条 pipeline）
   → 一张 Declaration / 一份 dec_results 形状 JSON
 ```
@@ -59,7 +59,7 @@ python -m docparse.cli declare /绝对路径/表.xlsx --agent-code 4403180867 --
 | 新单据类型要参与拼单 | `sheet_roles.yaml` 加 role；`assembly.fill` / `role_priority` | 否 |
 | 新辅助表 | `auxiliary` + `consume: exclude` | 否 |
 | 新表头字段 | `fields.yaml` 新字段 + anchors | 否（组装器按目录收） |
-| 新字段要转 code | 字段上写 `code_table`；码表加行 | 否 |
+| 新字段要转 code | 字段上写 `code_table`；码表加行。展示仍是名称 | 否 |
 | 无草单时不要编的海关项 | `assembly.customs_only` | 否 |
 | 要对一下的件毛净 / 单号 | `assembly.reconcile` | 否 |
 | 发票号要进报关单 | #37 先定落点 | 视目录 |

--- a/docs/review.md
+++ b/docs/review.md
@@ -3,20 +3,21 @@
 本地一眼看组装结果，不把 IR 格子摊开。依赖现有 `POST /v1/jobs`，本页不解析。
 
 ```bash
-cd /Users/baldwin/Desktop/taizhou/docparse-44-review-page
+cd /Users/baldwin/Desktop/taizhou/docparse
 source /Users/baldwin/Desktop/taizhou/docparse/.venv/bin/activate
 PYTHONPATH=src uvicorn docparse.api.app:app --host 127.0.0.1 --port 8088
 ```
 
 打开 [http://127.0.0.1:8088/review](http://127.0.0.1:8088/review)（`/` 同一页）。
 
-页先拉 `GET /v1/schema`（`fields.yaml` 的 display_name / default），再上传走 `POST /v1/jobs`。只画 `declaration` + `reviews`。
+页先拉 `GET /v1/schema`（`fields.yaml` 的 display_name / default），再上传走 `POST /v1/jobs`。只画 `declaration` + `reviews`。码表字段主格是名称，旁注 `_meta.codes`。
 
 ## 以后新 xlsx / 新叫法改哪
 
 | 你看到的现象 | 改哪里 | 动 HTML / 路由？ |
 |---|---|---|
 | 新表头 / 货列中文名 | `fields.yaml` display_name | 否 |
+| 码表字段要旁注 code | 字段写 `code_table` | 否 |
 | 新申报单位字段 | `caller_params` | 否（页按 schema 画输入框） |
 | 换默认申报单位 | `caller_params.default` | 否 |
 | 复核原因更多 | #20 规则文件 | 否（reviews 原样展示） |

--- a/src/docparse/api/static/review.html
+++ b/src/docparse/api/static/review.html
@@ -116,24 +116,25 @@ function escapeHtml(text) {
   }[ch]));
 }
 
-function cell(value, review) {
+function cell(value, review, code) {
   const empty = value === "" || value == null;
   const shown = empty ? "（空）" : String(value);
   const cls = empty ? "empty" : "";
+  const note = code ? `<div class="ev">code ${escapeHtml(code)}</div>` : "";
   const why = review ? `<div class="ev">${escapeHtml((review.reasons || []).join("；"))}</div>${evidenceHtml(review)}` : "";
-  return `<td class="${cls}">${escapeHtml(shown)}${why}</td>`;
+  return `<td class="${cls}">${escapeHtml(shown)}${note}${why}</td>`;
 }
 
-function renderHead(declaration, reviews) {
+function renderHead(declaration, reviews, codes) {
   const rows = [...catalog.head, ...catalog.caller].map((spec) => {
     const review = reviews[spec.name];
     const mark = review ? " class=\"review\"" : "";
-    return `<tr${mark}><th>${escapeHtml(spec.display_name)} <span class="empty">${escapeHtml(spec.name)}</span></th>${cell(declaration[spec.name], review)}</tr>`;
+    return `<tr${mark}><th>${escapeHtml(spec.display_name)} <span class="empty">${escapeHtml(spec.name)}</span></th>${cell(declaration[spec.name], review, codes[spec.name])}</tr>`;
   }).join("");
   return `<div class="panel"><h2>表头</h2><table>${rows}</table></div>`;
 }
 
-function renderGoods(declaration, reviews) {
+function renderGoods(declaration, reviews, codes) {
   const key = catalog.goods_array;
   const items = declaration[key] || [];
   if (!items.length) return `<div class="panel"><h2>商品</h2><p class="empty">无货行</p></div>`;
@@ -141,7 +142,7 @@ function renderGoods(declaration, reviews) {
   const body = items.map((item, index) => {
     const tds = catalog.goods.map((spec) => {
       const path = `${key}[${index}].${spec.name}`;
-      return cell(item[spec.name], reviews[path]);
+      return cell(item[spec.name], reviews[path], codes[path]);
     }).join("");
     return `<tr>${tds}</tr>`;
   }).join("");
@@ -152,6 +153,7 @@ function render(job) {
   const result = job.result || {};
   const declaration = result.declaration || {};
   const reviews = reviewMap(result.reviews);
+  const codes = (declaration._meta && declaration._meta.codes) || {};
   const status = job.status || "";
   $("out").innerHTML = `
     <div class="panel">
@@ -159,8 +161,8 @@ function render(job) {
       · 文件 ${escapeHtml(job.source_filename || "")}
       · job ${escapeHtml(job.id || "")}</div>
     </div>
-    ${renderHead(declaration, reviews)}
-    ${renderGoods(declaration, reviews)}
+    ${renderHead(declaration, reviews, codes)}
+    ${renderGoods(declaration, reviews, codes)}
   `;
 }
 

--- a/src/docparse/extraction/assemble.py
+++ b/src/docparse/extraction/assemble.py
@@ -76,6 +76,7 @@ def declaration_payload(declaration: Declaration, schema: Schema | None = None) 
         "head_status": {
             name: field.status.value for name, field in declaration.head.items() if field.value
         },
+        "codes": _code_index(declaration, schema),
     }
     return payload
 
@@ -325,7 +326,7 @@ def _apply_lookup(field: ExtractedField, spec: FieldSpec, codes: CodeTables) -> 
         field.status = FieldStatus.NEEDS_REVIEW
         field.validation_errors = [*field.validation_errors, f"unknown_code:{table}"]
         return
-    field.value = code
+    # 展示留名称；code 只进 normalized_value，不覆盖格子原文。
     field.normalized_value = code
 
 
@@ -425,6 +426,29 @@ def _collect_reasons(
                 detail = ";".join(field.validation_errors) or field.status.value
                 reasons.append(f"goods[{index}].{name}:{detail}")
     return reasons
+
+
+def _code_index(declaration: Declaration, schema: Schema) -> dict[str, str]:
+    """path → code。只收转成功的；展示值仍是名称。"""
+    codes: dict[str, str] = {}
+    for name, field in declaration.head.items():
+        spec = schema.field(name)
+        if spec is None or not spec.code_table:
+            continue
+        code = (field.normalized_value or "").strip()
+        text = (field.value or "").strip()
+        if code and code != text:
+            codes[name] = code
+    for index, item in enumerate(declaration.goods):
+        for name, field in item.fields.items():
+            spec = schema.field(name)
+            if spec is None or not spec.code_table:
+                continue
+            code = (field.normalized_value or "").strip()
+            text = (field.value or "").strip()
+            if code and code != text:
+                codes[f"{schema.goods_array}[{index}].{name}"] = code
+    return codes
 
 
 def _goods_payload(item: GoodsItem, schema: Schema) -> dict:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -153,6 +153,7 @@ def test_review_page_has_no_ir_and_no_hardcoded_field_list() -> None:
     assert "报关单对眼" in html
     assert "/v1/schema" in html
     assert "/v1/jobs" in html
+    assert "_meta.codes" in html
     assert "package.documents" not in html
     assert "contrNo" not in html
     assert "境内发货人" not in html

--- a/tests/test_assemble.py
+++ b/tests/test_assemble.py
@@ -47,9 +47,12 @@ def test_draft_is_copied_and_codes_are_looked_up() -> None:
     assert payload["packNo"] == "40"
     assert payload["grossWt"] == "296.46"
     assert payload["netWt"] == "218.375"
-    assert payload["cusTrafMode"] == "4"
-    assert payload["transMode"] == "3"
-    assert payload["supvModeCdde"] == "0110"
+    assert payload["cusTrafMode"] == "公路运输"
+    assert payload["transMode"] == "FOB"
+    assert payload["supvModeCdde"] == "一般贸易"
+    assert payload["_meta"]["codes"]["cusTrafMode"] == "4"
+    assert payload["_meta"]["codes"]["transMode"] == "3"
+    assert payload["_meta"]["codes"]["supvModeCdde"] == "0110"
     assert payload["cusIEFlag"] == "E"
     assert payload["agentCode"] == "4403180867"
     assert payload["agentName"] == "深圳市泰洲物流有限公司"
@@ -62,10 +65,14 @@ def test_draft_is_copied_and_codes_are_looked_up() -> None:
     goods = payload["tdecGoodsitemsVoArr"][0]
     assert goods["gno"] == "1"
     assert goods["gname"] == "表壳配件/壳体"
-    assert goods["gunit"] == "008"
-    assert goods["cusOriginCountry"] == "CHN"
-    assert goods["destinationCountry"] == "HKG"
-    assert goods["districtCode"] == "44139"
+    assert goods["gunit"] == "只"
+    assert goods["cusOriginCountry"] == "中国"
+    assert goods["destinationCountry"] == "中国香港"
+    assert goods["districtCode"] == "惠州其他"
+    assert payload["_meta"]["codes"]["tdecGoodsitemsVoArr[0].gunit"] == "008"
+    assert payload["_meta"]["codes"]["tdecGoodsitemsVoArr[0].cusOriginCountry"] == "CHN"
+    assert payload["_meta"]["codes"]["tdecGoodsitemsVoArr[0].destinationCountry"] == "HKG"
+    assert payload["_meta"]["codes"]["tdecGoodsitemsVoArr[0].districtCode"] == "44139"
     assert payload["tdecContasVoArr"] == []
     assert payload["_meta"]["source_roles"] == ["draft", "packing"]
     assert "SHOULD-NOT-ASSEMBLE" not in payload.values()
@@ -147,9 +154,9 @@ def test_hengxin_sample_one_declaration() -> None:
     assert payload["contrNo"] == "HDX2026-251"
     assert payload["packNo"] == "40"
     assert payload["grossWt"] == "296.46"
-    assert payload["transMode"] == "3"
-    assert payload["cusTrafMode"] == "4"
-    assert payload["supvModeCdde"] == "0110"
+    assert payload["transMode"] == "FOB"
+    assert payload["cusTrafMode"] == "公路运输"
+    assert payload["supvModeCdde"] == "一般贸易"
     assert len(payload["tdecGoodsitemsVoArr"]) >= 1
     assert payload["tdecGoodsitemsVoArr"][0]["gname"]
 


### PR DESCRIPTION
Closes #46

## 做了什么

有 `code_table` 的字段不再把格子原文覆盖成 code。对眼和 JSON 主值是名称。

- `公路运输` / `FOB` / `一般贸易` / `只` 留在 `cusTrafMode`、`transMode`、`supvModeCdde`、`gunit`
- 转得出的 code 进 `normalized_value` 和 `declaration._meta.codes`
- 转不出（莲塘口岸）仍是原文 + `needs_review`
- 对眼页主格显示名称，旁注 `code 4` / `code 008`
- 不加 `distinatePortCode` 一类双键；合单形状以后再定

不改码表、词表、版面刀。

## 验收

- 恒信夹具：运输方式 / 成交方式 / 监管方式 / 成交单位是中文；`_meta.codes` 里是 `4` / `3` / `0110` / `008`
- 莲塘口岸仍是原文 + 复核
- ruff / pytest 通过（78 passed）

## 以后新 xlsx / 新叫法改哪

| 你看到的现象 | 改哪里 | 动 Python？ |
|---|---|---|
| 新字段要转 code、展示仍是名称 | 字段写 `code_table`；码表加行 | 否 |
| 对眼页要旁注 code | 同上 | 否 |
| 俗称（莲塘口岸）要转得出 | #27 | 否 |
| 合单要 code 当主值 | 另开 Issue，不要改回覆盖 value | 视合单契约 |

不要在组装里 `if 恒信`。不要把名称改回 code 当 `declaration` 主值。