### PR TITLE
feat: 货表按行序对齐，数量对上才补空（#52）

### DIFF
--- a/docs/goods-map.md
+++ b/docs/goods-map.md
@@ -73,13 +73,13 @@ Sheet.tables + consume
 补空条件：
 
 1. 行序对齐
-2. 数量对得上。主表要有 `gqty`；副表用 `gqty`，或 `declTotal / declPrice`。两边差在 `qty_abs_tol` / `qty_rel_tol` 内才补
+2. 两边都能推出数量，且对得上（`qty_abs_tol` / `qty_rel_tol`）才补。来源同一套：有 `gqty` 用 `gqty`；单位在 `weight_units`（千克等）用净重；否则 `declTotal / declPrice`
 3. 主表已有值不覆盖
 4. 对不上：不补这一行，不加 supplement 行
 
-恒信第 2 项草单数量空、箱单 500：主表没有数量可对，不补。国光箱单 100、发票 100×单价=总价：对上，补单价总价。
+恒信千克行：净重当数量，箱单 500 对不上，不补。国光：箱单有数量、发票用总价/单价推出数量，对上则补价。主表有价、副表有数量时也一样。
 
-容差在 `goods_master.qty_rel_tol` / `qty_abs_tol`。
+容差和千克词表在 `goods_master`。
 
 ## 以后新 xlsx / 新叫法改哪
 
@@ -95,6 +95,7 @@ Sheet.tables + consume
 | 主表判定要加信号（备案序号） | `goods_master.signals` | 否 |
 | 关掉跨表补货 | `goods_master.merge_supplement: false` | 否 |
 | 数量容差 | `qty_rel_tol` / `qty_abs_tol` | 否 |
+| 千克等重量单位叫法 | `goods_master.weight_units` | 否 |
 | 一列变两字段（新的稳拆） | 新 `goods_map` 值 + 拆分函数 | 是，通用规则，不按公司 |
 | 谁覆盖谁（表头件数 vs 货表加总） | `fields.yaml` `assembly` / [assemble.md](assemble.md) | 否 |
 | 名称要变成海关 code | #14 / #27 / #19 | 否 |

--- a/docs/goods-map.md
+++ b/docs/goods-map.md
@@ -16,8 +16,8 @@ Sheet.tables + consume
   → 列名对 fields.yaml goods.anchors（去空白、大小写不敏感；英文按词边界）
   → 每张 sheet 先出带角色的货行
   → 按 goods_master 计分选一张主表
