### PR TITLE
feat: 货行没有毛重列则毛重留空（#50）

### DIFF
--- a/docs/goods-map.md
+++ b/docs/goods-map.md
@@ -61,7 +61,7 @@ Sheet.tables + consume
 |---|---|
 | 明确净重 / N.W. / 总净重 | `customNetWt` |
 | 明确毛重 / G.W. / 总毛重 | `customGrossWet` |
-| 未区分的重量 | `customNetWt`；合并后仍无毛重列 → 再抄一份到 `customGrossWet` |
+| 未区分的重量 | `customNetWt`；没有毛重列则 `customGrossWet` 空着 |
 | 法定第一数量 | 才进 `qty1` |
 
 表头整单件毛净交 #19。箱数不加商品字段。

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -66,7 +66,7 @@ sheet 角色（#16）：`schema/sheet_roles.yaml` + `extraction/sheet_role.py`�
 
 表头映射（#17）：`extraction/head_map.py` 吃已拆 `key_values`，按 `fields.yaml` 的 `anchors` / `head_map` 写成 TdecHead 候选。一次一张 sheet，多 sheet 并排放，不覆盖。`agent*` 不从文件填。中文值不转 code。名称+10 位海关代码用 `trailing_code`。运费 / 航次 / 唛码拆分见 #34–#36，发票号槽位见 #37。本地对眼：`python -m docparse.cli head file.xlsx`。见 [head-map.md](head-map.md)。
 
-商品映射（#18 / #48）：`extraction/goods_map.py` 吃已拆 `tables`，按 `fields.yaml` 的 `goods.anchors` / `goods_map` / `goods_master` 写成货行。先选主货表；`merge_supplement` 默认 false，不跨表补货。打开关后其它可消费 sheet 只补空。`auxiliary` / `unknown` 不读。重量未区分当净重，无毛重列再抄一份到毛重。申报要素原文进 `gmodel`，不编 `0|0|...`。箱数不加字段。本地对眼：`python -m docparse.cli goods file.xlsx`。见 [goods-map.md](goods-map.md)。
+商品映射（#18 / #48）：`extraction/goods_map.py` 吃已拆 `tables`，按 `fields.yaml` 的 `goods.anchors` / `goods_map` / `goods_master` 写成货行。先选主货表；`merge_supplement` 默认 false，不跨表补货。打开关后其它可消费 sheet 只补空。`auxiliary` / `unknown` 不读。重量未区分当净重；没有毛重列则毛重空着。申报要素原文进 `gmodel`，不编 `0|0|...`。箱数不加字段。本地对眼：`python -m docparse.cli goods file.xlsx`。见 [goods-map.md](goods-map.md)。
 
 整单组装（#19）：`extraction/assemble.py` 按 `fields.yaml` 的 `assembly` 收成一张报关单。有 `draft` 抄草单，商业单据只补空并核件毛净；无草单只抄能确定的商业事实，`customs_only` 空着复核。名称转 code；转不出留原文。`agent*` 只来自调用参数。表头只有净重时视同重量，不抄进毛重。本地对眼：`python -m docparse.cli declare file.xlsx`。见 [assemble.md](assemble.md)。
 

--- a/src/docparse/extraction/goods_map.py
+++ b/src/docparse/extraction/goods_map.py
@@ -13,8 +13,6 @@ _SPACE = re.compile(r"\s+")
 _LEADING_HS = re.compile(r"^(\d{8,10})")
 _SKIP_CONSUME = frozenset({"exclude"})
 _GOODS_LAYOUTS = frozenset({"table_col"})
