### PR TITLE
feat: 版面刀泛化：右向跳空取值、伪表头防线、占位值归零（#64）

### DIFF
--- a/src/docparse/adapters/parsers/layout.py
+++ b/src/docparse/adapters/parsers/layout.py
@@ -22,6 +22,15 @@ _DATE_ONLY = re.compile(r"^\d{4}[-/]\d{1,2}[-/]\d{1,2}$")
 _DATETIME_LEFT = re.compile(r"^\d{4}[-/]\d{1,2}[-/]\d{1,2}(?:[ T]\d{1,2})?$")
 _TIME_FULL = re.compile(r"^\d{1,2}:\d{2}(?::\d{2}(?:\.\d+)?)?$")
 _NUMERIC = re.compile(r"^[\d.,]+$")
+# 占位格：(  ) / （　） 视同空。占位后跟提示文字（「(  )跨境的才需要申报」）
+# 也整体视同空——那是模板提示，不是填了的值。
+_PLACEHOLDER = re.compile(r"^[\(（]\s*[\)）]")
+# 右向跳空取值：标签与值之间允许的空列上限（#64）。间距更大改这里。
+_RIGHT_SKIP_MAX = 2
+
+
+def _is_placeholder(text: str) -> bool:
+    return _PLACEHOLDER.match(text.strip()) is not None
 
 
 def split_sheet(sheet: Sheet) -> Sheet:
@@ -63,7 +72,7 @@ def _detect_tables(cells: list[Cell]) -> list[Table]:
             used_rows.add(body_row)
             values_by_col = {c.column: c.value for c in by_row[body_row]}
             record = {
-                header: values_by_col.get(col, "")
+                header: _blank_if_placeholder(values_by_col.get(col, ""))
                 for header, col in zip(headers, columns, strict=True)
             }
             if not any(record.values()):
@@ -119,7 +128,9 @@ def _all_kv_keys() -> frozenset[str]:
 
 
 def _norm_label(text: str) -> str:
-    cleaned = re.sub(r"\s+", " ", _label_text(text))
+    # 词形归一去掉全部空白（#64）：标签里的换行/空格（「毛重\n（公斤）」「毛    重」）
+    # 不该挡住词表匹配。锚点侧的全面归一（空白/尾码/繁体）在 #66。
+    cleaned = re.sub(r"\s+", "", _label_text(text))
     return cleaned.casefold()
 
 
@@ -150,15 +161,26 @@ def _ends_with_colon(text: str) -> bool:
     return bool(stripped) and stripped[-1] in _COLON_CHARS
 
 
+def _blank_if_placeholder(text: str) -> str:
+    return "" if _is_placeholder(text) else text
+
+
 def _is_box_label_row(row_cells: list[Cell]) -> bool:
-    """框表标签横排（包装种类/件数/毛重…）不当表头。只看 BOX，不看 KV。"""
+    """框表标签横排（包装种类/件数/毛重…）不当表头。只看 BOX，不看 KV。
+
+    占位格视同空（#64）：不占「整行 BOX」的名额，也不破坏判定。
+    """
     labels = _box_labels()
     hits = 0
+    present = 0
     for cell in row_cells:
         cleaned = _label_text(cell.value)
+        if _is_placeholder(cleaned):
+            continue
+        present += 1
         if cleaned in labels:
             hits += 1
-    return hits >= 3 and hits == len(row_cells)
+    return hits >= 3 and hits == present
 
 
 def _is_header_row(row_cells: list[Cell]) -> bool:
@@ -170,6 +192,10 @@ def _is_header_row(row_cells: list[Cell]) -> bool:
     hits = 0
     for cell in row_cells:
         text = cell.value
+        # 真实表头行全是文本（#64）：混进纯数值 / 日期 / 占位格的是数据行，
+        # 长套话格凑 token 不算表头。
+        if _looks_like_data_cell(text) or _is_placeholder(text):
+            return False
         if any(_token_in_text(token, text) for token in tokens):
             hits += 1
     return hits >= 2
@@ -246,7 +272,7 @@ def _detect_key_values(cells: list[Cell], occupied: set[str]) -> list[KeyValue]:
         found.append(item)
 
     for cell in cells:
