### PR TITLE
feat: .xls（BIFF）经 xlrd 读进同一套 IR（#63）

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,9 +20,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest>=8.3", "ruff>=0.8", "openpyxl>=3.1"]
+dev = ["pytest>=8.3", "ruff>=0.8", "openpyxl>=3.1", "xlrd>=2.0"]
 pdf = ["pymupdf>=1.24"]
-excel = ["openpyxl>=3.1"]
+excel = ["openpyxl>=3.1", "xlrd>=2.0"]
 bench = ["pymupdf>=1.24", "pillow>=10.0"]
 
 [project.scripts]

--- a/src/docparse/adapters/parsers/detect.py
+++ b/src/docparse/adapters/parsers/detect.py
@@ -15,11 +15,14 @@ _PDF_EXTS = {".pdf"}
 _EXCEL_EXTS = {".xlsx", ".xls", ".csv"}
 _IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".tif", ".tiff", ".webp", ".bmp"}
 _TEXT_EXTS = {".txt", ".md", ".csv"}
+_OLE2_MAGIC = b"\xd0\xcf\x11\xe0"
 
 
 def detect_kind(filename: str, data: bytes) -> SourceKind:
     name = filename.lower()
     if data.startswith(b"PK") and name.endswith(".xlsx"):
+        return SourceKind.EXCEL
+    if data.startswith(_OLE2_MAGIC) and name.endswith(".xls"):
         return SourceKind.EXCEL
     if data.startswith(b"PK"):
         return SourceKind.ZIP

--- a/src/docparse/adapters/parsers/excel.py
+++ b/src/docparse/adapters/parsers/excel.py
@@ -9,6 +9,8 @@ from docparse.domain.ir import Cell, CellBorder, DocumentIR, Sheet
 from docparse.extraction.sheet_role import classify_sheets
 
 _XLSX = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+_XLS = "application/vnd.ms-excel"