-_NET_FIELD = "customNetWt"
-_GROSS_FIELD = "customGrossWet"
 
 
 def map_document_goods(
@@ -43,8 +41,6 @@ def map_document_goods(
             if sheet is master_sheet:
                 continue
             _merge_sheet(merged, items, schema)
-    for item in merged:
-        _copy_net_as_gross(item, schema)
     return merged
 
 
@@ -250,18 +246,6 @@ def _worth_supplement(item: GoodsItem) -> bool:
         return True
     name = item.value_of("gname") or ""
     return bool(name) and not name.isdigit()
-
-
-def _copy_net_as_gross(item: GoodsItem, schema: Schema) -> None:
-    if item.value_of(_GROSS_FIELD) or not item.value_of(_NET_FIELD):
-        return
-    net = item.fields[_NET_FIELD]
-    spec = schema.field(_GROSS_FIELD)
-    copied = deepcopy(net)
-    copied.name = _GROSS_FIELD
-    copied.display_name = spec.display_name if spec else net.display_name
-    item.fields[_GROSS_FIELD] = copied
-    item.review_reasons = [*item.review_reasons, "net_as_gross"]
 
 
 def _row_reasons(fields: dict[str, ExtractedField]) -> list[str]:

--- a/src/docparse/schema/fields.yaml
+++ b/src/docparse/schema/fields.yaml
@@ -922,7 +922,7 @@ goods:
     value_type: number
     sources: [customs_declaration, packing_list]
     anchors: [总毛重, 毛重, "G.W.", "G.W", GW]
-    notes: json 原字段名 Wet。箱单可补充。无毛重列时由净重抄一份，见 #18。
+    notes: json 原字段名 Wet。没有毛重列就空着，不把净重抄过来。
 
   - name: customNetWt
     display_name: 自定义净重
@@ -931,7 +931,7 @@ goods:
     value_type: number
     sources: [customs_declaration, packing_list]
     anchors: [总净重, 净重, 重量KG, 重量, "N.W.", NW]
-    notes: 未区分的「重量 / 重量KG」当净重。不进 qty1。无毛重列再抄到 customGrossWet。
+    notes: 未区分的「重量 / 重量KG」当净重。不进 qty1。不抄进毛重。
 
   - name: exgVersion
     display_name: 加工成品单耗版本号

--- a/tests/test_goods_map.py
+++ b/tests/test_goods_map.py
@@ -215,7 +215,7 @@ def test_packing_does_not_fill_when_merge_off() -> None:
     assert items[0].source_role == "draft"
     assert values["gqty"] == "150"
     assert values["customNetWt"] == "5.74"
-    assert items[0].value_of("customGrossWet") in {None, "5.74"}
+    assert items[0].value_of("customGrossWet") is None
     assert all(
         not (field.evidence and field.evidence[0].cell.startswith("装箱单!"))
         for field in items[0].fields.values()
@@ -237,7 +237,7 @@ def test_packing_fills_missing_gross_when_merge_on() -> None:
     assert items[0].fields["customGrossWet"].evidence[0].cell.startswith("装箱单!")
 
 
-def test_weight_without_gross_copies_net() -> None:
+def test_weight_without_gross_leaves_gross_empty() -> None:
     document = parse_excel(
         _workbook({"一般贸易出口": _draft}),
         file_id="hx",
@@ -246,8 +246,8 @@ def test_weight_without_gross_copies_net() -> None:
     items = map_document_goods(document)
     values = _values(items[0])
     assert values["customNetWt"] == "5.74"
-    assert values["customGrossWet"] == "5.74"
-    assert "net_as_gross" in items[0].review_reasons
+    assert items[0].value_of("customGrossWet") is None
+    assert "net_as_gross" not in items[0].review_reasons
 
 
 def test_auxiliary_is_not_master_or_supplement() -> None:


### PR DESCRIPTION
Closes #50

## 做了什么

和表头同一条：净重 ≠ 毛重。未区分的「重量 / 重量KG」仍只进 `customNetWt`。没有毛重列时 **`customGrossWet` 空着**，不再抄净重。

有单独 G.W. / 毛重列照旧抄那一格。跨表补货开关不动。

## 验收

- 只有「重量KG」的草单：净重有值，毛重空
- 同时有 N.W. / G.W.：各填各的
- 不再打 `net_as_gross`
- ruff / pytest 通过（79 passed）

## 以后新 xlsx / 新叫法改哪

| 你看到的现象 | 改哪里 | 动 Python？ |
|---|---|---|
| 新叫法是净重 | `customNetWt` anchors | 否 |
| 新叫法是毛重 | `customGrossWet` anchors | 否 |
| 未区分的「重量」仍当净重 | 已在 `customNetWt` anchors | 否 |

不要再把净重抄进毛重。