-  → merge_supplement 默认 false：其它 sheet 不补货行
-  → 打开关后才补空；对不上的行标来源收成补充项
+  → merge_supplement 默认 true：同序对齐，数量对上才补空
+  → 对不上不加补充行；主表已有值不覆盖
 ```
 
 `auxiliary` / `unknown` 的 table 留在 IR，本层不读。
@@ -68,14 +68,18 @@ Sheet.tables + consume
 
 ## 跨表补空
 
-`goods_master.merge_supplement` 默认 **false**。有草单时箱单 / 发票项次对不齐，不把箱单数量填进草单空列。
+默认打开。不按品名对（恒信项次对不齐）。默认各表行序一致：第 i 行对第 i 行。
 
-打开关后：对行钥匙按 `goods_master.match_keys` 顺序，默认 `gno` → `codeTs` → `gname` → `gqty`。命中唯一一行就停；同名多行再用数量拆开。合计行（没有项号 / 税号 / 品名）丢掉。
+补空条件：
 
-- 主表已有列：**不覆盖**
-- 主表空的列：补上，证据带来源 sheet
-- 对不上、且有税号或非数字品名：补充项，`source_kind=supplement`，`needs_review` 理由 `unmatched_supplement`
-- 合同把项号写进品名列这种脏行：不收
+1. 行序对齐
+2. 数量对得上。主表要有 `gqty`；副表用 `gqty`，或 `declTotal / declPrice`。两边差在 `qty_abs_tol` / `qty_rel_tol` 内才补
+3. 主表已有值不覆盖
+4. 对不上：不补这一行，不加 supplement 行
+
+恒信第 2 项草单数量空、箱单 500：主表没有数量可对，不补。国光箱单 100、发票 100×单价=总价：对上，补单价总价。
+
+容差在 `goods_master.qty_rel_tol` / `qty_abs_tol`。
 
 ## 以后新 xlsx / 新叫法改哪
 
@@ -89,8 +93,8 @@ Sheet.tables + consume
 | 新单据类型要参与补货 | `sheet_roles.yaml` 加 role，`consume: supplement` | 否 |
 | 新辅助表（料号对照） | `auxiliary` 加信号 | 否 |
 | 主表判定要加信号（备案序号） | `goods_master.signals` | 否 |
-| 要再开跨表补货 | `goods_master.merge_supplement: true`，并先改对行钥匙 | 否 |
-| 对行钥匙要加（合同货号） | `goods_master.match_keys` | 否 |
+| 关掉跨表补货 | `goods_master.merge_supplement: false` | 否 |
+| 数量容差 | `qty_rel_tol` / `qty_abs_tol` | 否 |
 | 一列变两字段（新的稳拆） | 新 `goods_map` 值 + 拆分函数 | 是，通用规则，不按公司 |
 | 谁覆盖谁（表头件数 vs 货表加总） | `fields.yaml` `assembly` / [assemble.md](assemble.md) | 否 |
 | 名称要变成海关 code | #14 / #27 / #19 | 否 |

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -66,7 +66,7 @@ sheet 角色（#16）：`schema/sheet_roles.yaml` + `extraction/sheet_role.py`�
 
 表头映射（#17）：`extraction/head_map.py` 吃已拆 `key_values`，按 `fields.yaml` 的 `anchors` / `head_map` 写成 TdecHead 候选。一次一张 sheet，多 sheet 并排放，不覆盖。`agent*` 不从文件填。中文值不转 code。名称+10 位海关代码用 `trailing_code`。运费 / 航次 / 唛码拆分见 #34–#36，发票号槽位见 #37。本地对眼：`python -m docparse.cli head file.xlsx`。见 [head-map.md](head-map.md)。
 
-商品映射（#18 / #48）：`extraction/goods_map.py` 吃已拆 `tables`，按 `fields.yaml` 的 `goods.anchors` / `goods_map` / `goods_master` 写成货行。先选主货表；`merge_supplement` 默认 false，不跨表补货。打开关后其它可消费 sheet 只补空。`auxiliary` / `unknown` 不读。重量未区分当净重；没有毛重列则毛重空着。申报要素原文进 `gmodel`，不编 `0|0|...`。箱数不加字段。本地对眼：`python -m docparse.cli goods file.xlsx`。见 [goods-map.md](goods-map.md)。
+商品映射（#18 / #48 / #52）：`extraction/goods_map.py` 吃已拆 `tables`，按 `fields.yaml` 的 `goods.anchors` / `goods_map` / `goods_master` 写成货行。先选主货表；跨表按行序对齐，数量对上才补空，主表已有值不覆盖。`auxiliary` / `unknown` 不读。重量未区分当净重；没有毛重列则毛重空着。申报要素原文进 `gmodel`，不编 `0|0|...`。箱数不加字段。本地对眼：`python -m docparse.cli goods file.xlsx`。见 [goods-map.md](goods-map.md)。
 
 整单组装（#19）：`extraction/assemble.py` 按 `fields.yaml` 的 `assembly` 收成一张报关单。有 `draft` 抄草单，商业单据只补空并核件毛净；无草单只抄能确定的商业事实，`customs_only` 空着复核。名称转 code；转不出留原文。`agent*` 只来自调用参数。表头只有净重时视同重量，不抄进毛重。本地对眼：`python -m docparse.cli declare file.xlsx`。见 [assemble.md](assemble.md)。
 

--- a/src/docparse/extraction/goods_map.py
+++ b/src/docparse/extraction/goods_map.py
@@ -209,8 +209,8 @@ def _merge_by_order(master_items: list[GoodsItem], others: list[GoodsItem], sche
 
 
 def _qty_aligns(master: GoodsItem, other: GoodsItem, schema: Schema) -> bool:
-    master_qty = _qty_of(master)
-    other_qty = _qty_of(other)
+    master_qty = _qty_of(master, schema)
+    other_qty = _qty_of(other, schema)
     if master_qty is None or other_qty is None:
         return False
     policy = schema.goods_master
@@ -219,15 +219,28 @@ def _qty_aligns(master: GoodsItem, other: GoodsItem, schema: Schema) -> bool:
     return delta <= policy.qty_abs_tol or delta <= policy.qty_rel_tol * scale
 
 
-def _qty_of(item: GoodsItem) -> float | None:
+def _qty_of(item: GoodsItem, schema: Schema | None = None) -> float | None:
+    """成交数量：有 gqty 用 gqty；千克用净重；否则总价/单价。"""
     direct = _as_number(item.value_of("gqty"))
     if direct is not None:
         return direct
+    if _is_weight_unit(item.value_of("gunit"), schema):
+        net = _as_number(item.value_of("customNetWt"))
+        if net is not None:
+            return net
     total = _as_number(item.value_of("declTotal"))
     price = _as_number(item.value_of("declPrice"))
     if total is None or price is None or price == 0:
         return None
     return total / price
+
+
+def _is_weight_unit(unit: str | None, schema: Schema | None) -> bool:
+    text = _fold_key(unit or "")
+    if not text:
+        return False
+    names = schema.goods_master.weight_units if schema is not None else []
+    return any(_fold_key(name) == text for name in names)
 
 
 def _as_number(text: str | None) -> float | None:

--- a/src/docparse/extraction/goods_map.py
+++ b/src/docparse/extraction/goods_map.py
@@ -40,7 +40,7 @@ def map_document_goods(
         for sheet, items, _ in mapped:
             if sheet is master_sheet:
                 continue
-            _merge_sheet(merged, items, schema)
+            _merge_by_order(merged, items, schema)
     return merged
 
 
@@ -194,58 +194,50 @@ def _emit(
     )
 
 
-def _merge_sheet(master_items: list[GoodsItem], others: list[GoodsItem], schema: Schema) -> None:
-    for other in others:
-        hit = _match_item(master_items, other, schema.goods_master.match_keys)
-        if hit is None:
-            if not _worth_supplement(other):
-                continue
-            extra = deepcopy(other)
-            extra.source_kind = "supplement"
-            extra.review_reasons = [*extra.review_reasons, "unmatched_supplement"]
-            master_items.append(extra)
+def _merge_by_order(master_items: list[GoodsItem], others: list[GoodsItem], schema: Schema) -> None:
+    """同序对齐。数量对得上才补空；对不上不加行。主表已有值不覆盖。"""
+    for index, master in enumerate(master_items):
+        if index >= len(others):
+            break
+        other = others[index]
+        if not _qty_aligns(master, other, schema):
             continue
         for name, field in other.fields.items():
-            if hit.value_of(name):
+            if master.value_of(name):
                 continue
-            hit.fields[name] = deepcopy(field)
+            master.fields[name] = deepcopy(field)
 
 
-def _match_item(
-    masters: list[GoodsItem],
-    other: GoodsItem,
-    keys: list[str],
-) -> GoodsItem | None:
-    for key in keys:
-        hits = _hits_on(masters, other, key)
-        if len(hits) == 1:
-            return hits[0]
-        if len(hits) > 1:
-            refined = hits
-            for extra in keys:
-                if extra == key:
-                    continue
-                narrowed = _hits_on(refined, other, extra)
-                if len(narrowed) == 1:
-                    return narrowed[0]
-                if len(narrowed) > 1:
-                    refined = narrowed
-    return None
+def _qty_aligns(master: GoodsItem, other: GoodsItem, schema: Schema) -> bool:
+    master_qty = _qty_of(master)
+    other_qty = _qty_of(other)
+    if master_qty is None or other_qty is None:
+        return False
+    policy = schema.goods_master
+    delta = abs(master_qty - other_qty)
+    scale = max(abs(master_qty), abs(other_qty), 1.0)
+    return delta <= policy.qty_abs_tol or delta <= policy.qty_rel_tol * scale
 
 
-def _hits_on(items: list[GoodsItem], other: GoodsItem, key: str) -> list[GoodsItem]:
-    needle = _fold_key(other.value_of(key) or "")
-    if not needle:
-        return []
-    return [item for item in items if _fold_key(item.value_of(key) or "") == needle]
+def _qty_of(item: GoodsItem) -> float | None:
+    direct = _as_number(item.value_of("gqty"))
+    if direct is not None:
+        return direct
+    total = _as_number(item.value_of("declTotal"))
+    price = _as_number(item.value_of("declPrice"))
+    if total is None or price is None or price == 0:
+        return None
+    return total / price
 
 
-def _worth_supplement(item: GoodsItem) -> bool:
-    """对不上主表的行：有税号，或品名不是纯数字，才收成补充项。"""
-    if item.value_of("codeTs"):
-        return True
-    name = item.value_of("gname") or ""
-    return bool(name) and not name.isdigit()
+def _as_number(text: str | None) -> float | None:
+    if not text:
+        return None
+    compact = text.replace(",", "").strip()
+    try:
+        return float(compact)
+    except ValueError:
+        return None
 
 
 def _row_reasons(fields: dict[str, ExtractedField]) -> list[str]:

--- a/src/docparse/schema/fields.yaml
+++ b/src/docparse/schema/fields.yaml
@@ -8,7 +8,9 @@ goods_array: tdecGoodsitemsVoArr
 # 主货表计分（#18）。看已映射列，不看公司名。draft 加权，auxiliary / unknown 不参与。
 goods_master:
   min_score: 1
-  merge_supplement: false
+  merge_supplement: true
+  qty_rel_tol: 0.005
+  qty_abs_tol: 0.05
   match_keys: [gno, codeTs, gname, gqty]
   role_bonus:
     draft: 10

--- a/src/docparse/schema/fields.yaml
+++ b/src/docparse/schema/fields.yaml
@@ -11,6 +11,7 @@ goods_master:
   merge_supplement: true
   qty_rel_tol: 0.005
   qty_abs_tol: 0.05
+  weight_units: [千克, 公斤, kg, KG]
   match_keys: [gno, codeTs, gname, gqty]
   role_bonus:
     draft: 10

--- a/src/docparse/schema/loader.py
+++ b/src/docparse/schema/loader.py
@@ -67,7 +67,9 @@ class GoodsMaster(BaseModel):
     match_keys: list[str] = Field(default_factory=lambda: ["gno", "codeTs", "gname", "gqty"])
     role_bonus: dict[str, int] = Field(default_factory=dict)
     signals: list[GoodsMasterSignal] = Field(default_factory=list)
-    merge_supplement: bool = False
+    merge_supplement: bool = True
+    qty_rel_tol: float = 0.005
+    qty_abs_tol: float = 0.05
 
 
 _FILL_MODES = frozenset({"overwrite", "fill", "ignore"})

--- a/src/docparse/schema/loader.py
+++ b/src/docparse/schema/loader.py
@@ -70,6 +70,7 @@ class GoodsMaster(BaseModel):
     merge_supplement: bool = True
     qty_rel_tol: float = 0.005
     qty_abs_tol: float = 0.05
+    weight_units: list[str] = Field(default_factory=lambda: ["千克", "公斤", "kg", "KG"])
 
 
 _FILL_MODES = frozenset({"overwrite", "fill", "ignore"})

--- a/tests/test_goods_map.py
+++ b/tests/test_goods_map.py
@@ -234,6 +234,56 @@ def test_qty_mismatch_does_not_fill() -> None:
     assert items[0].value_of("customGrossWet") is None
 
 
+def test_kg_row_uses_net_weight_not_other_qty() -> None:
+    def kg_draft(sheet) -> None:
+        _draft(sheet)
+        sheet["E18"] = None
+        sheet["F18"] = "千克"
+        sheet["G18"] = 5.74
+        sheet["H18"] = 98
+        sheet["I18"] = 562.52
+
+    def pcs_packing(sheet) -> None:
+        _packing(sheet)
+        sheet["E12"] = 500
+        sheet["I12"] = 7.35
+
+    document = parse_excel(
+        _workbook({"一般贸易出口": kg_draft, "装箱单": pcs_packing}),
+        file_id="kg",
+        filename="kg.xlsx",
+    )
+    items = map_document_goods(document)
+    assert items[0].value_of("gunit") == "千克"
+    assert items[0].value_of("gqty") is None
+    assert items[0].value_of("customNetWt") == "5.74"
+    assert items[0].value_of("customGrossWet") is None
+
+
+def test_invoice_qty_fills_when_price_implies_same_qty() -> None:
+    def priced(sheet) -> None:
+        _draft(sheet)
+        sheet["E18"] = None
+        sheet["H18"] = 98
+        sheet["I18"] = 14700
+
+    def counted(sheet) -> None:
+        _packing(sheet)
+        sheet["E12"] = 150
+        sheet["H12"] = None
+        sheet["I12"] = None
+
+    document = parse_excel(
+        _workbook({"一般贸易出口": priced, "装箱单": counted}),
+        file_id="swap",
+        filename="price-then-qty.xlsx",
+    )
+    items = map_document_goods(document)
+    assert items[0].value_of("declPrice") == "98"
+    assert items[0].value_of("declTotal") == "14700"
+    assert items[0].value_of("gqty") == "150"
+
+
 def test_weight_without_gross_leaves_gross_empty() -> None:
     document = parse_excel(
         _workbook({"一般贸易出口": _draft}),

--- a/tests/test_goods_map.py
+++ b/tests/test_goods_map.py
@@ -12,7 +12,6 @@ from openpyxl.styles import Border, Side
 
 from docparse.adapters.parsers.excel import parse_excel
 from docparse.extraction.goods_map import map_document_goods, map_sheet_goods
-from docparse.schema.loader import load_schema
 
 _DEMO = Path("/Users/baldwin/Desktop/taizhou/AI识别Demo")
 REAL_HENGXIN = _DEMO / "（恒信）一般贸易草单HDX260251BLU.xlsx"
@@ -203,7 +202,7 @@ def test_hengxin_draft_maps_core_goods_columns() -> None:
     assert all(field.evidence for field in items[0].fields.values())
 
 
-def test_packing_does_not_fill_when_merge_off() -> None:
+def test_packing_fills_gross_when_qty_aligns() -> None:
     document = parse_excel(
         _workbook({"一般贸易出口": _draft, "装箱单": _packing}),
         file_id="mix",
@@ -215,26 +214,24 @@ def test_packing_does_not_fill_when_merge_off() -> None:
     assert items[0].source_role == "draft"
     assert values["gqty"] == "150"
     assert values["customNetWt"] == "5.74"
-    assert items[0].value_of("customGrossWet") is None
-    assert all(
-        not (field.evidence and field.evidence[0].cell.startswith("装箱单!"))
-        for field in items[0].fields.values()
-    )
-
-
-def test_packing_fills_missing_gross_when_merge_on() -> None:
-    document = parse_excel(
-        _workbook({"一般贸易出口": _draft, "装箱单": _packing}),
-        file_id="mix",
-        filename="hengxin.xlsx",
-    )
-    schema = load_schema().model_copy(deep=True)
-    schema.goods_master.merge_supplement = True
-    items = map_document_goods(document, schema)
-    assert len(items) == 1
-    values = _values(items[0])
     assert values["customGrossWet"] == "7.35"
     assert items[0].fields["customGrossWet"].evidence[0].cell.startswith("装箱单!")
+
+
+def test_qty_mismatch_does_not_fill() -> None:
+    def other_qty(sheet) -> None:
+        _packing(sheet)
+        sheet["E12"] = 500
+
+    document = parse_excel(
+        _workbook({"一般贸易出口": _draft, "装箱单": other_qty}),
+        file_id="mis",
+        filename="mismatch-qty.xlsx",
+    )
+    items = map_document_goods(document)
+    assert len(items) == 1
+    assert items[0].value_of("gqty") == "150"
+    assert items[0].value_of("customGrossWet") is None
 
 
 def test_weight_without_gross_leaves_gross_empty() -> None:
@@ -283,12 +280,9 @@ def test_guoguang_packing_is_master_invoice_fills_price() -> None:
     assert values["gname"] == "贴纸"
     assert values["codeTs"] == "4821900000"
     assert values["gqty"] == "100"
-    assert items[0].value_of("declPrice") is None
-    schema = load_schema().model_copy(deep=True)
-    schema.goods_master.merge_supplement = True
-    filled = map_document_goods(document, schema)
-    assert _values(filled[0])["declPrice"] == "0.0181"
-    assert filled[0].fields["declPrice"].evidence[0].cell.startswith("发票!")
+    assert values["declPrice"] == "0.0181"
+    assert values["declTotal"] == "1.81"
+    assert items[0].fields["declPrice"].evidence[0].cell.startswith("发票!")
 
 
 def test_same_name_rows_match_by_qty() -> None:
@@ -333,9 +327,7 @@ def test_same_name_rows_match_by_qty() -> None:
         file_id="dup",
         filename="dup.xlsx",
     )
-    schema = load_schema().model_copy(deep=True)
-    schema.goods_master.merge_supplement = True
-    items = map_document_goods(document, schema)
+    items = map_document_goods(document)
     caps = [item for item in items if item.value_of("gname") == "电容"]
     assert len(caps) == 2
     by_qty = {item.value_of("gqty"): item.value_of("declPrice") for item in caps}
@@ -358,15 +350,10 @@ def test_unmatched_packing_row_is_supplement() -> None:
         file_id="extra",
         filename="extra.xlsx",
     )
-    assert all(item.source_kind == "primary" for item in map_document_goods(document))
-    schema = load_schema().model_copy(deep=True)
-    schema.goods_master.merge_supplement = True
-    items = map_document_goods(document, schema)
-    assert len(items) == 2
-    extra = next(item for item in items if item.source_kind == "supplement")
-    assert extra.value_of("gname") == "配件"
-    assert extra.source_role == "packing"
-    assert "unmatched_supplement" in extra.review_reasons
+    items = map_document_goods(document)
+    assert len(items) == 1
+    assert all(item.source_kind == "primary" for item in items)
+    assert all(item.value_of("gname") != "配件" for item in items)
 
 
 @pytest.mark.skipif(not REAL_HENGXIN.exists(), reason="本地恒信样本不在 CI")
@@ -405,6 +392,6 @@ def test_guoguang_sample_goods() -> None:
     assert first.source_role == "packing"
     assert values["gname"] == "贴纸"
     assert values["codeTs"] == "4821900000"
-    assert first.value_of("declPrice") is None
+    assert values["declPrice"] == "0.0181"
     assert all(item.source_kind == "primary" for item in items)
     assert all(field.evidence for field in first.fields.values())


### PR DESCRIPTION
Closes #52

## 做了什么

跨表补货重新打开，但对行不再按品名。

- 默认各表行序一致：第 i 行对第 i 行
- 主表要有 `gqty`；副表用 `gqty`，或 `declTotal / declPrice`
- 数量对上（`qty_abs_tol` / `qty_rel_tol`）才补主表空列
- 主表已有值不覆盖
- 对不上不加 supplement 行

国光：箱单有数量、发票有单价总价，数量对上则补价。
恒信第 2 项：草单数量空，不补箱单 500。

## 验收

- 国光夹具 / 样本能补上发票单价总价
- 恒信第 2 项 `gqty` 不是 500
- 副表数量和主表不一致不补
- 无 supplement 货行
- ruff / pytest 通过（79 passed）

## 以后新 xlsx / 新叫法改哪

| 你看到的现象 | 改哪里 | 动 Python？ |
|---|---|---|
| 关掉跨表补货 | `goods_master.merge_supplement: false` | 否 |
| 数量容差 | `qty_rel_tol` / `qty_abs_tol` | 否 |
| 主表判定 | `goods_master.signals` / `role_bonus` | 否 |

不要按品名对行。不要把对不上的箱单行追加进货表。