### PR TITLE
feat: 千克行按净重对齐，毛重过闸即补（#56）

### DIFF
--- a/docs/goods-map.md
+++ b/docs/goods-map.md
@@ -73,13 +73,14 @@ Sheet.tables + consume
 补空条件：
 
 1. 行序对齐
-2. 两边都能推出数量，且对得上（`qty_abs_tol` / `qty_rel_tol`）才补。来源同一套：有 `gqty` 用 `gqty`；单位在 `weight_units`（千克等）用净重；否则 `declTotal / declPrice`
-3. 主表已有值不覆盖
-4. 对不上：不补这一行，不加 supplement 行
+2. 两边都能推出数量，且对得上才补。千克：净重（缺净重退总价/单价，单价是每千克价）。非千克：`gqty`，否则总价/单价。毛重不参与对齐
+3. 主表已有值不覆盖；过闸字段皆可补（含毛重）；`skip_fill` 默认空，个别列不要跨表抄再配
+4. 千克行数量格补值须 ≈ 该行净重（数量列可能混件数，如箱单 Ship Q'ty）
+5. 对不上：不补这一行，不加 supplement 行
 
-恒信千克行：净重当数量，箱单 500 对不上，不补。国光：箱单有数量、发票用总价/单价推出数量，对上则补价。主表有价、副表有数量时也一样。
+恒信第 1 项（只/150）数量对上，补箱单毛重 7.35。第 2 项（千克）净重对净重对得上，补箱单毛重 10.38；箱单数量列是件数 500 ≠ 净重不吃，发票 7.53 = 净重补数量。国光单价总价仍按数量闸补。
 
-容差和千克词表在 `goods_master`。
+容差、千克词表、不抄字段在 `goods_master`。
 
 ## 以后新 xlsx / 新叫法改哪
 
@@ -96,6 +97,8 @@ Sheet.tables + consume
 | 关掉跨表补货 | `goods_master.merge_supplement: false` | 否 |
 | 数量容差 | `qty_rel_tol` / `qty_abs_tol` | 否 |
 | 千克等重量单位叫法 | `goods_master.weight_units` | 否 |
+| 某列不要从副表抄（默认无） | `goods_master.skip_fill` | 否 |
+| 千克行数量补值须≈净重 | 内置规则，容差同 `qty_*` | 否 |
 | 一列变两字段（新的稳拆） | 新 `goods_map` 值 + 拆分函数 | 是，通用规则，不按公司 |
 | 谁覆盖谁（表头件数 vs 货表加总） | `fields.yaml` `assembly` / [assemble.md](assemble.md) | 否 |
 | 名称要变成海关 code | #14 / #27 / #19 | 否 |

