### PR TITLE
feat: 货表默认只取主表，不跨表补空（#48）

### DIFF
--- a/docs/goods-map.md
+++ b/docs/goods-map.md
@@ -16,7 +16,8 @@ Sheet.tables + consume
   → 列名对 fields.yaml goods.anchors（去空白、大小写不敏感；英文按词边界）
   → 每张 sheet 先出带角色的货行
   → 按 goods_master 计分选一张主表
-  → 其它可消费 sheet 只补空；对不上的行标来源收成补充项
+  → merge_supplement 默认 false：其它 sheet 不补货行
+  → 打开关后才补空；对不上的行标来源收成补充项
 ```
 
 `auxiliary` / `unknown` 的 table 留在 IR，本层不读。
@@ -67,7 +68,9 @@ Sheet.tables + consume
 
 ## 跨表补空
 
-对行钥匙按 `goods_master.match_keys` 顺序，默认 `gno` → `codeTs` → `gname` → `gqty`。命中唯一一行就停；同名多行再用数量拆开。合计行（没有项号 / 税号 / 品名）丢掉。
+`goods_master.merge_supplement` 默认 **false**。有草单时箱单 / 发票项次对不齐，不把箱单数量填进草单空列。
+
+打开关后：对行钥匙按 `goods_master.match_keys` 顺序，默认 `gno` → `codeTs` → `gname` → `gqty`。命中唯一一行就停；同名多行再用数量拆开。合计行（没有项号 / 税号 / 品名）丢掉。
 
 - 主表已有列：**不覆盖**
 - 主表空的列：补上，证据带来源 sheet
@@ -86,6 +89,7 @@ Sheet.tables + consume
 | 新单据类型要参与补货 | `sheet_roles.yaml` 加 role，`consume: supplement` | 否 |
 | 新辅助表（料号对照） | `auxiliary` 加信号 | 否 |
 | 主表判定要加信号（备案序号） | `goods_master.signals` | 否 |
+| 要再开跨表补货 | `goods_master.merge_supplement: true`，并先改对行钥匙 | 否 |
 | 对行钥匙要加（合同货号） | `goods_master.match_keys` | 否 |
 | 一列变两字段（新的稳拆） | 新 `goods_map` 值 + 拆分函数 | 是，通用规则，不按公司 |
 | 谁覆盖谁（表头件数 vs 货表加总） | `fields.yaml` `assembly` / [assemble.md](assemble.md) | 否 |

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -66,7 +66,7 @@ sheet 角色（#16）：`schema/sheet_roles.yaml` + `extraction/sheet_role.py`�
 
 表头映射（#17）：`extraction/head_map.py` 吃已拆 `key_values`，按 `fields.yaml` 的 `anchors` / `head_map` 写成 TdecHead 候选。一次一张 sheet，多 sheet 并排放，不覆盖。`agent*` 不从文件填。中文值不转 code。名称+10 位海关代码用 `trailing_code`。运费 / 航次 / 唛码拆分见 #34–#36，发票号槽位见 #37。本地对眼：`python -m docparse.cli head file.xlsx`。见 [head-map.md](head-map.md)。
 
-商品映射（#18）：`extraction/goods_map.py` 吃已拆 `tables`，按 `fields.yaml` 的 `goods.anchors` / `goods_map` / `goods_master` 写成货行。先选主货表，其它可消费 sheet 只补空；对不上的行标来源收成补充项。`auxiliary` / `unknown` 不读。重量未区分当净重，无毛重列再抄一份到毛重。申报要素原文进 `gmodel`，不编 `0|0|...`。箱数不加字段。本地对眼：`python -m docparse.cli goods file.xlsx`。见 [goods-map.md](goods-map.md)。
+商品映射（#18 / #48）：`extraction/goods_map.py` 吃已拆 `tables`，按 `fields.yaml` 的 `goods.anchors` / `goods_map` / `goods_master` 写成货行。先选主货表；`merge_supplement` 默认 false，不跨表补货。打开关后其它可消费 sheet 只补空。`auxiliary` / `unknown` 不读。重量未区分当净重，无毛重列再抄一份到毛重。申报要素原文进 `gmodel`，不编 `0|0|...`。箱数不加字段。本地对眼：`python -m docparse.cli goods file.xlsx`。见 [goods-map.md](goods-map.md)。
 
 整单组装（#19）：`extraction/assemble.py` 按 `fields.yaml` 的 `assembly` 收成一张报关单。有 `draft` 抄草单，商业单据只补空并核件毛净；无草单只抄能确定的商业事实，`customs_only` 空着复核。名称转 code；转不出留原文。`agent*` 只来自调用参数。表头只有净重时视同重量，不抄进毛重。本地对眼：`python -m docparse.cli declare file.xlsx`。见 [assemble.md](assemble.md)。
 

--- a/src/docparse/extraction/goods_map.py
+++ b/src/docparse/extraction/goods_map.py
@@ -38,10 +38,11 @@ def map_document_goods(
     if master_items[0].master_score < schema.goods_master.min_score:
         return []
     merged = [deepcopy(item) for item in master_items]
-    for sheet, items, _ in mapped:
-        if sheet is master_sheet:
-            continue
-        _merge_sheet(merged, items, schema)
+    if schema.goods_master.merge_supplement:
+        for sheet, items, _ in mapped:
+            if sheet is master_sheet:
+                continue
+            _merge_sheet(merged, items, schema)
     for item in merged:
         _copy_net_as_gross(item, schema)
     return merged

--- a/src/docparse/schema/fields.yaml
+++ b/src/docparse/schema/fields.yaml
@@ -8,6 +8,7 @@ goods_array: tdecGoodsitemsVoArr
 # 主货表计分（#18）。看已映射列，不看公司名。draft 加权，auxiliary / unknown 不参与。
 goods_master:
   min_score: 1
+  merge_supplement: false
   match_keys: [gno, codeTs, gname, gqty]
   role_bonus:
     draft: 10

--- a/src/docparse/schema/loader.py
+++ b/src/docparse/schema/loader.py
@@ -67,6 +67,7 @@ class GoodsMaster(BaseModel):
     match_keys: list[str] = Field(default_factory=lambda: ["gno", "codeTs", "gname", "gqty"])
     role_bonus: dict[str, int] = Field(default_factory=dict)
     signals: list[GoodsMasterSignal] = Field(default_factory=list)
+    merge_supplement: bool = False
 
 
 _FILL_MODES = frozenset({"overwrite", "fill", "ignore"})

--- a/tests/test_goods_map.py
+++ b/tests/test_goods_map.py
@@ -12,6 +12,7 @@ from openpyxl.styles import Border, Side
 
 from docparse.adapters.parsers.excel import parse_excel
 from docparse.extraction.goods_map import map_document_goods, map_sheet_goods
+from docparse.schema.loader import load_schema
 
 _DEMO = Path("/Users/baldwin/Desktop/taizhou/AI识别Demo")
 REAL_HENGXIN = _DEMO / "（恒信）一般贸易草单HDX260251BLU.xlsx"
@@ -202,7 +203,7 @@ def test_hengxin_draft_maps_core_goods_columns() -> None:
     assert all(field.evidence for field in items[0].fields.values())
 
 
-def test_packing_fills_missing_gross_and_does_not_overwrite() -> None:
+def test_packing_does_not_fill_when_merge_off() -> None:
     document = parse_excel(
         _workbook({"一般贸易出口": _draft, "装箱单": _packing}),
         file_id="mix",
@@ -212,13 +213,28 @@ def test_packing_fills_missing_gross_and_does_not_overwrite() -> None:
     assert len(items) == 1
     values = _values(items[0])
     assert items[0].source_role == "draft"
-    assert values["gname"] == "表壳配件/壳体"
     assert values["gqty"] == "150"
     assert values["customNetWt"] == "5.74"
+    assert items[0].value_of("customGrossWet") in {None, "5.74"}
+    assert all(
+        not (field.evidence and field.evidence[0].cell.startswith("装箱单!"))
+        for field in items[0].fields.values()
+    )
+
+
+def test_packing_fills_missing_gross_when_merge_on() -> None:
+    document = parse_excel(
+        _workbook({"一般贸易出口": _draft, "装箱单": _packing}),
+        file_id="mix",
+        filename="hengxin.xlsx",
+    )
+    schema = load_schema().model_copy(deep=True)
+    schema.goods_master.merge_supplement = True
+    items = map_document_goods(document, schema)
+    assert len(items) == 1
+    values = _values(items[0])
     assert values["customGrossWet"] == "7.35"
     assert items[0].fields["customGrossWet"].evidence[0].cell.startswith("装箱单!")
-    assert "packQty" not in values
-    assert not any("箱" in (field.value or "") for field in items[0].fields.values())
 
 
 def test_weight_without_gross_copies_net() -> None:
@@ -266,15 +282,13 @@ def test_guoguang_packing_is_master_invoice_fills_price() -> None:
     assert items[0].source_role == "packing"
     assert values["gname"] == "贴纸"
     assert values["codeTs"] == "4821900000"
-    assert values["gmodel"].startswith("0:品牌类型")
     assert values["gqty"] == "100"
-    assert values["gunit"] == "个"
-    assert values["declPrice"] == "0.0181"
-    assert values["declTotal"] == "1.81"
-    assert values["tradeCurr"] == "USD"
-    assert values["customNetWt"] == "0.0013"
-    assert values["customGrossWet"] == "0.5013"
-    assert items[0].fields["declPrice"].evidence[0].cell.startswith("发票!")
+    assert items[0].value_of("declPrice") is None
+    schema = load_schema().model_copy(deep=True)
+    schema.goods_master.merge_supplement = True
+    filled = map_document_goods(document, schema)
+    assert _values(filled[0])["declPrice"] == "0.0181"
+    assert filled[0].fields["declPrice"].evidence[0].cell.startswith("发票!")
 
 
 def test_same_name_rows_match_by_qty() -> None:
@@ -319,7 +333,9 @@ def test_same_name_rows_match_by_qty() -> None:
         file_id="dup",
         filename="dup.xlsx",
     )
-    items = map_document_goods(document)
+    schema = load_schema().model_copy(deep=True)
+    schema.goods_master.merge_supplement = True
+    items = map_document_goods(document, schema)
     caps = [item for item in items if item.value_of("gname") == "电容"]
     assert len(caps) == 2
     by_qty = {item.value_of("gqty"): item.value_of("declPrice") for item in caps}
@@ -342,7 +358,10 @@ def test_unmatched_packing_row_is_supplement() -> None:
         file_id="extra",
         filename="extra.xlsx",
     )
-    items = map_document_goods(document)
+    assert all(item.source_kind == "primary" for item in map_document_goods(document))
+    schema = load_schema().model_copy(deep=True)
+    schema.goods_master.merge_supplement = True
+    items = map_document_goods(document, schema)
     assert len(items) == 2
     extra = next(item for item in items if item.source_kind == "supplement")
     assert extra.value_of("gname") == "配件"
@@ -366,8 +385,10 @@ def test_hengxin_sample_goods() -> None:
     assert values["gname"] == "表壳配件/壳体"
     assert "不锈钢" in (values["gmodel"] or "")
     assert values["customNetWt"] == "5.74"
-    assert values["customGrossWet"] == "7.35"
+    assert all(item.source_kind == "primary" for item in items)
     assert all(item.source_role != "auxiliary" for item in items)
+    if len(items) >= 2:
+        assert items[1].value_of("gqty") != "500"
     assert all(field.evidence for field in first.fields.values())
 
 
@@ -384,6 +405,6 @@ def test_guoguang_sample_goods() -> None:
     assert first.source_role == "packing"
     assert values["gname"] == "贴纸"
     assert values["codeTs"] == "4821900000"
-    assert values["declPrice"] == "0.0181"
-    assert values["tradeCurr"] == "USD"
+    assert first.value_of("declPrice") is None
+    assert all(item.source_kind == "primary" for item in items)
     assert all(field.evidence for field in first.fields.values())


### PR DESCRIPTION
Closes #48

## 做了什么

恒信第 2 项成交单位是千克，数量格空着。跨表按品名对上装箱单，把 `500` 填进 `gqty`。草单和箱单项次对不齐，不该补。

- `goods_master.merge_supplement` 默认 `false`：只取一张主货表
- 有 draft 用草单货表；无 draft 仍按计分选一张（国光用箱单）
- 补空代码还在，YAML 打开关可恢复；打开关时旧测试仍过
- 表头件毛净核对不动

单价 × 数量对不上总价的闸走 [#20](https://github.com/Baldwinzc/docparse/issues/20)，不另起框架。千克行用净重当成交数量交后续，本 PR 不编数量。

## 验收

- 恒信样本第 2 项 `gqty` 不再是 500
- 默认无 `supplement` 货行
- 国光仍能出一张箱单货表（单价不再从发票补）
- ruff / pytest 通过（79 passed）

## 以后新 xlsx / 新叫法改哪

| 你看到的现象 | 改哪里 | 动 Python？ |
|---|---|---|
| 要再开跨表补货 | `goods_master.merge_supplement: true`，并先改对行钥匙 | 否 |
| 对行钥匙要加 | `goods_master.match_keys` | 否 |
| 主表判定要加信号 | `goods_master.signals` | 否 |
| 单价 × 数量对不上 | #20 规则文件 | 否 |

不要按品名默默对箱单。不要 `if 恒信`。