### PR TITLE
feat: 锚点归一化、别名补齐与纯代码值路由（#66）

### DIFF
--- a/docs/code-tables.md
+++ b/docs/code-tables.md
@@ -11,6 +11,7 @@
 | 方向 | `lookup(表, 名称) → code`；`reverse(表, code) → 名称` |
 | 比较 | `strip` 后**整词相等**。不模糊、不含、不别名 |
 | 未知名称 | 返回 `None`，不默认 FOB / 一般贸易 |
+| 反查兜底（#66） | `known_code(表, 值)`：值本身已是这张表的 code（如 GSC `iePort=5304`）→ assemble 接受，不报 `unknown_code`，payload 仍展示原值 |
 | 未知表名 | 抛 `ValueError`（含客户表没有、标了 pending 的表） |
 | 一对多 | 0 或 >1 个命中都返回 `None`，不瞎选 |
 | code 形态 | 一律字符串。`4` 不补成 `04`；`0110` 保留前导零 |

--- a/docs/goods-map.md
+++ b/docs/goods-map.md
@@ -13,7 +13,7 @@ python -m docparse.cli goods /绝对路径/表.xlsx
 ```text
 Sheet.tables + consume
   → 只处理 consume ≠ exclude
-  → 列名对 fields.yaml goods.anchors（去空白、大小写不敏感；英文按词边界）
+  → 列名对 fields.yaml goods.anchors（键归一化：去空白、全角括号统一；英文按词边界）
   → 每张 sheet 先出带角色的货行
   → 按 goods_master 计分选一张主表
   → merge_supplement 默认 true：同序对齐，数量对上才补空
@@ -23,6 +23,12 @@ Sheet.tables + consume
 `auxiliary` / `unknown` 的 table 留在 IR，本层不读。
 
 一份 xlsx 最终只有**一张**货表。箱单 / 发票 / 合同不能另开一张报关单。
+
+## 列归属（#66）
+
+每列归哪个字段是恒定规则：按锚点在 fields.yaml 里的**先后**（先专后泛，如申报要素 > 规格型号 > 商品规格），再看锚点长度。
+
+同一字段多列命中时才看数据形状：**常量列降级**——行数 >1 且非空值全部相同的列是合计列（通达2「总净重(千克)」全表 1793.6065），不抢行级列（「净重(千克)」）；国光「总净重 NW」每行不同，不受影响，仍按锚点顺序赢。
 
 ## 主货表
 
@@ -91,6 +97,8 @@ Sheet.tables + consume
 |---|---|---|
 | 列名没见过，layout 都没拆出表 | `layout_vocab.yaml` TABLE alias | 否 |
 | layout 有了，对不上报关字段 | 已有字段的 `anchors` | 否 |
+| 列名带空白 / 换行 / 尾码 | 已被键归一化吃掉，不用管 | 否 |
+| 「总净重」抢了「净重」 | 常量列降级已处理；若合计列每行不同，把专用列名写进 anchors 更前面 | 否 |
 | 语义是新的商品字段 | `fields.yaml` `goods:` 新字段 + anchors | 否（映射器按目录走） |
 | 新单据类型要参与补货 | `sheet_roles.yaml` 加 role，`consume: supplement` | 否 |
 | 新辅助表（料号对照） | `auxiliary` 加信号 | 否 |

--- a/docs/head-map.md
+++ b/docs/head-map.md
@@ -13,13 +13,25 @@ python -m docparse.cli head /绝对路径/表.xlsx
 ```text
 Sheet.key_values + consume
   → 只处理 consume ≠ exclude