-        if cell.address in occupied or not cell.value:
+        if cell.address in occupied or not cell.value or _is_placeholder(cell.value):
             continue
         candidates = [
             item
@@ -317,6 +343,8 @@ def _same_cell_colon(cell: Cell) -> KeyValue | None:
     if not split:
         return None
     key, value = split
+    if _is_placeholder(value):
+        return None
     if _DATETIME_LEFT.match(key) or _TIME_FULL.match(key):
         return None
     if any(_token_in_text(token, key) for token in _table_tokens()):
@@ -374,6 +402,8 @@ def _value_below(
     other = by_pos.get((below_row, cell.column))
     if other is None or other.address in occupied or not other.value:
         return None
+    if _is_placeholder(other.value):
+        return None
     if _same_cell_colon(other) is not None or _looks_like_label(other.value):
         return None
     key = _key_text(cell.value)
@@ -384,6 +414,24 @@ def _value_below(
         value_cell=other.address,
         strategy="below",
     )
+
+
+def _scan_right(
+    cell: Cell,
+    by_pos: dict[tuple[int, int], Cell],
+) -> Cell | None:
+    """右向找值：跳过 ≤_RIGHT_SKIP_MAX 个空列 / 占位格，取第一个非空格。"""
+    row = cell.row
+    col = (_merge_right(cell) or 0) + 1
+    blanks = 0
+    while blanks <= _RIGHT_SKIP_MAX:
+        other = by_pos.get((row, col))
+        if other is None or not other.value.strip() or _is_placeholder(other.value):
+            blanks += 1
+            col += 1
+            continue
+        return other
+    return None
 
 
 def _value_right(
@@ -397,9 +445,8 @@ def _value_right(
     key = _key_text(text)
     if not (_ends_with_colon(text) or _is_known_key(key)):
         return None
-    right_col = _merge_right(cell) + 1
-    other = by_pos.get((cell.row, right_col))
-    if other is None or other.address in occupied or not other.value:
+    other = _scan_right(cell, by_pos)
+    if other is None or other.address in occupied:
         return None
     if _same_cell_colon(other) is not None or _looks_like_label(other.value):
         return None

--- a/src/docparse/schema/layout_vocab.yaml
+++ b/src/docparse/schema/layout_vocab.yaml
@@ -1,13 +1,15 @@
 # 版面词表（Issue #13 / #15）
-# BOX：去冒号后整词相等；整行都是 BOX 才不当表头。
+# BOX：去冒号后整词相等；整行都是 BOX 才不当表头（占位格视同空，#64）。
 # KV：商业单据键，匹配同 BOX，但不参与「整行 BOX 不当表头」。
-# TABLE：子串匹配（英文大小写不敏感），一行 ≥2 命中才当表头。
+# TABLE：子串匹配（英文大小写不敏感），一行 ≥2 命中才当表头；
+# 行内混纯数值 / 日期 / 占位格的不当表头（#64）。
 # 抽出的 key / 列名仍是格子原文，不在这里映射到 fields.yaml。
 # 客户原件不进仓库；source 只引用样本路径，方便对照。
 # G.W. / N.W. 不进 BOX / KV（样本里只当列名）。
-# TABLE 不加「单位」（防误伤「生产销售单位」）。
+# TABLE 不加「单位」（防误伤「生产销售单位」。
 # 值域（#29）挂在会撞车的 id 上：date | datetime | number | text | pattern。
 # 无 value: = 不过滤。公司名 / 地址 / 成交方式不要写。新形状改 YAML，新格子关系另开刀。
+# 版面刀的跳空上限 / 占位符正则在 layout.py 常量里（#64）。
 
 version: 1
 
@@ -18,9 +20,12 @@ box:
         source: 恒信草单 一般贸易出口!A2（格内带冒号）
 
   - id: entry_id
+    value:
+      type: pattern
+      pattern: '^[A-Za-z0-9][A-Za-z0-9\-/]{5,}$'
     aliases:
       - text: 海关编号
-        source: 恒信草单 一般贸易出口!D2（格内带冒号）
+        source: 恒信草单 一般贸易出口!D2（格内带冒号）。值域挡跳空取来的「（深惠州关）」章戳（#64）
 
   - id: trade_party
     aliases:
@@ -30,8 +35,32 @@ box:
         source: "#12 表头对照 进出口镜像；本张恒信出口草单无独立格"
       - text: 境内收发货人
         source: "#12 fields.yaml anchors；本张恒信出口草单无独立格"
+      - text: 经营单位
+        source: GSC出仓!A3 旧叫法＝境内收发货人。词表键化后挡住「出口口岸=经营单位」错配（#64）
+      - text: 收货单位
+        source: GSC出仓!A4 旧叫法＝境内收货人；当纳利装箱单 A4「收货单位：」同源（#64）
+
+  - id: declare_unit
+    aliases:
+      - text: 报关单位
+        source: GSC出仓!A5 报关单位（代理方，agent* 不解析）。只为挡住错配 KV，fields.yaml 不挂锚点（#64）
+
+  - id: settle_mode
+    aliases:
+      - text: 结汇方式
+        source: GSC出仓!I4。只为挡住跳空取值带来的「征免性质=结汇方式」错配，fields.yaml 不挂锚点（#64）
+
+  - id: container_no
+    aliases:
+      - text: 集装箱号
+        source: GSC出仓!R3、多科报关单!A12。挡住「合同协议号=集装箱号」类 below 错配（#64）
+      - text: 集装箱规格
+        source: GSC出仓!S3。挡住「集装箱号=集装箱规格」类 right 错配（#64）
 
   - id: ie_port
+    value:
+      type: pattern
+      pattern: '^(?:\d{4}|[\u4e00-\u9fa5]{2,10})$'
     aliases:
       - text: 出境关别
         source: 恒信草单 一般贸易出口!E3
@@ -59,9 +88,12 @@ box:
         source: 恒信草单 一般贸易出口!J3
 
   - id: manual_no
+    value:
+      type: pattern
+      pattern: '^[A-Za-z0-9][A-Za-z0-9\-/]{5,}$'
     aliases:
       - text: 备案号
-        source: 恒信草单 一般贸易出口!N3
+        source: 恒信草单 一般贸易出口!N3。值域挡「备案号=运输工具」类标签错配（#64）
 
   - id: overseas_party
     aliases:
@@ -83,9 +115,12 @@ box:
         source: 恒信草单 一般贸易出口!G5
 
   - id: bill_no
+    value:
+      type: pattern
+      pattern: '^[A-Za-z0-9][A-Za-z0-9\-/&.]*$'
     aliases:
       - text: 提运单号
-        source: 恒信草单 一般贸易出口!N5
+        source: 恒信草单 一般贸易出口!N5。值域要字母/数字开头（#64）
 
   - id: owner
     aliases:
@@ -107,9 +142,12 @@ box:
         source: 恒信草单 一般贸易出口!I7
 
   - id: license_no
+    value:
+      type: pattern
+      pattern: '^[A-Za-z0-9][A-Za-z0-9\-/]{2,}$'
     aliases:
       - text: 许可证号
-        source: 恒信草单 一般贸易出口!N7
+        source: 恒信草单 一般贸易出口!N7。值域挡「许可证号=批准文号」标签错配（GSC/多科，#64）
 
   - id: contr_no
     aliases:
@@ -124,6 +162,8 @@ box:
         source: 恒信草单 一般贸易出口!E9
       - text: 贸易国(地区)
         source: "#12 anchors；半角括号变体"
+      - text: 贸易国
+        source: GSC出仓!M9 短写（#64）
 
   - id: trade_country
     aliases:
@@ -133,6 +173,8 @@ box:
         source: "#12 anchors；半角括号变体"
       - text: 启运国（地区）
         source: "#12 表头对照 运抵国/启运国；本张出口无独立格"
+      - text: 运抵国
+        source: GSC出仓!D6 短写；fields.yaml 已有同名 anchor（#64）
 
   - id: dest_port
     aliases:
@@ -152,6 +194,8 @@ box:
     aliases:
       - text: 包装种类
         source: 恒信草单 一般贸易出口!A11
+      - text: 包装类型
+        source: GSRUA26601!A11 同字异写（#64）
 
   - id: pack_no
     value:
@@ -170,6 +214,10 @@ box:
         source: "#12 grossWt anchors；半角括号变体"
       - text: 毛重
         source: "#12 别名交 #13；中文简称。G.W. 不进 BOX"
+      - text: 毛重（公斤）
+        source: 多科报关单!I11「毛重\n（公斤）」。词表匹配已去空白（#64）
+      - text: 毛重(公斤)
+        source: 半角括号变体（#64）
 
   - id: net_wt
     value:
@@ -181,6 +229,10 @@ box:
         source: "#12 netWt anchors；半角括号变体"
       - text: 净重
         source: "#12 别名交 #13；中文简称。N.W. 不进 BOX"
+      - text: 净重（公斤）
+        source: 多科报关单!K11「净重\n（公斤）」（#64）
+      - text: 净重(公斤)
+        source: 半角括号变体（#64）
 
   - id: trans_mode
     aliases:
@@ -210,6 +262,8 @@ box:
         source: 恒信草单 一般贸易出口!A13
       - text: 随附单证
         source: "#12 attachedDocs anchors；短写"
+      - text: 随附单据
+        source: 多科报关单!C12 同义异写；挡住跳空取值错配（#64）
 
   - id: marks
     aliases:

--- a/tests/test_excel_layout.py
+++ b/tests/test_excel_layout.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import io
+import re
 from datetime import datetime
 from pathlib import Path
 
@@ -425,3 +426,233 @@ def test_unlike_values_drop_the_key() -> None:
     document = parse_excel(_value_shape_workbook(), file_id="v1", filename="shape.xlsx")
     sheet = document.sheets[0]
     assert "Invoice No." not in _pairs(sheet)
+
+
+_SAMPLES = Path("/Users/baldwin/Desktop/taizhou/补充测试")
+REAL_GSC = _SAMPLES / "GSC出仓QPGSCO260617006A.xlsx"
+REAL_GSRUA = _SAMPLES / "GSRUA26601CLLG01(1).xlsx"
+
+_PLACEHOLDER_VALUE = re.compile(r"^[\(（]\s*[\)）]")
+
+
+def _flat_gap_workbook() -> bytes:
+    """GSC 平表：标签与值隔空列、below 是下一行的标签。"""
+    book = Workbook()
+    sheet = book.active
+    sheet.title = "出境备案清单"
+
+    sheet["A2"] = "出口口岸"
+    sheet["C2"] = "5304"
+    sheet["A3"] = "经营单位"
+    sheet["C3"] = "440356K004"
+    sheet["F2"] = "备案号"
+    sheet["G2"] = "T5339W000208"
+    sheet["F3"] = "运输工具"
+    sheet["A6"] = "许可证号"
+    sheet["A7"] = "批准文号"
+
+    buffer = io.BytesIO()
+    book.save(buffer)
+    return buffer.getvalue()
+
+
+def test_right_skips_blank_columns_and_rejects_label_below() -> None:
+    document = parse_excel(_flat_gap_workbook(), file_id="g1", filename="flat.xlsx")
+    sheet = document.sheets[0]
+    pairs = _pairs(sheet)
+    assert pairs["出口口岸"] == "5304"
+    assert pairs["备案号"] == "T5339W000208"
+    assert pairs["经营单位"] == "440356K004"
+    values = {item.value for item in sheet.key_values}
+    assert "经营单位" not in values
+    assert "运输工具" not in values
+    assert "批准文号" not in values
+    assert "许可证号" not in pairs
+
+
+def _fake_header_workbook() -> bytes:
+    """GSC R6/R8：长套话凑 token 的数据行不当表头。"""
+    book = Workbook()
+    sheet = book.active
+    sheet.title = "出境备案清单"
+
+    sheet["D6"] = "运抵国"
+    sheet["E6"] = "中国台湾"
+    sheet["F6"] = "指运港"
+    sheet["G6"] = "中国台湾"
+    sheet["I6"] = "境内货源地"
+    sheet["J6"] = "44036"
+    sheet["T6"] = "关联收发货单位海关编码"
+
+    sheet["D7"] = "成交方式"
+    sheet["E7"] = "FOB"
+    sheet["D8"] = "件数"
+    sheet["E8"] = "230.000000"
+    sheet["F8"] = "包装种类"
+    sheet["G8"] = "纸制或纤维板制盒/箱"
+    sheet["I8"] = "毛重"
+    sheet["J8"] = "1560"
+    sheet["K8"] = "净重"
+    sheet["L8"] = "785.02760"
+
+    headers = ["项号", "海关编码", "商品名称", "规格型号", "数量"]
+    for col, header in enumerate(headers, start=1):
+        sheet.cell(11, col, header)
+    sheet["A12"] = "1"
+    sheet["B12"] = "9503002900"
+    sheet["C12"] = "塑胶动漫造形"
+    sheet["D12"] = "MAX FACTORY 品牌"
+    sheet["E12"] = "96"
+
+    buffer = io.BytesIO()
+    book.save(buffer)
+    return buffer.getvalue()
+
+
+def test_data_rows_with_numbers_are_not_fake_headers() -> None:
+    document = parse_excel(_fake_header_workbook(), file_id="g2", filename="fake.xlsx")
+    sheet = document.sheets[0]
+    header_rows = {table.header_row for table in sheet.tables}
+    assert 6 not in header_rows
+    assert 8 not in header_rows
+
+    pairs = _pairs(sheet)
+    assert pairs["运抵国"] == "中国台湾"
+    assert pairs["指运港"] == "中国台湾"
+    assert pairs["成交方式"] == "FOB"
+    assert float(pairs["件数"]) == 230
+    assert pairs["包装种类"] == "纸制或纤维板制盒/箱"
+    assert float(pairs["毛重"]) == 1560
+    assert float(pairs["净重"]) == 785.0276
+
+    goods = next(table for table in sheet.tables if table.header_row == 11)
+    assert goods.rows[0]["海关编码"] == "9503002900"
+
+
+def _placeholder_workbook() -> bytes:
+    """GSRUA：占位格 (  ) 不当值、不当表头，框表标签行带占位格仍成立。"""
+    book = Workbook()
+    sheet = book.active
+    sheet.title = "报关单"
+
+    sheet["A2"] = "预录入编号："
+    sheet["G2"] = "申报口岸:"
+    sheet["G3"] = "(    )"
+    sheet["F3"] = "出境关别"
+    sheet["H3"] = "出口日期"
+    sheet["F7"] = "监管方式"
+    sheet["G7"] = "(    )"
+    sheet["H7"] = "征免性质"
+    sheet["I7"] = "(    )"
+
+    sheet["A11"] = "包装类型"
+    sheet["C11"] = "(    )"
+    sheet["F11"] = "件数"
+    sheet["G11"] = "毛重（千克）"
+    sheet["H11"] = "净重（千克）"
+    sheet["J11"] = "成交方式"
+    sheet["K11"] = "(  )"
+    sheet["L11"] = "运费"
+    sheet["A12"] = "胶合板箱,纸箱"
+    sheet["F12"] = "10"
+    sheet["G12"] = "1725"
+    sheet["H12"] = "1017.72"
+    sheet["J12"] = "DAT Selyatino"
+
+    headers = ["项号", "商品编号", "商品名称"]
+    for col, header in enumerate(headers, start=1):
+        sheet.cell(15, col, header)
+    sheet["A16"] = "1"
+    sheet["B16"] = "9503002900"
+    sheet["C16"] = "塑胶动漫造形"
+    sheet["A17"] = "(    )"
+    sheet["B17"] = "(    )"
+    sheet["C17"] = "(    )"
+    sheet["A18"] = "2"
+    sheet["B18"] = "9503002901"
+    sheet["C18"] = "第二行"
+
+    buffer = io.BytesIO()
+    book.save(buffer)
+    return buffer.getvalue()
+
+
+def test_placeholder_cells_are_blank_not_values() -> None:
+    document = parse_excel(_placeholder_workbook(), file_id="p1", filename="ph.xlsx")
+    sheet = document.sheets[0]
+    pairs = _pairs(sheet)
+    assert "申报口岸" not in pairs
+    assert "出境关别" not in pairs
+    assert "征免性质" not in pairs
+    assert all(_PLACEHOLDER_VALUE.match(value) is None for value in pairs.values())
+
+    header_rows = {table.header_row for table in sheet.tables}
+    assert 11 not in header_rows
+    assert pairs["包装类型"] == "胶合板箱,纸箱"
+    assert pairs["件数"] == "10"
+    assert float(pairs["毛重（千克）"]) == 1725
+    assert float(pairs["净重（千克）"]) == 1017.72
+    assert pairs["成交方式"] == "DAT Selyatino"
+
+    goods = next(table for table in sheet.tables if table.header_row == 15)
+    assert [row["项号"] for row in goods.rows] == ["1"]
+
+
+@pytest.mark.skipif(not REAL_GSC.exists(), reason="本地 GSC 样本不在 CI")
+def test_real_gsc_flat_layout_kvs_and_goods_table() -> None:
+    document = parse_excel(
+        REAL_GSC.read_bytes(),
+        file_id="gsc",
+        filename=REAL_GSC.name,
+    )
+    draft = document.sheets[0]
+    pairs = _pairs(draft)
+    assert pairs["出口口岸"] == "5304"
+    assert pairs["备案号"] == "T5339W000208"
+    assert pairs["贸易方式"] == "区内物流货物"
+    assert pairs["运抵国"] == "中国台湾"
+    assert pairs["指运港"] == "中国台湾"
+    assert float(pairs["件数"]) == 230
+    assert pairs["包装种类"] == "纸制或纤维板制盒/箱"
+    assert float(pairs["毛重"]) == 1560
+    assert float(pairs["净重"]) == 785.0276
+    assert pairs["成交方式"] == "FOB"
+    assert pairs["贸易国"] == "中国台湾"
+
+    values = {item.value for item in draft.key_values}
+    assert "经营单位" not in values
+    assert "运输工具" not in values
+    assert "批准文号" not in values
+
+    header_rows = {table.header_row for table in draft.tables}
+    assert 6 not in header_rows
+    assert 8 not in header_rows
+    goods = next(table for table in draft.tables if table.header_row == 11)
+    assert len(goods.rows) == 50
+    assert goods.rows[0]["海关编码"] == "9503002900"
+
+
+@pytest.mark.skipif(not REAL_GSRUA.exists(), reason="本地 GSRUA 样本不在 CI")
+def test_real_gsrua_box_row_with_placeholders() -> None:
+    document = parse_excel(
+        REAL_GSRUA.read_bytes(),
+        file_id="gsrua",
+        filename=REAL_GSRUA.name,
+    )
+    draft = document.sheets[0]
+    pairs = _pairs(draft)
+    assert pairs["包装类型"] == "胶合板箱,纸箱"
+    assert pairs["件数"] == "10"
+    assert float(pairs["毛重（千克）"]) == 1725
+    assert float(pairs["净重（千克）"]) == 1017.72
+    assert pairs["成交方式"] == "DAT Selyatino"
+    assert "出境关别" not in pairs
+    assert "征免性质" not in pairs
+    assert "离境口岸" not in pairs
+    assert "申报口岸" not in pairs
+    assert all(_PLACEHOLDER_VALUE.match(value) is None for value in pairs.values())
+
+    header_rows = {table.header_row for table in draft.tables}
+    assert 11 not in header_rows
+    goods = next(table for table in draft.tables if table.header_row == 19)
+    assert len(goods.rows) == 101


### PR DESCRIPTION
Closes #64

## 改了什么

只动 `adapters/parsers/layout.py` + `src/docparse/schema/layout_vocab.yaml`（词表驱动，不写公司分支）：

### layout.py（版面刀）

1. **占位值归零**：`^[\(（]\s*[\)）]` 开头的格（`(  )`、`(    )跨境的才需要申报`）视同空。生效位置：KV 候选过滤（below/right/same_cell）、`_is_box_label_row`（占位格不占「整行 BOX」名额）、表体记录判空（整行占位 → 表体止行）。
2. **表头行防混数据**：`_is_header_row` 行内出现纯数值 / 日期 / 占位格即不当表头（真实商品表头全是文本；GSC R6 的 44036、R8 的 230.00 都是数据）。
3. **右向跳空取值**：`_scan_right` 跳过 ≤2 个空列/占位格取第一个非空格（出口口岸 A2 → 跳 B2 → C2=5304）。上限是常量 `_RIGHT_SKIP_MAX`。
4. **词形归一去空白**：`_norm_label` 去掉全部空白，「毛重\n（公斤）」「毛    重」能对上词表（锚点侧全面归一仍归 #66）。

### layout_vocab.yaml（别名 + 值域，已与业务对齐）

新增别名：

| 组 | 新别名 | 来源 |
|---|---|---|
| trade_party | 经营单位、收货单位 | GSC 旧叫法；词表键化后挡住「出口口岸=经营单位」错配 |
| wrap_type | 包装类型 | GSRUA R11 同字异写 |
| trade_country | 运抵国 | GSC 短写；fields.yaml 已有同名 anchor |
| trade_nation | 贸易国 | GSC 短写 |
| gross_wt / net_wt | 毛/净重（公斤）+ 半角变体 | 多科「毛重\n（公斤）」 |
| attached_docs | 随附单据 | 多科同义异写 |
| declare_unit（不挂锚点） | 报关单位 | 纯防错配（agent* 不解析） |
| settle_mode（不挂锚点） | 结汇方式 | 纯防错配 |
| container_no（不挂锚点） | 集装箱号、集装箱规格 | 纯防错配 |

新增值域（#29 机制，写 YAML 不写代码）：

| 组 | pattern | 挡住的错配 |
|---|---|---|
| manual_no 备案号 | `^[A-Za-z0-9][A-Za-z0-9\-/]{5,}$` | 备案号=运输工具 |
| entry_id 海关编号 | 同上 | 海关编号=（深惠州关）章戳 |
| license_no 许可证号 | `^[A-Za-z0-9][A-Za-z0-9\-/]{2,}$` | 许可证号=批准文号（GSC/多科） |
| bill_no 提运单号 | `^[A-Za-z0-9][A-Za-z0-9\-/&.]*$` | 非 alnum 开头的值；GSC「粤港」会被拒掉留空转 needs_review |
| ie_port 口岸组 | `^(?:\d{4}|[\u4e00-\u9fa5]{2,10})$` | 四位关区码或 2-10 字中文口岸名 |

### 与 issue 方案的偏差（已对齐）

「候选值右侧紧跟自己的值 → 是标签」未实现：实测会误伤恒信框表（E8=一般贸易 右侧隔列有 G8）、GSRUA（A12=胶合板箱,纸箱 右侧有数值）等 below 正取值。改用「词表键化 + 值域」杀同类错配，效果等价且不伤框表。

## 验收

- GSC：R6/R8 不再判表头；KV 拿到 出口口岸=5304、备案号=T5339W000208、贸易方式=区内物流货物、运抵国=中国台湾、指运港=中国台湾、件数=230、包装种类=纸制或纤维板制盒/箱、毛重=1560、净重=785.0276、成交方式=FOB、贸易国=中国台湾；商品表（R11 表头，50 行）不受影响。
- GSRUA：R11 判为框表标签行；包装类型=胶合板箱,纸箱、件数=10、毛重=1725、净重=1017.72、成交方式=DAT Selyatino；iePort/cutMode 为空串而不是 `(    )`；端到端 declare 报关单 packNo=10、grossWt=1725、netWt=1017.72。
- 附带修复：多科假表（R11 混数据凑 token）消除，真实商品表（R15）恢复；「许可证号=批准文号」「Contract No.=日  期」错配消除。
- 全样本 KV/表 before/after 比对：恒信/国光/进料加工/通达2/国光-越子 零变化；其余变化均为修复项。
- 测试：98 passed（新增 5 条：占位值、跳空取值、伪表头各一条 + GSC/GSRUA 真机验收）；ruff 全绿。

## 以后新 xlsx / 新叫法改哪

| 场景 | 改哪 | 动 Python 吗 |
|---|---|---|
| 新占位符写法（如「待定」） | layout.py `_PLACEHOLDER` 正则 | 是（一行正则） |
| 标签-值间距超过 2 列 | layout.py `_RIGHT_SKIP_MAX` 常量 | 是（一个常量） |
| 新的撞车键（值不像值） | layout_vocab.yaml 对应组补 `value:` pattern | 否 |
| 新叫法/短写/异写 | layout_vocab.yaml 对应组补 alias | 否 |
| 新的纯防错配标签（无字段槽位） | layout_vocab.yaml 加不挂锚点的新组 | 否 |
| 锚点侧归一（空白/尾码/繁体、词表键→字段） | #66 | - |
| 表头字段映射（GSC 走到 declaration） | #65 角色识别 + #66 锚点 | - |