--- a/src/docparse/extraction/goods_map.py
+++ b/src/docparse/extraction/goods_map.py
@@ -202,10 +202,24 @@ def _merge_by_order(master_items: list[GoodsItem], others: list[GoodsItem], sche
         other = others[index]
         if not _qty_aligns(master, other, schema):
             continue
+        skip = set(schema.goods_master.skip_fill)
         for name, field in other.fields.items():
-            if master.value_of(name):
+            if name in skip or master.value_of(name):
+                continue
+            if not _fill_allowed(master, name, field, schema):
                 continue
             master.fields[name] = deepcopy(field)
+
+
+def _fill_allowed(master: GoodsItem, name: str, field: ExtractedField, schema: Schema) -> bool:
+    """千克行数量格只收与净重一致的候选值：净重即数量，件数混进数量列会错。"""
+    if name != "gqty" or not _is_weight_unit(master.value_of("gunit"), schema):
+        return True
+    net = _as_number(master.value_of("customNetWt"))
+    candidate = _as_number(field.value)
+    if net is None or candidate is None:
+        return False
+    return _close(net, candidate, schema)
 
 
 def _qty_aligns(master: GoodsItem, other: GoodsItem, schema: Schema) -> bool:
@@ -213,21 +227,30 @@ def _qty_aligns(master: GoodsItem, other: GoodsItem, schema: Schema) -> bool:
     other_qty = _qty_of(other, schema)
     if master_qty is None or other_qty is None:
         return False
+    return _close(master_qty, other_qty, schema)
+
+
+def _close(left: float, right: float, schema: Schema) -> bool:
     policy = schema.goods_master
-    delta = abs(master_qty - other_qty)
-    scale = max(abs(master_qty), abs(other_qty), 1.0)
+    delta = abs(left - right)
+    scale = max(abs(left), abs(right), 1.0)
     return delta <= policy.qty_abs_tol or delta <= policy.qty_rel_tol * scale
 
 
 def _qty_of(item: GoodsItem, schema: Schema | None = None) -> float | None:
-    """成交数量：有 gqty 用 gqty；千克用净重；否则总价/单价。"""
-    direct = _as_number(item.value_of("gqty"))
-    if direct is not None:
-        return direct
+    """千克：净重即数量，缺净重退总价/单价（单价是每千克价）。其它：gqty，否则总价/单价。毛重不参与。"""
     if _is_weight_unit(item.value_of("gunit"), schema):
         net = _as_number(item.value_of("customNetWt"))
         if net is not None:
             return net
+        return _total_over_price(item)
+    direct = _as_number(item.value_of("gqty"))
+    if direct is not None:
+        return direct
+    return _total_over_price(item)
+
+
+def _total_over_price(item: GoodsItem) -> float | None:
     total = _as_number(item.value_of("declTotal"))
     price = _as_number(item.value_of("declPrice"))
     if total is None or price is None or price == 0:

--- a/src/docparse/schema/fields.yaml
+++ b/src/docparse/schema/fields.yaml
@@ -12,6 +12,7 @@ goods_master:
   qty_rel_tol: 0.005
   qty_abs_tol: 0.05
   weight_units: [千克, 公斤, kg, KG]
+  skip_fill: []
   match_keys: [gno, codeTs, gname, gqty]
   role_bonus:
     draft: 10
@@ -835,7 +836,7 @@ goods:
     value_type: number
     sources: [customs_declaration, packing_list, invoice]
     anchors: [出货数量, 成交数量, 数量, Quantity, Q'ty, Qty]
-    notes: 海关商品表优先。别名交 #13。
+    notes: 海关商品表优先。别名交 #13。千克行跨表补数量，候选值须与净重一致（goods_master 容差）。
 
   - name: gunit
     display_name: 成交单位
@@ -925,7 +926,7 @@ goods:
     value_type: number
     sources: [customs_declaration, packing_list]
     anchors: [总毛重, 毛重, "G.W.", "G.W", GW]
-    notes: json 原字段名 Wet。没有毛重列就空着，不把净重抄过来。
+    notes: json 原字段名 Wet。没有毛重列就空着；行对齐后可从副表补（如箱单 G.W.）。不参与数量对齐。
 
   - name: customNetWt
     display_name: 自定义净重

--- a/src/docparse/schema/loader.py
+++ b/src/docparse/schema/loader.py
@@ -71,6 +71,7 @@ class GoodsMaster(BaseModel):
     qty_rel_tol: float = 0.005
     qty_abs_tol: float = 0.05
     weight_units: list[str] = Field(default_factory=lambda: ["千克", "公斤", "kg", "KG"])
+    skip_fill: list[str] = Field(default_factory=list)
 
 
 _FILL_MODES = frozenset({"overwrite", "fill", "ignore"})

--- a/tests/test_goods_map.py
+++ b/tests/test_goods_map.py
@@ -12,6 +12,7 @@ from openpyxl.styles import Border, Side
 
 from docparse.adapters.parsers.excel import parse_excel
 from docparse.extraction.goods_map import map_document_goods, map_sheet_goods
+from docparse.schema.loader import load_schema
 
 _DEMO = Path("/Users/baldwin/Desktop/taizhou/AI识别Demo")
 REAL_HENGXIN = _DEMO / "（恒信）一般贸易草单HDX260251BLU.xlsx"
@@ -224,6 +225,8 @@ def test_ten_digit_customs_code_header_maps_hs() -> None:
     assert items[0].value_of("codeTs") == "4821900000"
     assert items[0].value_of("gname") == "贴纸"
 
+
+def test_packing_fills_gross_when_qty_aligns() -> None:
     document = parse_excel(
         _workbook({"一般贸易出口": _draft, "装箱单": _packing}),
         file_id="mix",
@@ -237,6 +240,19 @@ def test_ten_digit_customs_code_header_maps_hs() -> None:
     assert values["customNetWt"] == "5.74"
     assert values["customGrossWet"] == "7.35"
     assert items[0].fields["customGrossWet"].evidence[0].cell.startswith("装箱单!")
+
+
+def test_skip_fill_knob_blocks_configured_field() -> None:
+    schema = load_schema().model_copy(deep=True)
+    schema.goods_master.skip_fill = ["customGrossWet"]
+    document = parse_excel(
+        _workbook({"一般贸易出口": _draft, "装箱单": _packing}),
+        file_id="skip",
+        filename="skip.xlsx",
+    )
+    items = map_document_goods(document, schema)
+    assert items[0].value_of("gqty") == "150"
+    assert items[0].value_of("customGrossWet") is None
 
 
 def test_qty_mismatch_does_not_fill() -> None:
@@ -279,6 +295,41 @@ def test_kg_row_uses_net_weight_not_other_qty() -> None:
     assert items[0].value_of("gqty") is None
     assert items[0].value_of("customNetWt") == "5.74"
     assert items[0].value_of("customGrossWet") is None
+
+
+def test_kg_row_fills_qty_only_when_close_to_net() -> None:
+    def kg_draft(sheet) -> None:
+        _draft(sheet)
+        sheet["E18"] = None
+        sheet["F18"] = "千克"
+        sheet["G18"] = 5.74
+        sheet["H18"] = 98
+        sheet["I18"] = 562.52
+
+    def kg_packing(sheet) -> None:
+        _packing(sheet)
+        sheet["F11"] = "Unit(单位）"
+        sheet["F12"] = "千克"
+        sheet["E12"] = 500
+
+    def kg_invoice(sheet) -> None:
+        _invoice(sheet)
+        sheet["D17"] = 5.74
+        sheet["F17"] = 98
+        sheet["G17"] = 562.52
+
+    document = parse_excel(
+        _workbook({"一般贸易出口": kg_draft, "装箱单": kg_packing, "发票": kg_invoice}),
+        file_id="kgfill",
+        filename="kgfill.xlsx",
+    )
+    items = map_document_goods(document)
+    item = items[0]
+    assert item.value_of("gunit") == "千克"
+    assert item.value_of("gqty") == "5.74"
+    assert item.fields["gqty"].evidence[0].cell.startswith("发票!")
+    assert item.value_of("customGrossWet") == "7.35"
+    assert item.fields["customGrossWet"].evidence[0].cell.startswith("装箱单!")
 
 
 def test_invoice_qty_fills_when_price_implies_same_qty() -> None:
@@ -446,7 +497,14 @@ def test_hengxin_sample_goods() -> None:
     assert all(item.source_kind == "primary" for item in items)
     assert all(item.source_role != "auxiliary" for item in items)
     if len(items) >= 2:
-        assert items[1].value_of("gqty") != "500"
+        second = items[1]
+        assert second.value_of("gunit") == "千克"
+        assert second.value_of("gqty") != "500"
+        assert second.value_of("gqty") == second.value_of("customNetWt")
+        assert second.fields["gqty"].evidence[0].cell.startswith("发票!")
+        assert second.value_of("customGrossWet") == "10.38"
+        assert second.fields["customGrossWet"].evidence[0].cell.startswith("裝箱單!")
+    assert first.value_of("customGrossWet") == "7.35"
     assert all(field.evidence for field in first.fields.values())
 
 


### PR DESCRIPTION
Closes #56

## 问题

- 千克行（`gunit` ∈ `weight_units`）的成交数量 ≡ 净重，但 `_qty_of` 优先用 `gqty`：草单数量空、箱单数量列是件数（500）、发票才是千克（7.53），优先 gqty 让千克行对不上。
- 毛重不参与成交计算，也不该参与数量对齐；但它是普通字段，行对齐通过后应照常补空（原 issue 把"不参与对齐"误写成"不抄"，正文已更正）。

## 改动

- `_qty_of`：千克行 → 净重，缺净重退 总价÷单价（单价是每千克价）；非千克不变（gqty → 总价÷单价）。毛重从不参与（goods_map.py）
- 新增 `_fill_allowed`：千克行 `gqty` 补空时候选值须 ≈ 该行净重，否则拒绝（防件数混进数量列）
- 容差比较抽成 `_close` 复用
- `goods_master.skip_fill` 默认空（YAML + loader），留作扩展旋钮：某列确实不能跨表抄再配
- docs/goods-map.md 补空条件与例子更新

## 恒信真实样本（已验证）

| 项 | 单位 | gqty | 净重 | 毛重 |
|---|---|---|---|---|
| 1 | 只 | 150（主表） | 5.74（主表） | 7.35（箱单补） |
| 2 | 千克 | 7.53（发票，=净重；不吃箱单 500） | 7.53 | 10.38（箱单补） |
| 3 | 千克 | 1.78（发票） | 1.78 | 4.28（箱单补） |

## 以后新 xlsx / 新叫法改哪

| 你看到的现象 | 改哪里 | 动 Python？ |
|---|---|---|
| 千克等重量单位叫法 | `goods_master.weight_units` | 否 |
| 某列不要从副表抄（默认无） | `goods_master.skip_fill` | 否 |
| 数量容差 | `qty_rel_tol` / `qty_abs_tol` | 否 |
| 新数量列别名 | `gqty` 的 `anchors` | 否 |
| 新的"数量语义"推导规则 | `_qty_of` / `_fill_allowed` | 是，通用规则，不按公司 |

## 验收

- [x] 恒信第 1 项（只 / 150）：数量对上，补箱单毛重 7.35
- [x] 恒信第 2 项（千克）：净重对齐；不吃箱单 500；发票 7.53 = 净重补数量；补箱单毛重 10.38
- [x] 国光：发票单价总价仍能补
- [x] ruff / pytest 通过（84 passed）
- [x] 客户原件不进仓库