-  → key 对 fields.yaml head.anchors（去空白、大小写不敏感）
+  → key 对 fields.yaml head.anchors（键归一化，见下）
   → ExtractedField（值先留原文，证据 = sheet 名 + 格子）
 ```
 
 一份 xlsx 有几张合格 sheet，就调用几次，结果**并排**。草单 `packNo=40` 和箱单上的件数不会在这一层互相覆盖。谁是主、谁补空是 #19。
 
 `auxiliary` / `unknown` 的 KV 留在 IR，本层不读。
+
+## 键归一化（#66）
+
+键与锚点两侧都过 `schema/textnorm.py`，值永远不动：
+
+| 现象 | 例子 | 折成 |
+|---|---|---|
+| 去全部空白（含换行） | `毛 重` / `毛重\n（公斤）` | `毛重(公斤)` |
+| 全角括号统一半角 | `贸易国（地区）` | `贸易国(地区)` |
+| 键尾剥「（≤6 位字母数字）」码 | `贸易方式（0110）` | `贸易方式` |
+| 括号里不是字母数字不剥 | `贸易国（地区）` / `毛重（公斤）` | 保持 |
+| 繁体字**不**转换 | `淨重` | `淨重`（靠 alias 收，不做简繁映射） |
 
 ## `head_map`
 
@@ -32,6 +44,17 @@ Sheet.key_values + consume
 | `trailing_code` | 值末尾 10 位海关代码（字母数字）拆给 `split_target`，前面进本字段 |
 
 稳拆只做这一种：`tradeName` / `ownerName`。没有 10 位尾巴就整格当名称，不编造代码。
+
+## 纯代码值路由（#66）
+
+`trailing_code` 字段的值整体是码（可带括号壳）时不当名称：
+
+| 值形状 | 落点 |
+|---|---|
+| 整体 10 位海关码（GSC 经营单位 `440356K004`） | `split_target`（tradeCode / ownerCode）；name 留空标 `pure_code_value` 待复核 |
+| 整体 18 位信用代码（GSRUA `91330206MA2818T42Q`） | `scc_target`（tradeScc / ownerScc）；name 同上 |
+| `（码）`括号壳 | 剥壳按码处理 |
+| 名称+尾码（恒信 `…公司441394164D`） | 原 `trailing_code` 拆法不变 |
 
 ## 出口商业单据（不是某家公司）
 
@@ -65,6 +88,9 @@ Sheet.key_values + consume
 |---|---|---|
 | 键的叫法没见过，layout 都没拆出 | `layout_vocab.yaml` alias | 否 |
 | layout 有了，对不上报关字段 | 已有字段的 `anchors` | 否 |
+| 键带空白 / 换行 / 全角括号 / 尾码（`贸易方式（0110）`） | 已被键归一化吃掉，不用管 | 否 |
+| 新的「标签（码）」写法剥不掉 | `textnorm.py` 剥码正则 | 是，常量 |
+| 值是纯码 / 括号码，新形状 | `head_map.py` 值路由规则 | 是，通用规则 |
 | 语义是新表头字段 | `fields.yaml` 新字段 + anchors | 否（映射器按目录走） |
 | 名称+代码粘在一起 | 已有 `trailing_code` | 否 |
 | 新的稳拆规则（例如 18 位信用代码） | 新 `head_map` 值 + 拆分函数 | 是，通用规则，不按公司 |
@@ -72,6 +98,7 @@ Sheet.key_values + consume
 | 跨表谁覆盖谁（表头） | `fields.yaml` `assembly` / [assemble.md](assemble.md) | 否 |
 | 商品行跨表补空 | #18 / [goods-map.md](goods-map.md) | 否 |
 | 名称要变成海关 code | #14 / #27 / #19 | 否 |
+| 值本身已是合法 code（iePort=5304） | assemble 反查兜底已接受，不用管 | 否 |
 | 发票号要进报关单 | #37 先定落点 | 视目录 |
 
 不要 `if company == "恒信"`。不要在这一层 `lookup(code_tables)`。不要把 key 在 layout 里改写成 `contrNo`。

--- a/src/docparse/adapters/parsers/layout.py
+++ b/src/docparse/adapters/parsers/layout.py
@@ -9,6 +9,7 @@ import re
 
 from docparse.domain.ir import Cell, KeyValue, Sheet, Table
 from docparse.schema.loader import VocabValue, load_layout_vocab
+from docparse.schema.textnorm import fold_key
 
 # 半角 / 全角 / 小冒号（U+FE55）/ 竖排冒号。不按客户码点特判。
 _COLON_CHARS = ":：﹕︰"
@@ -128,10 +129,10 @@ def _all_kv_keys() -> frozenset[str]:
 
 
 def _norm_label(text: str) -> str:
-    # 词形归一去掉全部空白（#64）：标签里的换行/空格（「毛重\n（公斤）」「毛    重」）
-    # 不该挡住词表匹配。锚点侧的全面归一（空白/尾码/繁体）在 #66。
-    cleaned = re.sub(r"\s+", "", _label_text(text))
-    return cleaned.casefold()
+    # 词形归一（#64/#66）：去全部空白、全角括号统一、键尾剥「（≤6 位码）」
+    # （「贸易方式（0110）」＝「贸易方式」）。抽出的 KV key 仍是格子原文；
+    # 剥码只用于词表匹配，值永远不动。
+    return fold_key(_label_text(text))
 
 
 def _kv_norms() -> frozenset[str]:

--- a/src/docparse/extraction/assemble.py
+++ b/src/docparse/extraction/assemble.py
@@ -337,6 +337,11 @@ def _apply_lookup(field: ExtractedField, spec: FieldSpec, codes: CodeTables) -> 
         field.validation_errors = [*field.validation_errors, f"code_table_pending:{table}"]
         return
     if code is None:
+        # 反查兜底（#66）：值本身已是码表 code（如 GSC iePort=5304）则接受，
+        # 不再报 unknown_code。payload 展示仍是原值。
+        if codes.known_code(table, raw):
+            field.normalized_value = raw
+            return
         field.status = FieldStatus.NEEDS_REVIEW
         field.validation_errors = [*field.validation_errors, f"unknown_code:{table}"]
         return

--- a/src/docparse/extraction/goods_map.py
+++ b/src/docparse/extraction/goods_map.py
@@ -8,8 +8,8 @@ from copy import deepcopy
 from docparse.domain.fields import ExtractedField, FieldStatus, GoodsItem
 from docparse.domain.ir import DocumentIR, Evidence, Sheet, Table
 from docparse.schema.loader import FieldSpec, Schema, load_schema
+from docparse.schema.textnorm import fold_key, fold_spaced
 
-_SPACE = re.compile(r"\s+")
 _LEADING_HS = re.compile(r"^(\d{8,10})")
 _SKIP_CONSUME = frozenset({"exclude"})
 _GOODS_LAYOUTS = frozenset({"table_col"})
@@ -55,7 +55,7 @@ def map_sheet_goods(
     table = _best_table(sheet, schema)
     if table is None:
         return []
-    mapping = _column_map(table.headers, schema)
+    mapping = _column_map(table.headers, schema, table.rows)
     if not mapping:
         return []
     score = _table_score(mapping, sheet.role, schema)
@@ -70,7 +70,7 @@ def map_sheet_goods(
 def _best_table(sheet: Sheet, schema: Schema) -> Table | None:
     scored: list[tuple[int, Table]] = []
     for table in sheet.tables:
-        mapping = _column_map(table.headers, schema)
+        mapping = _column_map(table.headers, schema, table.rows)
         if not mapping:
             continue
         scored.append((_table_score(mapping, sheet.role, schema), table))
@@ -88,29 +88,55 @@ def _table_score(mapping: dict[str, FieldSpec], role: str, schema: Schema) -> in
     return score
 
 
-def _column_map(headers: list[str], schema: Schema) -> dict[str, FieldSpec]:
-    header_best: dict[str, tuple[int, FieldSpec]] = {}
+def _column_map(
+    headers: list[str],
+    schema: Schema,
+    rows: list[dict[str, str]] | None = None,
+) -> dict[str, FieldSpec]:
+    """列 → 字段。
+
+    每列归属：按锚点在 fields.yaml 里的先后（先专后泛），再看锚点长度——
+    与数据无关，恒定规则。同一字段多列命中时才看数据形状：
+    常量列（>1 行且非空值全部相同，如通达2「总净重(千克)」全表合计）
+    降级，让行级列（净重(千克)）赢；国光「总净重 NW」每行不同，不受影响。
+    """
+    constant = _constant_headers(headers, rows or [])
+    header_best: dict[str, tuple[int, int, FieldSpec]] = {}
     for header in headers:
         if not header.strip():
             continue
-        best: tuple[int, FieldSpec] | None = None
+        best: tuple[int, int, FieldSpec] | None = None
         for spec in schema.goods:
             if not _mappable(spec):
                 continue
-            for anchor in spec.anchors:
+            for order, anchor in enumerate(spec.anchors):
                 if not _anchor_hits(anchor, header):
                     continue
-                length = len(_fold_key(anchor))
-                if best is None or length > best[0]:
-                    best = (length, spec)
+                rank = (-order, len(fold_key(anchor)))
+                if best is None or rank > (best[0], best[1]):
+                    best = (*rank, spec)
         if best is not None:
             header_best[header] = best
-    field_best: dict[str, tuple[int, str, FieldSpec]] = {}
-    for header, (length, spec) in header_best.items():
+    field_best: dict[str, tuple[int, int, int, str, FieldSpec]] = {}
+    for header, (order, length, spec) in header_best.items():
         current = field_best.get(spec.name)
-        if current is None or length > current[0]:
-            field_best[spec.name] = (length, header, spec)
-    return {header: spec for _, header, spec in field_best.values()}
+        rank = (0 if header in constant else 1, order, length)
+        if current is None or rank > (current[0], current[1], current[2]):
+            field_best[spec.name] = (*rank, header, spec)
+    return {header: spec for _, _, _, header, spec in field_best.values()}
+
+
+def _constant_headers(headers: list[str], rows: list[dict[str, str]]) -> frozenset[str]:
+    """非空值全部相同且行数 >1 的列是合计列。空值不参与判定。"""
+    constant: set[str] = set()
+    if len(rows) <= 1:
+        return frozenset(constant)
+    for header in headers:
+        values = {(row.get(header) or "").strip() for row in rows}
+        values.discard("")
+        if len(values) == 1 and values:
+            constant.add(header)
+    return frozenset(constant)
 
 
 def _mappable(spec: FieldSpec) -> bool:
@@ -220,7 +246,7 @@ def _unit_aligns(master: GoodsItem, other: GoodsItem, schema: Schema) -> bool:
     other_unit = (other.value_of("gunit") or "").strip()
     if not master_unit or not other_unit:
         return True
-    return _fold_key(master_unit) == _fold_key(other_unit)
+    return fold_key(master_unit) == fold_key(other_unit)
 
 
 def _fill_allowed(master: GoodsItem, name: str, field: ExtractedField, schema: Schema) -> bool:
@@ -277,11 +303,11 @@ def _total_over_price(item: GoodsItem) -> float | None:
 
 
 def _is_weight_unit(unit: str | None, schema: Schema | None) -> bool:
-    text = _fold_key(unit or "")
+    text = fold_key(unit or "")
     if not text:
         return False
     names = schema.goods_master.weight_units if schema is not None else []
-    return any(_fold_key(name) == text for name in names)
+    return any(fold_key(name) == text for name in names)
 
 
 def _as_number(text: str | None) -> float | None:
@@ -313,15 +339,11 @@ def _body_cell(table: Table, header: str, row_index: int) -> str | None:
 
 
 def _anchor_hits(anchor: str, header: str) -> bool:
-    needle = _fold_key(anchor)
-    text = _fold_key(header)
+    needle = fold_spaced(anchor)
+    text = fold_spaced(header)
     if not needle or not text:
         return False
     if needle.isascii() and any(char.isalpha() for char in needle):
         pattern = r"(?<![a-z0-9])" + re.escape(needle) + r"(?![a-z0-9])"
         return re.search(pattern, text) is not None
-    return needle in text
-
-
-def _fold_key(text: str) -> str:
-    return _SPACE.sub(" ", text.strip()).casefold()
+    return fold_key(anchor) in fold_key(text)

--- a/src/docparse/extraction/head_map.py
+++ b/src/docparse/extraction/head_map.py
@@ -7,9 +7,13 @@ import re
 from docparse.domain.fields import ExtractedField, FieldStatus
 from docparse.domain.ir import DocumentIR, Evidence, KeyValue, Sheet
 from docparse.schema.loader import FieldSpec, Schema, load_schema
+from docparse.schema.textnorm import fold_key
 
-_SPACE = re.compile(r"\s+")
 _TRAILING_CUSTOMS_CODE = re.compile(r"^(.*?)([A-Za-z0-9]{10})$")
+# 纯代码值路由（#66）：整体是海关码 / 信用代码（可带括号壳）时不当名称。
+_CUSTOMS_CODE = re.compile(r"^[A-Z0-9]{10}$")
+_CREDIT_CODE = re.compile(r"^[A-Z0-9]{18}$")
+_CODE_SHELL = re.compile(r"^[（(]\s*([A-Za-z0-9]+)\s*[)）]$")
 _SKIP_CONSUME = frozenset({"exclude"})
 _HEAD_LAYOUTS = frozenset({"box_kv"})
 _CALLER_PREFIX = "agent"
@@ -40,7 +44,7 @@ def map_sheet_head(
     for pair in sheet.key_values:
         if not pair.value.strip():
             continue
-        specs = index.get(_fold_key(pair.key), [])
+        specs = index.get(fold_key(pair.key), [])
         for spec in specs:
             if spec.name in found:
                 continue
@@ -56,7 +60,7 @@ def _anchor_index(schema: Schema) -> dict[str, list[FieldSpec]]:
         if not _mappable(spec):
             continue
         for anchor in spec.anchors:
-            index.setdefault(_fold_key(anchor), []).append(spec)
+            index.setdefault(fold_key(anchor), []).append(spec)
     return index
 
 
@@ -81,6 +85,9 @@ def _emit(
 ) -> list[ExtractedField]:
     raw = pair.value.strip()
     if spec.head_map == "trailing_code":
+        routed = _route_code_value(spec, raw, pair, sheet, document, schema)
+        if routed is not None:
+            return routed
         name, code = _split_trailing_code(raw)
         fields = [_accepted(spec, name, pair, sheet, document)]
         target = schema.field(spec.split_target or "")
@@ -88,6 +95,48 @@ def _emit(
             fields.append(_accepted(target, code, pair, sheet, document))
         return fields
     return [_accepted(spec, raw, pair, sheet, document)]
+
+
+def _route_code_value(
+    spec: FieldSpec,
+    raw: str,
+    pair: KeyValue,
+    sheet: Sheet,
+    document: DocumentIR,
+    schema: Schema,
+) -> list[ExtractedField] | None:
+    """纯代码值路由：值整体是海关码 / 信用代码（可带括号壳）时不当名称。
+
+    name 字段留空并标 needs_review，码写进对应的 *Code / *Scc 字段。
+    """
+    shell = _CODE_SHELL.fullmatch(raw)
+    candidate = (shell.group(1) if shell else raw).replace(" ", "")
+    if _CREDIT_CODE.fullmatch(candidate):
+        fields = [_code_only_name(spec, pair, sheet, document)]
+        target = schema.field(spec.scc_target or "")
+        if spec.scc_target and target is not None:
+            fields.append(_accepted(target, candidate, pair, sheet, document))
+        return fields
+    if _CUSTOMS_CODE.fullmatch(candidate):
+        fields = [_code_only_name(spec, pair, sheet, document)]
+        target = schema.field(spec.split_target or "")
+        if spec.split_target and target is not None:
+            fields.append(_accepted(target, candidate, pair, sheet, document))
+        return fields
+    return None
+
+
+def _code_only_name(
+    spec: FieldSpec,
+    pair: KeyValue,
+    sheet: Sheet,
+    document: DocumentIR,
+) -> ExtractedField:
+    """名称格只来了一个码：名称留空待补，证据仍指向原格。"""
+    field = _accepted(spec, "", pair, sheet, document)
+    field.status = FieldStatus.NEEDS_REVIEW
+    field.validation_errors = ["pure_code_value"]
+    return field
 
 
 def _split_trailing_code(value: str) -> tuple[str, str | None]:
@@ -125,7 +174,3 @@ def _accepted(
             )
         ],
     )
-
-
-def _fold_key(text: str) -> str:
-    return _SPACE.sub(" ", text.strip()).casefold()

--- a/src/docparse/schema/fields.yaml
+++ b/src/docparse/schema/fields.yaml
@@ -367,10 +367,11 @@ head:
     group: head
     layout: box_kv
     sources: [customs_declaration]
-    anchors: [境内发货人, 境内收发货人, 卖方SELLER, 卖方, SELLER, 卖 方]
+    anchors: [境内发货人, 境内收发货人, 卖方SELLER, 卖方, SELLER, 卖 方, 经营单位]
     head_map: trailing_code
     split_target: tradeCode
-    notes: 框表常与海关代码写在同一格，末尾 10 位拆给 tradeCode。出口商业单据卖方只补充。
+    scc_target: tradeScc
+    notes: 框表常与海关代码写在同一格，末尾 10 位拆给 tradeCode。纯代码值路由（#66）：值整体是 10 位海关码写 tradeCode、18 位信用代码写 tradeScc，name 留空标 pure_code_value。经营单位为 GSC 旧叫法。
 
   - name: tradeCode
     display_name: 10位境内收发货人海关代码
@@ -413,7 +414,8 @@ head:
     anchors: [生产销售单位, 消费使用单位]
     head_map: trailing_code
     split_target: ownerCode
-    notes: 文件里有就抽，没有就空。与代码同一格时末尾 10 位拆给 ownerCode。
+    scc_target: ownerScc
+    notes: 文件里有就抽，没有就空。与代码同一格时末尾 10 位拆给 ownerCode；纯代码值路由同 tradeName（#66）。
 
   - name: ownerCode
     display_name: 生产销售单位代码
@@ -447,9 +449,9 @@ head:
     group: head
     layout: box_kv
     sources: [customs_declaration]
-    anchors: [申报地海关]
+    anchors: [申报地海关, 申报海关]
     code_table: 海关口岸代码
-    notes: 四位关区。见 port_mapping。草单不一定有独立格。
+    notes: 四位关区。见 port_mapping。草单不一定有独立格。申报海关为通达2 叫法（#66）。
 
   - name: iePort
     display_name: 进/出口口岸
@@ -543,25 +545,25 @@ head:
     group: head
     layout: box_kv
     sources: [customs_declaration]
-    anchors: [备案号]
-    notes: 无则空。
+    anchors: [备案号, 账册号]
+    notes: 无则空。账册号为通达2 叫法（#66）。
 
   - name: contrNo
     display_name: 合同协议号
     group: head
     layout: box_kv
     sources: [customs_declaration, contract]
-    anchors: [合同协议号, 合同号, Contract No, CONTRACT NO., 合同号CONTRACT NO.]
-    notes: 框表优先；合同 / 箱单只补充。多 sheet 不在本层合并。
+    anchors: [合同协议号, 合同号, Contract No, CONTRACT NO., 合同号CONTRACT NO., 合約號碼]
+    notes: 框表优先；合同 / 箱单只补充。多 sheet 不在本层合并。合約號碼为 MXY 合同繁体（#66）。
 
   - name: supvModeCdde
     display_name: 监管方式/贸易方式
     group: head
     layout: box_kv
     sources: [customs_declaration]
-    anchors: [监管方式, 贸易方式]
+    anchors: [监管方式, 贸易方式, 貿易方式]
     code_table: 监管方式
-    notes: 字段名按 json 原样（Cdde）。恒信草单 G7 标签错写成「监管方式」的版面问题不在本 Issue。
+    notes: 字段名按 json 原样（Cdde）。恒信草单 G7 标签错写成「监管方式」的版面问题不在本 Issue。貿易方式为当纳利出口发票繁体（#66）。
 
   - name: cutMode
     display_name: 征免性质
@@ -595,9 +597,9 @@ head:
     group: head
     layout: box_kv
     sources: [customs_declaration]
-    anchors: [包装种类]
+    anchors: [包装种类, 包装类型, 包裝种类]
     code_table: 包装种类
-    notes: 名称转码交 #14。
+    notes: 名称转码交 #14。包装类型为 GSRUA 叫法（#64）；包裝种类为当纳利出口发票繁体（#66）。
 
   - name: packNo
     display_name: 件数
@@ -614,8 +616,8 @@ head:
     layout: box_kv
     value_type: number
     sources: [customs_declaration, packing_list]
-    anchors: [毛重（千克）, 毛重(千克), 毛重]
-    notes: "框表优先。别名 G.W. 交 #13。只有净重时不把净重抄进本字段，见 assembly.weight。"
+    anchors: [毛重（千克）, 毛重(千克), 毛重, 毛重（公斤）, 毛重(公斤)]
+    notes: "框表优先。别名 G.W. 交 #13。只有净重时不把净重抄进本字段，见 assembly.weight。（公斤）变体来自多科（#66）。"
 
   - name: netWt
     display_name: 净重(公斤)
@@ -623,8 +625,8 @@ head:
     layout: box_kv
     value_type: number
     sources: [customs_declaration, packing_list]
-    anchors: [净重（千克）, 净重(千克), 净重]
-    notes: "框表优先。别名 N.W. 交 #13。只有净重、没有毛重时视同重量，只进本字段。"
+    anchors: [净重（千克）, 净重(千克), 净重, 净重（公斤）, 净重(公斤), 淨重, 淨重（公斤）, 淨重(公斤)]
+    notes: "框表优先。别名 N.W. 交 #13。只有净重、没有毛重时视同重量，只进本字段。（公斤）变体来自多科；淨重变体来自当纳利出口发票（繁体，#66）。"
 
   - name: transMode
     display_name: 成交方式
@@ -769,8 +771,8 @@ goods:
     layout: table_col
     value_type: number
     sources: [customs_declaration]
-    anchors: [项号, Item]
-    notes: 商品表列。有海关商品表以它为主。不要编造项号。
+    anchors: [项号, Item, 序号]
+    notes: 商品表列。有海关商品表以它为主。不要编造项号。序号为通达2 / 当纳利出口发票叫法（#66）。
 
   - name: codeTs
     display_name: 商品编号(T+S)
@@ -812,8 +814,8 @@ goods:
     layout: table_col
     value_type: number
     sources: [customs_declaration, invoice]
-    anchors: [单价, Unit Price]
-    notes: 海关商品表优先，发票补充。
+    anchors: [单价, Unit Price, 申报单价]
+    notes: 海关商品表优先，发票补充。申报单价为通达2 叫法（#66）。
 
   - name: declTotal
     display_name: 申报总价
@@ -821,8 +823,8 @@ goods:
     layout: table_col
     value_type: number
     sources: [customs_declaration, invoice]
-    anchors: [总价, 汇总价, 总值, Amount]
-    notes: 海关商品表优先。可能是公式。
+    anchors: [总价, 汇总价, 总值, Amount, 申报总价, 金额]
+    notes: 海关商品表优先。可能是公式。申报总价为通达2 叫法；金额为 GSC 叫法（#66）。
 
   - name: tradeCurr
     display_name: 币制
@@ -839,17 +841,17 @@ goods:
     layout: table_col
     value_type: number
     sources: [customs_declaration, packing_list, invoice]
-    anchors: [出货数量, 成交数量, 数量, Quantity, Q'ty, Qty]
-    notes: 海关商品表优先。别名交 #13。千克行跨表补数量，候选值须与净重一致（goods_master 容差）。
+    anchors: [出货数量, 成交数量, 数量, Quantity, Q'ty, Qty, 申报数量]
+    notes: 海关商品表优先。别名交 #13。千克行跨表补数量，候选值须与净重一致（goods_master 容差）。申报数量为通达2 叫法（#66）。
 
   - name: gunit
     display_name: 成交单位
     group: goods
     layout: table_col
     sources: [customs_declaration]
-    anchors: [计价单位, 成交单位, 申报单位, 单位]
+    anchors: [计价单位, 成交单位, 申报单位, 单位, 申报计量单位]
     code_table: 计量单位
-    notes: 名称转码交 #14。映射层可认「单位」列；layout 词表仍不加，防框表误伤。
+    notes: 名称转码交 #14。映射层可认「单位」列；layout 词表仍不加，防框表误伤。申报计量单位为通达2 叫法（#66）。
 
   - name: qty1
     display_name: 法定第一数量
@@ -901,9 +903,9 @@ goods:
     group: goods
     layout: table_col
     sources: [customs_declaration]
-    anchors: [最终目的国, 最终目的地]
+    anchors: [最终目的国, 最终目的地, 目的国]
     code_table: 国别
-    notes: 名称转码交 #14。
+    notes: 名称转码交 #14。目的国为 GSC 叫法（#66）。
 
   - name: districtCode
     display_name: 境内目的地/境内货源地

--- a/src/docparse/schema/layout_vocab.yaml
+++ b/src/docparse/schema/layout_vocab.yaml
@@ -1,5 +1,8 @@
 # 版面词表（Issue #13 / #15）
 # BOX：去冒号后整词相等；整行都是 BOX 才不当表头（占位格视同空，#64）。
+# 键匹配走 textnorm 键归一化（#66）：去全部空白、全角括号统一、
+# 键尾剥「（≤6 位字母数字）」码（「贸易方式（0110）」＝「贸易方式」）。
+# 抽出的 key 仍是格子原文；繁体不转换，靠 alias 收（「淨重」）。
 # KV：商业单据键，匹配同 BOX，但不参与「整行 BOX 不当表头」。
 # TABLE：子串匹配（英文大小写不敏感），一行 ≥2 命中才当表头；
 # 行内混纯数值 / 日期 / 占位格的不当表头（#64）。
@@ -39,6 +42,14 @@ box:
         source: GSC出仓!A3 旧叫法＝境内收发货人。词表键化后挡住「出口口岸=经营单位」错配（#64）
       - text: 收货单位
         source: GSC出仓!A4 旧叫法＝境内收货人；当纳利装箱单 A4「收货单位：」同源（#64）
+
+  - id: credit_code
+    value:
+      type: pattern
+      pattern: '^[A-Z0-9]{18}$'
+    aliases:
+      - text: 信用代码
+        source: "#12 tradeScc anchors；GSRUA 境内发货人右侧格是 18 位信用代码（#66）"
 
   - id: declare_unit
     aliases:
@@ -94,6 +105,8 @@ box:
     aliases:
       - text: 备案号
         source: 恒信草单 一般贸易出口!N3。值域挡「备案号=运输工具」类标签错配（#64）
+      - text: 账册号
+        source: 通达2 扁平表头列名；fields.yaml manualNo 同步（#66）
 
   - id: overseas_party
     aliases:
@@ -135,11 +148,13 @@ box:
         source: 恒信草单 一般贸易出口!E7（G7 标签错写，#9 已知不修）
       - text: 贸易方式
         source: "#12 supvModeCdde anchors"
+      - text: 貿易方式
+        source: 当纳利出口发票!A9 繁体；词表键归一剥尾码后「贸易方式（0110）」也能打中（#66）
 
   - id: cut_mode
     aliases:
       - text: 征免性质
-        source: 恒信草单 一般贸易出口!I7
+        source: 恒信草单 一般贸易出口!I7；多科报关单!H6「征免性质（101）」剥尾码后同键（#66）
 
   - id: license_no
     value:
@@ -196,6 +211,8 @@ box:
         source: 恒信草单 一般贸易出口!A11
       - text: 包装类型
         source: GSRUA26601!A11 同字异写（#64）
+      - text: 包裝种类
+        source: 当纳利出口发票!G10 繁体（#66）
 
   - id: pack_no
     value:
@@ -203,6 +220,8 @@ box:
     aliases:
       - text: 件数
         source: 恒信草单 一般贸易出口!D11
+      - text: 件    数
+        source: 当纳利出口发票!G9 键内多空格；词表匹配已去空白（#66）
 
   - id: gross_wt
     value:
@@ -218,6 +237,8 @@ box:
         source: 多科报关单!I11「毛重\n（公斤）」。词表匹配已去空白（#64）
       - text: 毛重(公斤)
         source: 半角括号变体（#64）
+      - text: 毛    重
+        source: 当纳利出口发票!G7 键内多空格；词表匹配已去空白（#66）
 
   - id: net_wt
     value:
@@ -233,6 +254,8 @@ box:
         source: 多科报关单!K11「净重\n（公斤）」（#64）
       - text: 净重(公斤)
         source: 半角括号变体（#64）
+      - text: 淨    重
+        source: 当纳利出口发票!G8 繁体+多空格；fields.yaml netWt 同步（#66）
 
   - id: trans_mode
     aliases:
@@ -291,6 +314,8 @@ box:
     aliases:
       - text: 申报地海关
         source: "#12 customMaster。恒信 G2 只有「（深惠州关）」，无此标签"
+      - text: 申报海关
+        source: 通达2 扁平表头列名；fields.yaml customMaster 同步（#66）
 
 kv:
   - id: invoice_no

--- a/src/docparse/schema/loader.py
+++ b/src/docparse/schema/loader.py
@@ -5,9 +5,12 @@ from pathlib import Path
 import yaml
 from pydantic import BaseModel, Field, model_validator
 
+from docparse.schema.textnorm import fold_key
+
 
 def _fold_label(text: str) -> str:
-    return re.sub(r"\s+", " ", text.strip()).casefold()
+    # 键归一（#66）：去空白 + 全角括号统一 + 键尾剥码。「毛 重:」与「毛重」同键。
+    return fold_key(text)
 
 
 class FieldSpec(BaseModel):
@@ -26,9 +29,11 @@ class FieldSpec(BaseModel):
     notes: str = ""
     code_table: str | None = None
     # 单 sheet 表头映射（#17）。keep=原样；skip=本层不映射；
-    # trailing_code=末尾海关代码拆给 split_target。
+    # trailing_code=末尾海关代码拆给 split_target；
+    # scc_target=值整体是 18 位信用代码时写入的字段（#66 纯代码值路由）。
     head_map: str = "keep"
     split_target: str | None = None
+    scc_target: str | None = None
     # 商品列映射（#18）。keep=原样；skip=本层不映射；
     # leading_hs=取列值前缀税则号；raw_review=原文 + needs_review。
     goods_map: str = "keep"
@@ -320,6 +325,12 @@ class CodeTables(BaseModel):
         if len(set(codes)) != 1:
             return None
         return codes[0]
+
+    def known_code(self, table: str, code: str | None) -> bool:
+        """值本身是这张表的 code 吗（#66 反查兜底）。"""
+        entries = self._require_table(table).entries
+        key = str(code or "").strip()
+        return bool(key) and any(item.code == key for item in entries)
 
     def reverse(self, table: str, code: str | None) -> str | None:
         """code → 中文名称。0 或 >1 个命中都返回 None。"""

--- a/src/docparse/schema/textnorm.py
+++ b/src/docparse/schema/textnorm.py
@@ -1,0 +1,42 @@
+"""键文本归一化（Issue #66）。键 / 锚点专用，永远不碰值。
+
+三件事：
+- 去全部空白（含换行）：「毛 重」「毛重\\n（公斤）」都折成可对锚点的形状；
+- 全角括号统一半角：锚点 / 词表只收一种写法；
+- 键尾剥「（≤6 位字母数字）」码：「贸易方式（0110）」→「贸易方式」。
+  括号里不是字母数字（「贸易国（地区）」「毛重（公斤）」）不剥。
+值里的括号码是业务信息，剥码只发生在键这一侧。
+"""
+
+from __future__ import annotations
+
+import re
+
+_WHITESPACE = re.compile(r"\s+")
+_CJK_SPACE = re.compile(r"(?<=[^\x00-\x7f])\s+(?=[^\x00-\x7f])")
+_FULLWIDTH_PARENS = str.maketrans("（）", "()")
+_TRAILING_CODE = re.compile(r"[（(][A-Za-z0-9]{1,6}[)）]\Z")
+
+
+def strip_trailing_code(text: str) -> str:
+    """键尾括号码剥掉。「（0110）」剥，「（地区）」不剥。"""
+    return _TRAILING_CODE.sub("", text)
+
+
+def _prepare(text: str, space: str) -> str:
+    collapsed = _WHITESPACE.sub(space, text.strip())
+    if space:
+        # 中日韩字符之间的空格是排版噪声，去掉；ASCII 词距保留
+        collapsed = _CJK_SPACE.sub("", collapsed)
+    cleaned = strip_trailing_code(collapsed.translate(_FULLWIDTH_PARENS))
+    return cleaned.casefold()
+
+
+def fold_key(text: str) -> str:
+    """紧凑形：空白全去。中文键 / 锚点对齐用它。"""
+    return _prepare(text, "")
+
+
+def fold_spaced(text: str) -> str:
+    """保留词距形：英文 token 边界还在，供词边界匹配。"""
+    return _prepare(text, " ")

--- a/tests/test_anchor_normalize.py
+++ b/tests/test_anchor_normalize.py
@@ -1,0 +1,434 @@
+"""锚点归一化与别名补齐（#66）：键形状、纯代码值路由、列映射优先级。"""
+
+from __future__ import annotations
+
+import io
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("openpyxl")
+
+from openpyxl import Workbook
+
+from docparse.adapters.parsers.excel import parse_excel
+from docparse.extraction.assemble import assemble_declaration
+from docparse.extraction.goods_map import map_sheet_goods
+from docparse.extraction.head_map import map_sheet_head
+from docparse.schema.loader import load_code_tables, load_layout_vocab, load_schema
+from docparse.schema.textnorm import fold_key, fold_spaced, strip_trailing_code
+
+_SAMPLES = Path("/Users/baldwin/Desktop/taizhou/补充测试")
+REAL_GSC = _SAMPLES / "GSC出仓QPGSCO260617006A.xlsx"
+REAL_GSRUA = _SAMPLES / "GSRUA26601CLLG01(1).xlsx"
+REAL_TONDA2 = _SAMPLES / "通达2.xlsx"
+REAL_DUOKE = _SAMPLES / "6-17 多科报关资料香港出货 DKTX-2606057 多科通讯乐乐高(1).xls"
+REAL_DONNELLEY = _SAMPLES / "202606 R26JU551-Y报关一般.xls"
+
+
+def _workbook(builders: dict) -> bytes:
+    book = Workbook()
+    first = True
+    for title, fill in builders.items():
+        sheet = book.active if first else book.create_sheet(title)
+        if first:
+            sheet.title = title
+            first = False
+        fill(sheet)
+    buffer = io.BytesIO()
+    book.save(buffer)
+    return buffer.getvalue()
+
+
+def _by_name(fields) -> dict:
+    return {item.name: item for item in fields}
+
+
+# ---- 键归一化 ----
+
+
+def test_fold_key_strips_all_whitespace_and_fullwidth_parens() -> None:
+    assert fold_key("毛 重") == fold_key("毛重")
+    assert fold_key("毛重\n（公斤）") == fold_key("毛重(公斤)")
+    assert fold_key("淨    重") == "淨重"
+
+
+def test_fold_key_strips_trailing_alnum_code_not_words() -> None:
+    assert fold_key("贸易方式（0110）") == fold_key("贸易方式")
+    assert fold_key("征免性质(101)") == fold_key("征免性质")
+    # 括号里不是字母数字的不剥：这是语义的一部分
+    assert fold_key("贸易国（地区）") != fold_key("贸易国")
+    assert fold_key("毛重（公斤）") != fold_key("毛重")
+
+
+def test_strip_trailing_code_variants() -> None:
+    assert strip_trailing_code("申报要素（A1B2）") == "申报要素"
+    assert strip_trailing_code("监管方式") == "监管方式"
+
+
+def test_fold_spaced_keeps_token_boundaries() -> None:
+    assert fold_spaced("Unit Price") == "unit price"
+    assert fold_spaced("毛重\n（公斤）") == "毛重(公斤)"
+
+
+# ---- 尾码标签：版面刀认出 + head_map 命中 ----
+
+
+def _duoke_label_sheet(sheet) -> None:
+    sheet["A1"] = "中华人民共和国海关出口货物报关单"
+    sheet["A3"] = "境内发货人"
+    sheet["A4"] = "深圳市多科通讯有限公司"
+    sheet["D6"] = "贸易方式（0110）"
+    sheet["D7"] = "一般贸易"
+    sheet["H6"] = "征免性质（101）"
+    sheet["H7"] = "一般征税"
+
+
+def test_coded_label_extracts_kv_and_maps_anchor() -> None:
+    document = parse_excel(
+        _workbook({"报关单": _duoke_label_sheet}),
+        file_id="dk",
+        filename="duoke.xlsx",
+    )
+    draft = document.sheets[0]
+    assert draft.role == "draft"
+    pairs = {item.key: item.value for item in draft.key_values}
+    # KV 键保留格子原文，剥码只发生在匹配侧
+    assert pairs.get("贸易方式（0110）") == "一般贸易"
+    assert pairs.get("征免性质（101）") == "一般征税"
+    by_name = _by_name(map_sheet_head(draft, document))
+    assert by_name["supvModeCdde"].value == "一般贸易"
+    assert by_name["cutMode"].value == "一般征税"
+
+
+# ---- 繁体 / 多空格键 ----
+
+
+def _donnelley_invoice_sheet(sheet) -> None:
+    sheet["A1"] = "出     口    发     票"
+    sheet["H4"] = "发票号:"
+    sheet["K4"] = "R26JU551-Y"
+    sheet["G7"] = "毛    重:"
+    sheet["I7"] = "19137"
+    sheet["G8"] = "淨    重:"
+    sheet["I8"] = "17432"
+    sheet["A9"] = "贸易方式:"
+    sheet["C9"] = "一般贸易"
+    sheet["G9"] = "件    数:"
+    sheet["I9"] = "1278"
+    sheet["G10"] = "包裝种类:"
+    sheet["I10"] = "纸制或纤维板制盒/箱"
+
+
+def test_traditional_spaced_keys_map_head_fields() -> None:
+    document = parse_excel(
+        _workbook({"出口发票": _donnelley_invoice_sheet}),
+        file_id="dnn",
+        filename="donnelley.xlsx",
+    )
+    invoice = document.sheets[0]
+    by_name = _by_name(map_sheet_head(invoice, document))
+    assert by_name["grossWt"].value == "19137"
+    assert by_name["netWt"].value == "17432"
+    assert by_name["supvModeCdde"].value == "一般贸易"
+    assert by_name["packNo"].value == "1278"
+    assert by_name["wrapType"].value == "纸制或纤维板制盒/箱"
+
+
+# ---- 纯代码值路由 ----
+
+
+def _gsc_party_sheet(sheet) -> None:
+    sheet["A1"] = "出境备案清单"
+    sheet["A3"] = "经营单位"
+    sheet["C3"] = "440356K004"
+    sheet["A5"] = "生产销售单位"
+    sheet["C5"] = "（440356K004）"
+
+
+def _credit_code_sheet(sheet) -> None:
+    sheet["A1"] = "中华人民共和国海关出口货物报关单"
+    sheet["A3"] = "境内发货人"
+    sheet["C3"] = "91330206MA2818T42Q"
+
+
+def test_pure_code_values_route_to_code_fields() -> None:
+    document = parse_excel(
+        _workbook({"出境备案清单": _gsc_party_sheet}),
+        file_id="gsc",
+        filename="gsc.xlsx",
+    )
+    sheet = document.sheets[0]
+    by_name = _by_name(map_sheet_head(sheet, document))
+    # 10 位海关码 → tradeCode，name 留空待补
+    assert by_name["tradeName"].value == ""
+    assert by_name["tradeName"].status.value == "needs_review"
+    assert "pure_code_value" in by_name["tradeName"].validation_errors
+    assert by_name["tradeCode"].value == "440356K004"
+    # （码）括号壳剥壳按码处理
+    assert by_name["ownerCode"].value == "440356K004"
+    assert by_name["ownerName"].status.value == "needs_review"
+
+
+def test_credit_code_routes_to_scc() -> None:
+    document = parse_excel(
+        _workbook({"一般贸易出口": _credit_code_sheet}),
+        file_id="scc",
+        filename="scc.xlsx",
+    )
+    by_name = _by_name(map_sheet_head(document.sheets[0], document))
+    assert by_name["tradeScc"].value == "91330206MA2818T42Q"
+    assert by_name["tradeName"].value == ""
+    assert by_name["tradeName"].status.value == "needs_review"
+
+
+def test_name_plus_trailing_code_still_splits() -> None:
+    def sheet_fill(sheet) -> None:
+        sheet["A1"] = "中华人民共和国海关出口货物报关单"
+        sheet["A3"] = "境内发货人"
+        sheet["A4"] = "惠州市恒德信精密科技有限公司441394164D"
+
+    document = parse_excel(
+        _workbook({"一般贸易出口": sheet_fill}),
+        file_id="hx",
+        filename="hx.xlsx",
+    )
+    by_name = _by_name(map_sheet_head(document.sheets[0], document))
+    assert by_name["tradeName"].value == "惠州市恒德信精密科技有限公司"
+    assert by_name["tradeCode"].value == "441394164D"
+
+
+# ---- 商品列映射：常量列降级 + 锚点顺序 ----
+
+
+def _tonda2_sheet(sheet) -> None:
+    sheet["A1"] = "申报海关"
+    sheet["B1"] = "序号"
+    sheet["C1"] = "申报数量"
+    sheet["D1"] = "申报计量单位"
+    sheet["E1"] = "申报单价"
+    sheet["F1"] = "申报总价"
+    sheet["G1"] = "净重(千克)"
+    sheet["H1"] = "毛重(千克)"
+    sheet["I1"] = "总净重(千克)"
+    sheet["J1"] = "总毛重(千克)"
+    rows = [
+        ("1", "3000", "个", "0.0318", "95.49", "2.7", "5.5", "1793.6065", "2045.266"),
+        ("2", "18000", "个", "0.0166", "298.02", "10.62", "16.9", "", ""),
+        ("3", "4000", "个", "0.0143", "57.2", "1.92", "1.93", "", ""),
+    ]
+    for r, row in enumerate(rows, start=2):
+        for c, value in enumerate(row, start=1):
+            sheet.cell(r, c + 1, value)  # B 起填，申报海关列留空
+
+
+def test_constant_total_column_loses_to_row_column() -> None:
+    document = parse_excel(
+        _workbook({"Sheet1": _tonda2_sheet}),
+        file_id="td2",
+        filename="tonda2.xlsx",
+    )
+    items = map_sheet_goods(document.sheets[0], document)
+    assert [item.value_of("gno") for item in items] == ["1", "2", "3"]
+    assert [item.value_of("customNetWt") for item in items] == ["2.7", "10.62", "1.92"]
+    assert [item.value_of("customGrossWet") for item in items] == ["5.5", "16.9", "1.93"]
+    assert items[0].value_of("gqty") == "3000"
+    assert items[0].value_of("declPrice") == "0.0318"
+    assert items[0].value_of("declTotal") == "95.49"
+
+
+def _varying_total_sheet(sheet) -> None:
+    """国光形：总净重每行不同，是正确列——锚点顺序（总净重更专）应当赢。"""
+    sheet["A1"] = "物料名称"
+    sheet["B1"] = "净重/个"
+    sheet["C1"] = "总净重"
+    rows = [
+        ("贴纸", "1.3e-05", "0.0013"),
+        ("音盆组", "0.001", "22.4"),
+        ("防尘帽", "4e-05", "0.84"),
+    ]
+    for r, row in enumerate(rows, start=2):
+        for c, value in enumerate(row, start=1):
+            sheet.cell(r, c, value)
+
+
+def test_varying_total_column_wins_by_anchor_order() -> None:
+    document = parse_excel(
+        _workbook({"总箱单": _varying_total_sheet}),
+        file_id="gg",
+        filename="gg.xlsx",
+    )
+    items = map_sheet_goods(document.sheets[0], document)
+    assert [item.value_of("customNetWt") for item in items] == ["0.0013", "22.4", "0.84"]
+
+
+def _element_vs_spec_sheet(sheet) -> None:
+    sheet["A1"] = "装箱单 PACKING LIST"
+    sheet["A3"] = "商品名称"
+    sheet["B3"] = "商品规格"
+    sheet["C3"] = "申报要素"
+    sheet["A4"] = "电容"
+    sheet["B4"] = "瓷介质"
+    sheet["C4"] = "0|0|单层片式|陶瓷|无品牌|无型号"
+
+
+def test_anchor_order_prefers_specific_declare_element() -> None:
+    document = parse_excel(
+        _workbook({"装箱单": _element_vs_spec_sheet}),
+        file_id="el",
+        filename="el.xlsx",
+    )
+    items = map_sheet_goods(document.sheets[0], document)
+    assert items[0].value_of("gmodel") == "0|0|单层片式|陶瓷|无品牌|无型号"
+
+
+# ---- 码表反查兜底 ----
+
+
+def test_known_code_reverse_lookup() -> None:
+    codes = load_code_tables()
+    assert codes.known_code("海关口岸代码", "5304")
+    assert not codes.known_code("海关口岸代码", "9999")
+    assert not codes.lookup("海关口岸代码", "5304")  # 名称侧查不到
+
+
+def test_port_code_value_stays_accepted() -> None:
+    def sheet_fill(sheet) -> None:
+        sheet["A1"] = "出境备案清单"
+        sheet["A2"] = "出口口岸"
+        sheet["C2"] = "5304"
+        sheet["A3"] = "成交方式"
+        sheet["C3"] = "FOB"
+
+    document = parse_excel(
+        _workbook({"出境备案清单": sheet_fill}),
+        file_id="gsc",
+        filename="gsc.xlsx",
+    )
+    declaration = assemble_declaration(document)
+    field = declaration.head["iePort"]
+    assert field.value == "5304"
+    assert field.status.value == "accepted"
+    assert not field.validation_errors
+
+
+# ---- 别名目录 ----
+
+
+def test_issue66_aliases_present() -> None:
+    schema = load_schema()
+    anchors = {spec.name: spec.anchors for spec in (*schema.head, *schema.goods)}
+    assert "经营单位" in anchors["tradeName"]
+    assert "包装类型" in anchors["wrapType"]
+    assert "包裝种类" in anchors["wrapType"]
+    assert "申报海关" in anchors["customMaster"]
+    assert "账册号" in anchors["manualNo"]
+    assert "合約號碼" in anchors["contrNo"]
+    assert "貿易方式" in anchors["supvModeCdde"]
+    assert "淨重" in anchors["netWt"]
+    assert "序号" in anchors["gno"]
+    assert "申报数量" in anchors["gqty"]
+    assert "申报计量单位" in anchors["gunit"]
+    assert "申报单价" in anchors["declPrice"]
+    assert "申报总价" in anchors["declTotal"]
+    assert "金额" in anchors["declTotal"]
+    assert "目的国" in anchors["destinationCountry"]
+
+
+def test_vocab_gained_synced_aliases() -> None:
+    vocab = load_layout_vocab()
+    groups = {group.id: group for group in (*vocab.box, *vocab.kv)}
+    box_texts = {alias.text for group in vocab.box for alias in group.aliases}
+    assert "申报海关" in box_texts
+    assert "账册号" in box_texts
+    assert "貿易方式" in box_texts
+    assert "包裝种类" in box_texts
+    assert "淨    重" in box_texts
+    assert any(alias.text == "经营单位" for alias in groups["trade_party"].aliases)
+
+
+# ---- 真机样本（本地有才跑） ----
+
+
+@pytest.mark.skipif(not REAL_GSC.exists(), reason="本地 GSC 样本不在 CI")
+def test_gsc_sample_pure_code_routing() -> None:
+    document = parse_excel(
+        REAL_GSC.read_bytes(),
+        file_id="gsc-real",
+        filename=REAL_GSC.name,
+    )
+    declaration = assemble_declaration(document)
+    assert declaration.head["tradeCode"].value == "440356K004"
+    assert declaration.head["tradeName"].value == ""
+    assert declaration.head["tradeName"].status.value == "needs_review"
+    assert declaration.head["iePort"].value == "5304"
+    assert declaration.head["iePort"].status.value == "accepted"
+    assert declaration.head["packNo"].value == "230.000000"
+    assert declaration.head["grossWt"].value == "1560"
+    assert declaration.head["netWt"].value == "785.02760"
+    assert declaration.head["transMode"].value == "FOB"
+
+
+@pytest.mark.skipif(not REAL_GSRUA.exists(), reason="本地 GSRUA 样本不在 CI")
+def test_gsrua_sample_wrap_type_alias() -> None:
+    document = parse_excel(
+        REAL_GSRUA.read_bytes(),
+        file_id="gsrua-real",
+        filename=REAL_GSRUA.name,
+    )
+    declaration = assemble_declaration(document)
+    assert declaration.head["wrapType"].value == "胶合板箱,纸箱"
+    assert declaration.head["packNo"].value == "10"
+
+
+@pytest.mark.skipif(
+    sys.modules.get("xlrd") is None or not REAL_DUOKE.exists(),
+    reason="需要 xlrd 且本地多科样本不在 CI",
+)
+def test_duoke_sample_coded_labels_and_weights() -> None:
+    document = parse_excel(
+        REAL_DUOKE.read_bytes(),
+        file_id="dk-real",
+        filename=REAL_DUOKE.name,
+    )
+    declaration = assemble_declaration(document)
+    assert declaration.head["supvModeCdde"].value == "一般贸易"
+    assert declaration.head["cutMode"].value == "一般征税"
+    assert declaration.head["grossWt"].value == "625.45"
+    assert declaration.head["netWt"].value == "573.1"
+    assert declaration.head["packNo"].value == "42"
+    assert declaration.head["wrapType"].value == "纸箱/其他包装"
+    assert declaration.head["transMode"].value == "FOB"
+
+
+@pytest.mark.skipif(
+    sys.modules.get("xlrd") is None or not REAL_DONNELLEY.exists(),
+    reason="需要 xlrd 且本地当纳利样本不在 CI",
+)
+def test_donnelley_sample_traditional_keys() -> None:
+    document = parse_excel(
+        REAL_DONNELLEY.read_bytes(),
+        file_id="dnn-real",
+        filename=REAL_DONNELLEY.name,
+    )
+    invoice = next(sheet for sheet in document.sheets if sheet.name == "出口发票")
+    by_name = _by_name(map_sheet_head(invoice, document))
+    assert by_name["grossWt"].value == "19137"
+    assert by_name["netWt"].value == "17432"
+
+
+@pytest.mark.skipif(not REAL_TONDA2.exists(), reason="本地通达2 样本不在 CI")
+def test_tonda2_sample_row_level_weights() -> None:
+    document = parse_excel(
+        REAL_TONDA2.read_bytes(),
+        file_id="td2-real",
+        filename=REAL_TONDA2.name,
+    )
+    items = map_sheet_goods(document.sheets[0], document)
+    assert len(items) == 50
+    assert items[0].value_of("customNetWt") == "2.7"
+    assert items[1].value_of("customNetWt") == "10.62"
+    assert items[2].value_of("customNetWt") == "1.92"
+    assert items[0].value_of("gno") == "1"
+    assert items[0].value_of("customGrossWet") == "5.5"


### PR DESCRIPTION
Closes #66

## 改了什么

### 1. 键归一化（新增 `schema/textnorm.py`）
- 去全部空白（含换行）：「毛 重」「毛重\n（公斤）」→ 统一形状
- 全角/半角括号统一
- 键尾剥「（≤6 位字母数字）」码：「贸易方式（0110）」→「贸易方式」；「（地区）」「（公斤）」不剥
- 三侧统一：head_map 锚点、goods_map 列锚点、layout 词表匹配 + loader group_for_key。**值永远不动**，抽出的 KV key 仍是格子原文
- 落地位置说明：多科「贸易方式（0110）」此前连 KV 都抽不出（词表不认尾码标签），剥码落在 layout.py 匹配处是本 issue 键归一化的一部分

### 2. 纯代码值路由（`head_map.py`）
| 值形状 | 落点 |
|---|---|
| 整体 10 位海关码（GSC 经营单位 440356K004） | `*Code`；name 留空标 `pure_code_value` 待复核 |
| 整体 18 位信用代码（GSRUA 91330206MA2818T42Q） | `*Scc`（YAML 新增 `scc_target`）；name 同上 |
| 「（码）」括号壳 | 剥壳按码处理 |
| 名称+尾码（恒信 …公司441394164D） | 原 trailing_code 拆法不变 |

### 3. goods 列映射优先级（`goods_map.py`）
- 列归属恒定规则：锚点在 fields.yaml 先后（先专后泛，申报要素 > 规格型号 > 商品规格）> 锚点长度
- 同字段多列冲突才看数据形状：**常量列降级**（>1 行且非空值全相同 = 合计列）。通达2「总净重(千克)」（全表 1793.6065）不再抢「净重(千克)」；国光「总净重 NW」每行不同、不受影响
- 与用户对齐记录：纯锚点顺序无法同时答对通达2/国光（同字面冲突、相反赢家），常量列是唯一诚实判别器

### 4. 别名补齐（fields.yaml / layout_vocab.yaml，全部标来源）
- 表头：tradeName+经营单位；wrapType+包装类型/包裝种类；customMaster+申报海关；manualNo+账册号；grossWt/netWt+（公斤）/淨重变体；supvModeCdde+貿易方式；contrNo+合約號碼
- 商品列：gno+序号；gqty+申报数量；gunit+申报计量单位；declPrice+申报单价；declTotal+申报总价+金额；destinationCountry+目的国

### 5. 码表反查兜底（`assemble.py` + `CodeTables.known_code`）
值本身是码表合法 code（GSC iePort=5304=蛇口海关）→ 接受、payload 仍展示 5304，不再误报 unknown_code。

## 验收对照（issue 验收标准）

| 项 | 结果 |
|---|---|
| GSC | tradeCode=440356K004、tradeName 空（needs_review: pure_code_value）、iePort=5304 accepted、件数/毛重/净重/成交方式全部进对应字段 ✅ |
| 多科 | supvModeCdde=一般贸易、cutMode=一般征税、grossWt=625.45、netWt=573.1、packNo=42、wrapType=纸箱/其他包装、transMode=FOB ✅ |
| 当纳利出口发票 | 毛重=19137、净重=17432（繁体+多空格键命中）✅ |
| 通达2 | customNetWt 取「净重(千克)」列（2.7/10.62/1.92/…），不被「总净重(千克)」常量列抢走 ✅ |
| 现有测试 | 124 passed, 3 skipped（新增 test_anchor_normalize.py 20 例）✅ |
| 恒信/国光回归 | declare 全 JSON 输出与合并前逐字节一致 ✅ |

## 以后新 xlsx / 新叫法改哪

| 场景 | 改哪 | 动 Python 吗 |
|---|---|---|
| 新标签叫法 | fields.yaml / layout_vocab.yaml 加 alias | 否 |
| 新的「标签（码）」写法 | textnorm.py 剥码正则（常量） | 是 |
| 新的值形状（纯码/括号码） | head_map.py 值路由规则 | 是 |
| 列名带空白/换行/尾码 | 已被键归一化吃掉 | 否 |
| 「总净重」抢「净重」 | 常量列降级已处理；合计列每行不同时把专用列名写进 anchors 更前 | 否 |
| 值本身已是合法 code | assemble 反查兜底已接受 | 否 |