+_OLE2_MAGIC = b"\xd0\xcf\x11\xe0"
 _SHEET_REF = re.compile(
     r"^=(?:'([^']+)'|([^'!]+))!(\$?[A-Z]{1,3}\$?\d+)$",
     re.IGNORECASE,
@@ -22,6 +24,87 @@ _MUL_REF = re.compile(
 def parse_excel(data: bytes, *, file_id: str, filename: str) -> DocumentIR:
     if filename.lower().endswith(".csv"):
         return _parse_csv(data, file_id=file_id, filename=filename)
+    if data.startswith(_OLE2_MAGIC):
+        return _parse_xls(data, file_id=file_id, filename=filename)
+    return _parse_xlsx(data, file_id=file_id, filename=filename)
+
+
+def _parse_xls(data: bytes, *, file_id: str, filename: str) -> DocumentIR:
+    try:
+        import xlrd
+    except ImportError:
+        return DocumentIR(
+            document_id=uuid4().hex,
+            file_id=file_id,
+            filename=filename,
+            media_type=_XLS,
+            warnings=["未安装 xlrd，.xls 仅登记未解析。pip install 'docparse[excel]'"],
+        )
+
+    book = xlrd.open_workbook(file_contents=data, formatting_info=True)
+    parsed = [_read_xls_sheet(book, sheet) for sheet in book.sheets()]
+    return _finish_document(parsed, file_id=file_id, filename=filename, media_type=_XLS)
+
+
+def _read_xls_sheet(book, raw_sheet) -> Sheet:
+    merges = _xls_merge_origins(raw_sheet)
+    covered = _xls_covered_cells(raw_sheet)
+    cells: list[Cell] = []
+    for row_idx in range(raw_sheet.nrows):
+        for col_idx in range(raw_sheet.ncols):
+            address = f"{_col_letter(col_idx + 1)}{row_idx + 1}"
+            if address in covered and address not in merges:
+                continue
+            item = raw_sheet.cell(row_idx, col_idx)
+            display = _xls_value(book, item)
+            if not display and address not in merges:
+                continue
+            cells.append(
+                Cell(
+                    address=address,
+                    value=display,
+                    raw_value=display or None,
+                    row=row_idx + 1,
+                    column=col_idx + 1,
+                    merge_range=merges.get(address),
+                    border=None,
+                )
+            )
+    return Sheet(name=raw_sheet.name, cells=cells)
+
+
+def _xls_value(book, item) -> str:
+    import xlrd
+
+    if item.ctype == xlrd.XL_CELL_ERROR:
+        return ""
+    if item.ctype == xlrd.XL_CELL_DATE:
+        try:
+            return _stringify(xlrd.xldate_as_datetime(item.value, book.datemode))
+        except (ValueError, OverflowError):
+            return _stringify(item.value)
+    return _stringify(item.value)
+
+
+def _xls_merge_origins(sheet) -> dict[str, str]:
+    origins: dict[str, str] = {}
+    for rlo, rhi, clo, chi in sheet.merged_cells:
+        start = f"{_col_letter(clo + 1)}{rlo + 1}"
+        end = f"{_col_letter(chi)}{rhi}"
+        origins[start] = f"{start}:{end}"
+    return origins
+
+
+def _xls_covered_cells(sheet) -> set[str]:
+    covered: set[str] = set()
+    for rlo, rhi, clo, chi in sheet.merged_cells:
+        for row in range(rlo, rhi):
+            for col in range(clo, chi):
+                covered.add(f"{_col_letter(col + 1)}{row + 1}")
+    return covered
+
+
+def _parse_xlsx(data: bytes, *, file_id: str, filename: str) -> DocumentIR:
     try:
         from openpyxl import load_workbook
     except ImportError:
@@ -49,13 +132,22 @@ def parse_excel(data: bytes, *, file_id: str, filename: str) -> DocumentIR:
         pending.extend((sheet.name, cell) for cell in formulas)
 
     _resolve_formulas(grids, pending)
+    return _finish_document(parsed, file_id=file_id, filename=filename, media_type=_XLSX)
 
+
+def _finish_document(
+    parsed: list[Sheet],
+    *,
+    file_id: str,
+    filename: str,
+    media_type: str,
+) -> DocumentIR:
     sheets = [split_sheet(sheet) for sheet in parsed]
     document = DocumentIR(
         document_id=uuid4().hex,
         file_id=file_id,
         filename=filename,
-        media_type=_XLSX,
+        media_type=media_type,
         sheets=sheets,
         raw_text="",
     )

--- a/tests/test_xls_layout.py
+++ b/tests/test_xls_layout.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("xlrd")
+
+from docparse.adapters.parsers.detect import SourceKind, detect_kind
+from docparse.adapters.parsers.excel import parse_excel
+from docparse.adapters.parsers.registry import parse_bytes
+from xls_fixtures import _label, _number, build_xls, draft_xls
+
+_SAMPLES = Path("/Users/baldwin/Desktop/taizhou/补充测试")
+REAL_DONNELLY = _SAMPLES / "202606 R26JU551-Y报关一般.xls"
+REAL_DUOKE = _SAMPLES / "6-17 多科报关资料香港出货 DKTX-2606057 多科通讯乐乐高(1).xls"
+
+
+def _pairs(sheet) -> dict[str, str]:
+    return {item.key: item.value for item in sheet.key_values}
+
+
+def test_ole2_magic_with_xls_suffix_routes_to_excel() -> None:
+    data = draft_xls()
+    assert data.startswith(b"\xd0\xcf\x11\xe0")
+    assert detect_kind("report.xls", data) is SourceKind.EXCEL
+
+
+def test_registry_parses_ole2_xls_without_zip_error() -> None:
+    document = parse_bytes(draft_xls(), file_id="f1", filename="report.xls")
+    assert not document.warnings
+    assert {sheet.name for sheet in document.sheets} == {"报关单一般贸易", "发票"}
+
+
+def test_xls_layout_key_values_and_table() -> None:
+    document = parse_excel(draft_xls(), file_id="f1", filename="report.xls")
+    assert not document.warnings
+    draft = next(sheet for sheet in document.sheets if sheet.name == "报关单一般贸易")
+    pairs = _pairs(draft)
+
+    assert pairs["境内发货人"] == "深圳市多科通讯有限公司"
+    assert pairs["出口口岸"] == "深圳湾"
+    assert pairs["出口日期"] == "2026-06-17 00:00:00"
+    assert pairs["运输方式"] == "公路运输"
+    assert pairs["件数"] == "40"
+
+    merged = next(cell for cell in draft.cells if cell.address == "A3")
+    assert merged.merge_range == "A3:C3"
+    assert all(cell.address != "B3" for cell in draft.cells)
+
+    assert draft.tables
+    table = draft.tables[0]
+    assert table.header_row == 8
+    assert "项号" in table.headers
+    assert "商品编号" in table.headers
+    first = table.rows[0]
+    assert first["项号"] == "1"
+    assert first["商品编号"] == "4821900000"
+    assert first["商品名称及规格型号"] == "标签"
+    assert first["数量"] == "100"
+
+
+def test_xls_date_serial_and_float_shapes() -> None:
+    body = (
+        _label(0, 0, "出口日期")
+        + _number(0, 1, 46190.0, xf=1)
+        + _number(0, 2, 218.375)
+        + _number(0, 3, 1.81)
+    )
+    document = parse_excel(build_xls([("S", body)]), file_id="f1", filename="a.xls")
+    sheet = document.sheets[0]
+    values = {cell.address: cell.value for cell in sheet.cells}
+    assert values["B1"] == "2026-06-17 00:00:00"
+    assert values["C1"] == "218.375"
+    assert values["D1"] == "1.81"
+
+
+def test_xls_missing_xlrd_registers_warning(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setitem(sys.modules, "xlrd", None)
+    document = parse_excel(draft_xls(), file_id="f1", filename="report.xls")
+    assert not document.sheets
+    assert any("xlrd" in warning for warning in document.warnings)
+
+
+@pytest.mark.skipif(not REAL_DONNELLY.exists(), reason="本地当纳利样本不在 CI")
+def test_real_donnelly_xls_layout_reads_in() -> None:
+    document = parse_bytes(
+        REAL_DONNELLY.read_bytes(),
+        file_id="dn",
+        filename=REAL_DONNELLY.name,
+    )
+    assert not document.warnings
+    assert document.sheets
+    assert {sheet.name for sheet in document.sheets} == {
+        "装 箱 单",
+        "报关预录入单",
+        "出口发票",
+        "销售合同",
+    }
+    draft = next(sheet for sheet in document.sheets if sheet.name == "报关预录入单")
+    assert len(draft.cells) > 50
+    assert draft.key_values
+
+
+@pytest.mark.skipif(not REAL_DUOKE.exists(), reason="本地多科样本不在 CI")
+def test_real_duoke_xls_export_date_serial_becomes_datetime() -> None:
+    document = parse_bytes(
+        REAL_DUOKE.read_bytes(),
+        file_id="dk",
+        filename=REAL_DUOKE.name,
+    )
+    assert not document.warnings
+    draft = next(sheet for sheet in document.sheets if sheet.name == "报关单一般贸易")
+    pairs = _pairs(draft)
+    assert pairs["出口日期"] == "2026-06-17 00:00:00"
+    assert pairs["出口口岸"] == "深圳湾"

--- a/tests/xls_fixtures.py
+++ b/tests/xls_fixtures.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import struct
+
+import pytest
+
+pytest.importorskip("xlrd")
+
+_BOF = 0x0809
+_EOF = 0x000A
+_DIMENSIONS = 0x0200
+_BOUNDSHEET = 0x0085
+_DATEMODE = 0x0022
+_XF = 0x00E0
+_LABEL = 0x0204
+_NUMBER = 0x0203
+_MERGECELLS = 0x00E5
+
+_XF_GENERAL = 0
+_XF_DATE = 1
+
+_DRAFT_NAME = "报关单一般贸易"
+
+_EOC = -2
+_FREE = -1
+_FAT = -3
+_SEC_SIZE = 512
+_MIN_STD_STREAM = 4096
+
+
+def _rec(rtype: int, payload: bytes = b"") -> bytes:
+    return struct.pack("<HH", rtype, len(payload)) + payload
+
+
+def _bof(dt: int) -> bytes:
+    return _rec(_BOF, struct.pack("<HHHHII", 0x0600, dt, 1, 1997, 0, 0x0600))
+
+
+def _eof() -> bytes:
+    return _rec(_EOF)
+
+
+def _datemode(system: int = 0) -> bytes:
+    return _rec(_DATEMODE, struct.pack("<H", system))
+
+
+def _xf_record(fmt_key: int) -> bytes:
+    return _rec(_XF, struct.pack("<HHHBBBBIiH", 0, fmt_key, 0xFFF0, 0x20, 0, 0, 0xFC, 0, 0, 0))
+
+
+def _name_bytes(name: str) -> bytes:
+    if any(ord(ch) > 127 for ch in name):
+        return bytes([len(name), 0x01]) + name.encode("utf-16-le")
+    return bytes([len(name), 0x00]) + name.encode("ascii")
+
+
+def _boundsheet(offset: int, name: str) -> bytes:
+    return _rec(_BOUNDSHEET, struct.pack("<IBB", offset, 0, 0) + _name_bytes(name))
+
+
+def _label(row: int, col: int, text: str, xf: int = _XF_GENERAL) -> bytes:
+    if any(ord(ch) > 127 for ch in text):
+        payload = struct.pack("<HB", len(text), 0x01) + text.encode("utf-16-le")
+    else:
+        payload = struct.pack("<HB", len(text), 0x00) + text.encode("ascii")
+    return _rec(_LABEL, struct.pack("<HHH", row, col, xf) + payload)
+
+
+def _number(row: int, col: int, value: float, xf: int = _XF_GENERAL) -> bytes:
+    return _rec(_NUMBER, struct.pack("<HHHd", row, col, xf, value))
+
+
+def _date(row: int, col: int, serial: float) -> bytes:
+    return _number(row, col, serial, xf=_XF_DATE)
+
+
+def _merged(ranges: list[tuple[int, int, int, int]]) -> bytes:
+    payload = struct.pack("<H", len(ranges))
+    for row_first, row_last, col_first, col_last in ranges:
+        payload += struct.pack("<HHHH", row_first, row_last, col_first, col_last)
+    return _rec(_MERGECELLS, payload)
+
+
+def build_xls(sheets: list[tuple[str, bytes]]) -> bytes:
+    """sheets: [(name, body_records)]，body 不含 BOF/DIMENSIONS/EOF。"""
+    bodies = [_bof(0x0010) + _dimensions(body) + body + _eof() for _, body in sheets]
+    globals_head = _bof(0x0005) + _datemode() + _xf_record(0) + _xf_record(14)
+    offset = len(globals_head) + sum(len(_boundsheet(0, name)) for name, _ in sheets)
+    offset += len(_eof())
+    parts = [globals_head]
+    for (name, _), body in zip(sheets, bodies, strict=True):
+        parts.append(_boundsheet(offset, name))
+        offset += len(body)
+    parts.append(_eof())
+    parts.extend(bodies)
+    return _ole2_wrap(b"".join(parts))
+
+
+def _dir_entry(
+    name: str | None,
+    etype: int,
+    first_sid: int,
+    size: int,
+    child: int = -1,
+) -> bytes:
+    entry = bytearray(128)
+    if name:
+        encoded = name.encode("utf-16-le") + b"\x00\x00"
+        entry[0 : len(encoded)] = encoded
+        struct.pack_into("<H", entry, 64, len(encoded))
+    struct.pack_into("<B", entry, 66, etype)
+    struct.pack_into("<B", entry, 67, 1)
+    struct.pack_into("<i", entry, 68, -1)
+    struct.pack_into("<i", entry, 72, -1)
+    struct.pack_into("<i", entry, 76, child)
+    struct.pack_into("<i", entry, 116, first_sid)
+    struct.pack_into("<i", entry, 120, size)
+    return bytes(entry)
+
+
+def _ole2_wrap(stream: bytes) -> bytes:
+    stream += b"\x00" * (-len(stream) % _SEC_SIZE)
+    if len(stream) < _MIN_STD_STREAM:
+        stream += b"\x00" * (_MIN_STD_STREAM - len(stream))
+    n_stream_secs = len(stream) // _SEC_SIZE
+
+    fat = [_FREE] * (_SEC_SIZE // 4)
+    fat[0] = _FAT
+    fat[1] = _EOC
+    for idx in range(n_stream_secs):
+        fat[2 + idx] = _EOC if idx == n_stream_secs - 1 else 3 + idx
+
+    directory = (
+        _dir_entry("Root Entry", 5, _EOC, 0, child=1)
+        + _dir_entry("Workbook", 2, 2, len(stream))
+        + _dir_entry(None, 0, 0, 0)
+        + _dir_entry(None, 0, 0, 0)
+    )
+
+    header = bytearray(_SEC_SIZE)
+    header[0:8] = b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1"
+    struct.pack_into("<HH", header, 24, 0x3E, 3)
+    header[28:30] = b"\xfe\xff"
+    struct.pack_into("<HH", header, 30, 9, 6)
+    struct.pack_into("<i", header, 44, 1)
+    struct.pack_into("<i", header, 48, 1)
+    struct.pack_into("<i", header, 56, _MIN_STD_STREAM)
+    struct.pack_into("<i", header, 60, _EOC)
+    struct.pack_into("<i", header, 64, 0)
+    struct.pack_into("<i", header, 68, _EOC)
+    struct.pack_into("<i", header, 72, 0)
+    struct.pack_into("<109i", header, 76, *([0] + [_FREE] * 108))
+    return bytes(header) + struct.pack("<128i", *fat) + directory + stream
+
+
+def _dimensions(body: bytes) -> bytes:
+    max_row = 0
+    max_col = 0
+    pos = 0
+    while pos + 4 <= len(body):
+        rtype, size = struct.unpack_from("<HH", body, pos)
+        pos += 4
+        if rtype in {_LABEL, _NUMBER} and size >= 6:
+            row, col = struct.unpack_from("<HH", body, pos)
+            max_row = max(max_row, row + 1)
+            max_col = max(max_col, col + 1)
+        pos += size
+    return _rec(_DIMENSIONS, struct.pack("<IIHHH", 0, max_row, 0, max_col, 0))
+
+
+def draft_xls() -> bytes:
+    sheet1 = (
+        _label(0, 0, "中华人民共和国海关出口货物报关单")
+        + _label(2, 0, "境内发货人")
+        + _merged([(2, 2, 0, 2)])
+        + _label(3, 0, "深圳市多科通讯有限公司")
+        + _merged([(3, 3, 0, 2)])
+        + _label(2, 4, "出口口岸")
+        + _label(2, 5, "深圳湾")
+        + _label(2, 8, "出口日期")
+        + _date(2, 9, 46190.0)
+        + _label(4, 4, "运输方式")
+        + _label(5, 4, "公路运输")
+        + _label(6, 3, "件数")
+        + _number(6, 4, 40.0)
+        + _label(7, 0, "项号")
+        + _label(7, 1, "商品编号")
+        + _label(7, 2, "商品名称及规格型号")
+        + _label(7, 3, "数量")
+        + _label(7, 4, "币制")
+        + _number(8, 0, 1.0)
+        + _label(8, 1, "4821900000")
+        + _label(8, 2, "标签")
+        + _number(8, 3, 100.0)
+        + _label(8, 4, "美元")
+    )
+    sheet2 = (
+        _label(0, 0, "INVOICE")
+        + _label(1, 0, "发票号码:")
+        + _label(1, 1, "DKTX-2606057")
+        + _number(2, 0, 1.81)
+    )
+    return build_xls([(_DRAFT_NAME, sheet1), ("发票", sheet2)])


### PR DESCRIPTION
Closes #63

## 问题

补充测试里两份真机 `.xls`（当纳利 `202606 R26JU551-Y报关一般.xls`、多科 `6-17 多科报关资料香港出货 DKTX-2606057 多科通讯乐乐高(1).xls`）直接报 `BadZipFile`：`detect_kind` 把 `.xls` 路由到 EXCEL 后 `parse_excel` 无条件走 openpyxl，而 openpyxl 只认 zip 容器，OLE2（magic `D0 CF 11 E0`）直接炸，整份文件一个字段都出不来。另外 .xls 的日期以序列号存（多科出口日期 `46190.0`），不转会输出 `46190`。

## 改动

- `adapters/parsers/detect.py`：OLE2 magic + `.xls` 后缀 → EXCEL，与 zip 容器区分。
- `adapters/parsers/excel.py`：按**数据内容**分流——`parse_excel` 开头是 OLE2 magic 走 `_parse_xls`（xlrd），否则走 `_parse_xlsx`（openpyxl，行为不变）。两个容器汇入同一条收尾链路（split_sheet / classify_sheets / raw_text），后续 #64–#68 的版面刀/角色/映射改动对两种容器同时生效。
  - `XL_CELL_DATE` → `xldate_as_datetime` → 现有 `_stringify`；数字沿用 `.10g`。
  - EMPTY/BLANK 不进 IR；ERROR（#DIV/0! 等）同样不进（错误码无抽取价值）。
  - `merged_cells` 映射成现有 `merge_range`，只留左上源格；xlrd 需 `formatting_info=True` 才有合并格。
  - border 置 None（不取边框；已验证版面刀全链路不依赖 border）。
  - xlrd 未安装时与 openpyxl 同策略：登记 warning，不炸。
- `pyproject.toml`：`excel` extra 与 `dev` extra 均加 `xlrd>=2.0`（CI 装 `.[dev]`）。

## 验收

- 两份真机 .xls `python -m docparse.cli layout` 不再 BadZipFile：当纳利 4 sheets（报关预录入单 240 格 / 18 KV / 2 表）；多科 7 sheets（报关单一般贸易 role=draft）。
- 多科「出口日期 46190.0」→ `2026-06-17 00:00:00`。
- 测试 93 passed（86 旧全绿 + 7 新）；ruff 通过。新增 `tests/xls_fixtures.py` 纯 Python 手造 BIFF 记录 + OLE2 复合文档容器（FAT / 目录 / Workbook 流），零新依赖、不含客户原件；真机断言走 skipif 本地样本。

## 以后新 xlsx / 新叫法改哪

| 场景 | 改哪 | 动 Python 吗 |
|---|---|---|
| 新的二进制表格容器（.xlsm / .et） | `detect.py` magic/后缀 + `excel.py` 分流加分支 | 是（新分支） |
| .xls 特殊值形状（文本格式数字等） | `excel.py` 的 `_xls_value` 取值函数 | 是 |
| .xls 读不出的合并格 / 边框信息 | 不在仓库侧改，属 xlrd 能力边界，先登记 warning 观察 | 否 |