### PR TITLE
feat: 平表表列 → 表头字段（恒定列 + 表尾注记行治理）（#67）

### DIFF
--- a/docs/head-map.md
+++ b/docs/head-map.md
@@ -1,4 +1,4 @@
-# 表头映射（BOX / KV → TdecHead）
+# 表头映射（BOX / KV / 平表恒定列 → TdecHead）
 
 运行时：`extraction/head_map.py`。目录在 [`fields.yaml`](../src/docparse/schema/fields.yaml) 的 `head`。本地对眼：
 
@@ -6,20 +6,36 @@
 python -m docparse.cli head /绝对路径/表.xlsx
 ```
 
-本文件只回答「一张已经打好角色的 sheet，原文 KV 怎么变成表头字段」。不切格子（layout）、不认角色（#16）、不拼整单（#19）、不转 code（#14）。
+本文件只回答「一张已经打好角色的 sheet，原文怎么变成表头字段」。不切格子（layout）、不认角色（#16）、不拼整单（#19）、不转 code（#14）。
 
 ## 输入 / 输出
 
 ```text
-Sheet.key_values + consume
+Sheet.key_values / 恒定列 + consume
   → 只处理 consume ≠ exclude
-  → key 对 fields.yaml head.anchors（键归一化，见下）
+  → key / 表头列名 对 fields.yaml head.anchors（键归一化，见下）
   → ExtractedField（值先留原文，证据 = sheet 名 + 格子）
 ```
 
 一份 xlsx 有几张合格 sheet，就调用几次，结果**并排**。草单 `packNo=40` 和箱单上的件数不会在这一层互相覆盖。谁是主、谁补空是 #19。
 
 `auxiliary` / `unknown` 的 KV 留在 IR，本层不读。
+
+## 平表恒定列（#67）
+
+报关平表（一行一商品）没有框表 KV，表头级信息全在列里。第二条路径「表列 → 表头」：
+
+| 规则 | 说明 |
+|---|---|
+| 触发 | 角色 `head_from_columns: true`（[`sheet_roles.yaml`](../src/docparse/schema/sheet_roles.yaml)，目前仅 `declaration_list`）。框表角色不开，防商品表常量列误伤 |
+| 表 | 复用该 sheet 的最佳商品表（[`goods-map.md`](goods-map.md) 同一张） |
+| 恒定 | 该列非空值集合无冲突（只一个值）即恒定。合计列只填首行（通达2「总件数=272」只在第一行）也算 |
+| 行级防线 | 每行变化的列（件数 / 净重 / 毛重）值集合 >1，不出表头 |
+| 单行表 | 整表只有一行数据时恒定无法佐证，取值但标 `needs_review`（`single_row_column`） |
+| 证据 | 表头格 + 首个值格；发射复用 KV 路径（`trailing_code` / 纯码路由同样生效） |
+| 优先级 | 同字段 BOX KV 先、列后（`found` 先到先得） |
+
+配套：表尾冒号注记行（通达2 R52「境内发货人:…」）不进表体，格子留给 same_cell KV（layout 层 `_is_note_row`）。
 
 ## 键归一化（#66）
 
@@ -89,6 +105,10 @@ Sheet.key_values + consume
 | 键的叫法没见过，layout 都没拆出 | `layout_vocab.yaml` alias | 否 |
 | layout 有了，对不上报关字段 | 已有字段的 `anchors` | 否 |
 | 键带空白 / 换行 / 全角括号 / 尾码（`贸易方式（0110）`） | 已被键归一化吃掉，不用管 | 否 |
+| 平表新表头级列叫法（恒定列） | 已有字段的 `anchors` | 否 |
+| 恒定列判定想收紧（比如要求 ≥2 行同值） | `head_map.py` 常量 | 是 |
+| 其它角色也要走表列路径 | `sheet_roles.yaml` 该角色 `head_from_columns: true` | 否 |
+| 表尾冒号注记行误伤数据行 | `layout.py` `_is_note_row` | 是，通用规则 |
 | 新的「标签（码）」写法剥不掉 | `textnorm.py` 剥码正则 | 是，常量 |
 | 值是纯码 / 括号码，新形状 | `head_map.py` 值路由规则 | 是，通用规则 |
 | 语义是新表头字段 | `fields.yaml` 新字段 + anchors | 否（映射器按目录走） |

--- a/docs/sheet-roles.md
+++ b/docs/sheet-roles.md
@@ -9,7 +9,7 @@
 | 角色 | consume | 谁用 | #17 / #18 / #19 |
 |---|---|---|---|
 | `draft` | `primary` | 海关框表草单 / 出境备案清单 | 表头主源；主货表候选 |
-| `declaration_list` | `primary` | 扁平海关表（表头混表头字段 + 货列） | 与 draft 同权：主货表加权 10、overwrite；表头列映射交 #67 |
+| `declaration_list` | `primary` | 扁平海关表（表头混表头字段 + 货列） | 与 draft 同权：主货表加权 10、overwrite；表头经恒定列映射（`head_from_columns: true`，#67） |
 | `packing` | `supplement` | 箱单 | 只补空；核对件毛净 |
 | `invoice` | `supplement` | 发票 | 只补空 |
 | `contract` | `supplement` | 合同 | 只补空 |
@@ -50,6 +50,7 @@
 | 新叫法（「装箱明细」「形式发票」） | `sheet_roles.yaml` 已有 role 下加信号 | 否 |
 | 新单据类型（产地证、提单 sheet） | 新 `id` + `consume`；若要当主源再改 `fields.yaml` 的 `role_bonus` / `assembly` | 否（打分器已按目录走） |
 | 新的扁平海关表头 | `declaration_list.headers` | 否 |
+| 其它角色表头也在列里 | 该角色 `head_from_columns: true` | 否 |
 | 新辅助表长相对照 / 台账 | `auxiliary` 加表头或标题 | 否 |
 | 对不上 | 保持 unknown，整包复核 | 否 |
 | layout 键都没拆出来 | 先补 `layout_vocab.yaml` | 视词表 |

--- a/src/docparse/adapters/parsers/layout.py
+++ b/src/docparse/adapters/parsers/layout.py
@@ -70,6 +70,11 @@ def _detect_tables(cells: list[Cell]) -> list[Table]:
         for body_row in range(body_start, body_start + 200):
             if body_row not in by_row:
                 break
+            if _is_note_row(by_row[body_row]):
+                # 表尾注记行（整行都是同格冒号 KV，如通达2「境内发货人:…」）
+                # 不进表体：进了既污染恒定列判定，又把格子占住让 same_cell
+                # 接不住（#67）。表体到此为止，注记行不标 occupied。
+                break
             used_rows.add(body_row)
             values_by_col = {c.column: c.value for c in by_row[body_row]}
             record = {
@@ -90,6 +95,17 @@ def _detect_tables(cells: list[Cell]) -> list[Table]:
             )
         )
     return tables
+
+
+def _is_note_row(cells: list[Cell]) -> bool:
+    """表尾注记行：非空格全部能拆成同格冒号 KV。
+
+    数据行必有数值 / 日期格（拆不出冒号），不会整行全中。
+    """
+    non_empty = [cell for cell in cells if cell.value and cell.value.strip()]
+    if not non_empty:
+        return False
+    return all(_same_cell_colon(cell) is not None for cell in non_empty)
 
 
 def _compose_headers(row_cells: list[Cell], extra_cells: list[Cell]) -> list[str]:

--- a/src/docparse/extraction/goods_map.py
+++ b/src/docparse/extraction/goods_map.py
@@ -67,6 +67,11 @@ def map_sheet_goods(
     return items
 
 
+def best_goods_table(sheet: Sheet, schema: Schema) -> Table | None:
+    """该 sheet 的最佳商品表。head_map 表列路径（#67）复用同一张表。"""
+    return _best_table(sheet, schema)
+
+
 def _best_table(sheet: Sheet, schema: Schema) -> Table | None:
     scored: list[tuple[int, Table]] = []
     for table in sheet.tables:

--- a/src/docparse/extraction/head_map.py
+++ b/src/docparse/extraction/head_map.py
@@ -1,12 +1,13 @@
-"""单 sheet：版面 KV → 表头字段。不合并多 sheet，不转 code，不填 agent*。"""
+"""单 sheet：版面 KV / 平表恒定列 → 表头字段。不合并多 sheet，不转 code，不填 agent*。"""
 
 from __future__ import annotations
 
 import re
 
 from docparse.domain.fields import ExtractedField, FieldStatus
-from docparse.domain.ir import DocumentIR, Evidence, KeyValue, Sheet
-from docparse.schema.loader import FieldSpec, Schema, load_schema
+from docparse.domain.ir import DocumentIR, Evidence, KeyValue, Sheet, Table
+from docparse.extraction.goods_map import best_goods_table
+from docparse.schema.loader import FieldSpec, Schema, load_schema, load_sheet_roles
 from docparse.schema.textnorm import fold_key
 
 _TRAILING_CUSTOMS_CODE = re.compile(r"^(.*?)([A-Za-z0-9]{10})$")
@@ -17,6 +18,12 @@ _CODE_SHELL = re.compile(r"^[（(]\s*([A-Za-z0-9]+)\s*[)）]$")
 _SKIP_CONSUME = frozenset({"exclude"})
 _HEAD_LAYOUTS = frozenset({"box_kv"})
 _CALLER_PREFIX = "agent"
+_COLUMN_STRATEGY = "column"
+# 恒定列判定（#67）：非空值集合无冲突（只一个值）即恒定。合计列常只填
+# 首行（通达2 总件数=272 只在第一行），照样恒定；每行变化的行级列
+# （件数 / 净重 / 毛重）值集合 >1，天然被拦。
+_CONSTANT_MAX_VALUES = 1
+_SINGLE_ROW_ERROR = "single_row_column"
 
 
 def map_document_head(
@@ -51,7 +58,91 @@ def map_sheet_head(
             for field in _emit(spec, pair, sheet, document, schema):
                 if field.name not in found:
                     found[field.name] = field
+    if _columns_enabled(sheet):
+        _head_from_columns(sheet, document, schema, index, found)
     return list(found.values())
+
+
+def _columns_enabled(sheet: Sheet) -> bool:
+    """表列路径只对显式声明 head_from_columns 的角色开（#67 默认仅平表）。
+
+    框表 sheet 不走，防商品表常量列误伤表头 KV。
+    """
+    role = load_sheet_roles().role(sheet.role)
+    return role is not None and role.head_from_columns
+
+
+def _head_from_columns(
+    sheet: Sheet,
+    document: DocumentIR,
+    schema: Schema,
+    index: dict[str, list[FieldSpec]],
+    found: dict[str, ExtractedField],
+) -> None:
+    """平表恒定列 → 表头字段（#67）。
+
+    恒定 = 该列非空值集合无冲突（合计列只填首行也算）。每行变化的列
+    （件数 / 净重 / 毛重）是行级信息，不出表头。整表只有一行数据时
+    恒定性无法佐证，取值但标 needs_review。
+    """
+    table = best_goods_table(sheet, schema)
+    if table is None:
+        return
+    single_row = len(table.rows) == 1
+    for column, header in enumerate(table.headers):
+        if not header.strip():
+            continue
+        values = _column_values(table, column)
+        if not values:
+            continue
+        unique = {text for text, _ in values}
+        if len(unique) > _CONSTANT_MAX_VALUES:
+            continue
+        value, first_row = values[0]
+        pair = _column_pair(table, column, header, value, first_row)
+        for spec in index.get(fold_key(header), []):
+            if spec.name in found:
+                continue
+            for field in _emit(spec, pair, sheet, document, schema):
+                if field.name not in found:
+                    if single_row:
+                        field.status = FieldStatus.NEEDS_REVIEW
+                        field.validation_errors = [
+                            *field.validation_errors,
+                            _SINGLE_ROW_ERROR,
+                        ]
+                    found[field.name] = field
+
+
+def _column_values(table: Table, column: int) -> list[tuple[str, int]]:
+    """该列的非空值及所在数据行序，按行序。"""
+    header = table.headers[column]
+    values: list[tuple[str, int]] = []
+    for row_index, row in enumerate(table.rows):
+        text = (row.get(header) or "").strip()
+        if text:
+            values.append((text, row_index))
+    return values
+
+
+def _column_pair(table: Table, column: int, header: str, value: str, row: int) -> KeyValue:
+    """把「表头格 + 首个值格」包成 KeyValue，复用 KV 发射（拆码 / 纯码路由同路径）。"""
+    return KeyValue(
+        key=header,
+        value=value,
+        key_cell=table.header_cells[column] if column < len(table.header_cells) else header,
+        value_cell=_column_cell(table, column, row) or header,
+        strategy=_COLUMN_STRATEGY,
+    )
+
+
+def _column_cell(table: Table, column: int, row_index: int) -> str | None:
+    if column >= len(table.header_cells):
+        return None
+    letters = "".join(char for char in table.header_cells[column] if char.isalpha())
+    if not letters or not table.header_rows:
+        return None
+    return f"{letters}{table.header_rows[-1] + 1 + row_index}"
 
 
 def _anchor_index(schema: Schema) -> dict[str, list[FieldSpec]]:

--- a/src/docparse/schema/fields.yaml
+++ b/src/docparse/schema/fields.yaml
@@ -451,7 +451,7 @@ head:
     sources: [customs_declaration]
     anchors: [申报地海关, 申报海关]
     code_table: 海关口岸代码
-    notes: 四位关区。见 port_mapping。草单不一定有独立格。申报海关为通达2 叫法（#66）。
+    notes: 四位关区。见 port_mapping。草单不一定有独立格。申报海关为通达2 叫法（#66），平表经恒定列出本字段（#67）。
 
   - name: iePort
     display_name: 进/出口口岸
@@ -607,8 +607,8 @@ head:
     layout: box_kv
     value_type: number
     sources: [customs_declaration, packing_list]
-    anchors: [件数]
-    notes: 恒信草单公式引用装箱单。有海关框表以框表为准，箱单补充。
+    anchors: [件数, 总件数]
+    notes: 恒信草单公式引用装箱单。有海关框表以框表为准，箱单补充。平表取「总件数」恒定列，不取每行件数（#67）。
 
   - name: grossWt
     display_name: 毛重(公斤)
@@ -616,8 +616,8 @@ head:
     layout: box_kv
     value_type: number
     sources: [customs_declaration, packing_list]
-    anchors: [毛重（千克）, 毛重(千克), 毛重, 毛重（公斤）, 毛重(公斤)]
-    notes: "框表优先。别名 G.W. 交 #13。只有净重时不把净重抄进本字段，见 assembly.weight。（公斤）变体来自多科（#66）。"
+    anchors: [毛重（千克）, 毛重(千克), 毛重, 毛重（公斤）, 毛重(公斤), 总毛重（千克）, 总毛重(千克)]
+    notes: "框表优先。别名 G.W. 交 #13。只有净重时不把净重抄进本字段，见 assembly.weight。（公斤）变体来自多科（#66）；总毛重为通达2 平表恒定列（#67）。"
 
   - name: netWt
     display_name: 净重(公斤)
@@ -625,8 +625,8 @@ head:
     layout: box_kv
     value_type: number
     sources: [customs_declaration, packing_list]
-    anchors: [净重（千克）, 净重(千克), 净重, 净重（公斤）, 净重(公斤), 淨重, 淨重（公斤）, 淨重(公斤)]
-    notes: "框表优先。别名 N.W. 交 #13。只有净重、没有毛重时视同重量，只进本字段。（公斤）变体来自多科；淨重变体来自当纳利出口发票（繁体，#66）。"
+    anchors: [净重（千克）, 净重(千克), 净重, 净重（公斤）, 净重(公斤), 淨重, 淨重（公斤）, 淨重(公斤), 总净重（千克）, 总净重(千克)]
+    notes: "框表优先。别名 N.W. 交 #13。只有净重、没有毛重时视同重量，只进本字段。（公斤）变体来自多科；淨重变体来自当纳利出口发票（繁体，#66）；总净重为通达2 平表恒定列（#67）。"
 
   - name: transMode
     display_name: 成交方式

--- a/src/docparse/schema/loader.py
+++ b/src/docparse/schema/loader.py
@@ -248,6 +248,8 @@ class SheetRole(BaseModel):
     id: str
     consume: str
     lookup_pairs: bool = False
+    # 表头字段允许从商品表恒定列取值（#67 平表路径）。只对显式声明的角色开。
+    head_from_columns: bool = False
     signals: RoleSignals = Field(default_factory=RoleSignals)
 
     @model_validator(mode="after")

--- a/src/docparse/schema/sheet_roles.yaml
+++ b/src/docparse/schema/sheet_roles.yaml
@@ -101,6 +101,7 @@ roles:
 
   - id: declaration_list
     consume: primary
+    head_from_columns: true  # 表头级信息在列里（#67）：恒定列 → 表头字段
     signals:
       titles: []
       keys: []

--- a/tests/test_head_from_columns.py
+++ b/tests/test_head_from_columns.py
@@ -1,0 +1,265 @@
+"""平表表列 → 表头字段（#67）。
+
+覆盖：恒定列出字段、每行变化列不出、合计只填首行、单行数据 review、
+表尾冒号注记行走 same_cell、框表角色不走列路径、真机通达2。
+"""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("openpyxl")
+
+from openpyxl import Workbook
+from openpyxl.styles import Border, Side
+
+from docparse.adapters.parsers.excel import parse_excel
+from docparse.extraction.head_map import map_sheet_head
+from docparse.schema.loader import load_schema, load_sheet_roles
+
+_SUPPLY = Path("/Users/baldwin/Desktop/taizhou/补充测试")
+REAL_TONGDA = _SUPPLY / "通达2.xlsx"
+
+_HEADERS = [
+    "申报海关",
+    "账册号",
+    "申报计量单位",
+    "第一法定数量",
+    "总件数",
+    "总净重(千克)",
+    "总毛重(千克)",
+    "序号",
+    "商品编码",
+    "商品名称",
+    "申报数量",
+    "件数",
+    "净重(千克)",
+    "毛重(千克)",
+    "申报日期",
+    "出口口岸",
+    "监管方式",
+    "征免性质",
+    "包装类型",
+    "成交方式",
+    "贸易国(地区)",
+    "指运港",
+    "离境口岸",
+]
+
+
+def _thin() -> Border:
+    line = Side(style="thin")
+    return Border(left=line, right=line, top=line, bottom=line)
+
+
+def _workbook(builders: dict) -> bytes:
+    book = Workbook()
+    first = True
+    for title, fill in builders.items():
+        sheet = book.active if first else book.create_sheet(title)
+        if first:
+            sheet.title = title
+            first = False
+        fill(sheet)
+    buffer = io.BytesIO()
+    book.save(buffer)
+    return buffer.getvalue()
+
+
+def _flat_rows(total_first_only: bool = False) -> list[list]:
+    rows = [
+        ["东兴海关", "H1234", "个", "10", "272", "1793.6", "2045.2",
+         "1", "8532221000", "电容", "3000", "4", "2.7", "4.6",
+         "2026/08/13", "东兴海关", "一般贸易", "一般征税", "纸制或纤维板制盒/箱",
+         "FOB", "越南", "越南", "东兴"],
+        ["东兴海关", "H1234", "个", "5", "272", "1793.6", "2045.2",
+         "2", "8532221000", "电容", "1500", "2", "1.3", "2.2",
+         "2026/08/13", "东兴海关", "一般贸易", "一般征税", "纸制或纤维板制盒/箱",
+         "FOB", "越南", "越南", "东兴"],
+        ["东兴海关", "H1234", "个", "8", "272", "1793.6", "2045.2",
+         "3", "8544422900", "喇叭线", "3900", "6", "3.4", "5.1",
+         "2026/08/13", "东兴海关", "一般贸易", "一般征税", "纸制或纤维板制盒/箱",
+         "FOB", "越南", "越南", "东兴"],
+    ]
+    if total_first_only:
+        # 合计只填首行（通达2 真实形状）
+        for row in rows[1:]:
+            for col in (4, 5, 6):  # 总件数 / 总净重 / 总毛重
+                row[col] = ""
+    return rows
+
+
+def _flat_sheet(rows: list[list], notes: bool = True) -> None:
+    def fill(sheet) -> None:
+        for index, header in enumerate(_HEADERS, start=1):
+            sheet.cell(1, index, header)
+        for r, row in enumerate(rows, start=2):
+            for c, value in enumerate(row, start=1):
+                if value != "":
+                    sheet.cell(r, c, value)
+        last = len(rows) + 1
+        if notes:
+            sheet.cell(last + 1, 1, "境内发货人:惠州市通达国际供应链管理有限公司")
+            sheet.cell(last + 2, 1, "境外收货人:TONLY ELECTRONICS TECHNOLOGY VIET NAM")
+            last += 2
+        for row in sheet.iter_rows(min_row=1, max_row=last, min_col=1, max_col=len(_HEADERS)):
+            for cell in row:
+                cell.border = _thin()
+
+    return fill
+
+
+def _draft_with_constant_column(sheet) -> None:
+    """框表草单：商品表带恒定「监管方式」列，但 KV 里没有监管方式。
+
+    draft 未声明 head_from_columns，列路径必须不开，supvModeCdde 不得出现。
+    """
+    sheet["A1"] = "中华人民共和国海关出口货物报关单"
+    sheet["A3"] = "境内发货人"
+    sheet["A4"] = "惠州市恒德信精密科技有限公司"
+    sheet["A5"] = "境外收货人"
+    sheet["A6"] = "BLU PRECISION LIMITED"
+    goods_headers = ["项号", "商品编号", "商品名称及规格型号", "监管方式"]
+    for index, header in enumerate(goods_headers, start=1):
+        sheet.cell(17, index, header)
+    for row_index, item_no in enumerate((1, 2, 3), start=18):
+        sheet.cell(row_index, 1, item_no)
+        sheet.cell(row_index, 2, "9111900000")
+        sheet.cell(row_index, 3, "电容")
+        sheet.cell(row_index, 4, "一般贸易")
+    for row in sheet.iter_rows(min_row=1, max_row=20, min_col=1, max_col=4):
+        for cell in row:
+            cell.border = _thin()
+
+
+def _parse(fill, *, title="Sheet1", file_id="fx", filename="fixture.xlsx"):
+    document = parse_excel(_workbook({title: fill}), file_id=file_id, filename=filename)
+    return document, document.sheets[0]
+
+
+def _by_name(fields) -> dict:
+    return {item.name: item for item in fields}
+
+
+def test_sheet_roles_flag_declaration_list_head_from_columns() -> None:
+    roles = load_sheet_roles()
+    role = roles.role("declaration_list")
+    assert role is not None and role.head_from_columns
+    draft = roles.role("draft")
+    assert draft is not None and not draft.head_from_columns
+
+
+def test_constant_columns_map_head_fields() -> None:
+    document, sheet = _parse(_flat_sheet(_flat_rows()))
+    assert sheet.role == "declaration_list"
+    by_name = _by_name(map_sheet_head(sheet, document))
+    assert by_name["customMaster"].value == "东兴海关"
+    assert by_name["iePort"].value == "东兴海关"
+    assert by_name["declDate"].value == "2026/08/13"
+    assert by_name["supvModeCdde"].value == "一般贸易"
+    assert by_name["cutMode"].value == "一般征税"
+    assert by_name["wrapType"].value == "纸制或纤维板制盒/箱"
+    assert by_name["transMode"].value == "FOB"
+    assert by_name["cusTradeNationCode"].value == "越南"
+    assert by_name["distinatePort"].value == "越南"
+    assert by_name["ciqEntyPortCode"].value == "东兴"
+    assert by_name["packNo"].value == "272"
+    assert by_name["grossWt"].value == "2045.2"
+    assert by_name["netWt"].value == "1793.6"
+    for name in ("packNo", "grossWt", "netWt", "declDate", "customMaster"):
+        field = by_name[name]
+        assert field.status.value == "accepted"
+        assert field.evidence[0].cell.startswith("Sheet1!")
+        assert field.evidence[0].quote.startswith("Sheet1!")
+
+
+def test_totals_written_only_on_first_row_still_map() -> None:
+    """合计列只填首行（通达2 真实形状）：无冲突值即恒定。"""
+    document, sheet = _parse(_flat_sheet(_flat_rows(total_first_only=True)))
+    by_name = _by_name(map_sheet_head(sheet, document))
+    assert by_name["packNo"].value == "272"
+    assert by_name["grossWt"].value == "2045.2"
+    assert by_name["netWt"].value == "1793.6"
+    assert by_name["packNo"].status.value == "accepted"
+
+
+def test_variable_columns_do_not_map() -> None:
+    """每行变化的件数 / 净重 / 毛重是行级信息，不出表头。"""
+    document, sheet = _parse(_flat_sheet(_flat_rows()))
+    by_name = _by_name(map_sheet_head(sheet, document))
+    assert by_name["packNo"].value == "272"  # 取总件数，不是行级 4/2/6
+    assert by_name["netWt"].value == "1793.6"
+    assert by_name["grossWt"].value == "2045.2"
+
+
+def test_single_row_table_marks_needs_review() -> None:
+    document, sheet = _parse(_flat_sheet(_flat_rows()[:1]))
+    by_name = _by_name(map_sheet_head(sheet, document))
+    assert by_name["declDate"].value == "2026/08/13"
+    assert by_name["declDate"].status.value == "needs_review"
+    assert "single_row_column" in by_name["declDate"].validation_errors
+
+
+def test_trailing_note_rows_become_same_cell_kv() -> None:
+    """表尾冒号注记行不进表体，走 same_cell：tradeName / consignorEname 有值。"""
+    document, sheet = _parse(_flat_sheet(_flat_rows()))
+    table = sheet.tables[0]
+    assert len(table.rows) == 3  # 注记行不在表体
+    pairs = {pair.key: pair for pair in sheet.key_values}
+    assert pairs["境内发货人"].value == "惠州市通达国际供应链管理有限公司"
+    assert pairs["境内发货人"].strategy == "same_cell"
+    assert pairs["境外收货人"].value.startswith("TONLY ELECTRONICS")
+    by_name = _by_name(map_sheet_head(sheet, document))
+    assert by_name["tradeName"].value == "惠州市通达国际供应链管理有限公司"
+    assert by_name["consignorEname"].value.startswith("TONLY ELECTRONICS")
+
+
+def test_draft_role_never_reads_columns() -> None:
+    """框表角色不声明 head_from_columns：商品表常量列不出表头字段。"""
+    document, sheet = _parse(_draft_with_constant_column, title="一般贸易出口")
+    assert sheet.role == "draft"
+    by_name = _by_name(map_sheet_head(sheet, document))
+    assert "supvModeCdde" not in by_name
+    assert by_name["tradeName"].value == "惠州市恒德信精密科技有限公司"
+
+
+def test_schema_total_anchors_registered() -> None:
+    schema = load_schema()
+    assert "总件数" in schema.field("packNo").anchors
+    assert "总毛重（千克）" in schema.field("grossWt").anchors
+    assert "总毛重(千克)" in schema.field("grossWt").anchors
+    assert "总净重（千克）" in schema.field("netWt").anchors
+    assert "总净重(千克)" in schema.field("netWt").anchors
+    assert "申报海关" in schema.field("customMaster").anchors
+
+
+@pytest.mark.skipif(not REAL_TONGDA.exists(), reason="本地通达2 样本不在 CI")
+def test_real_tongda_head_from_columns() -> None:
+    document = parse_excel(
+        REAL_TONGDA.read_bytes(),
+        file_id="td-real",
+        filename=REAL_TONGDA.name,
+    )
+    sheet = document.sheets[0]
+    assert sheet.role == "declaration_list"
+    by_name = _by_name(map_sheet_head(sheet, document))
+    assert by_name["declDate"].value == "2026/08/13"
+    assert by_name["iePort"].value == "东兴海关"
+    assert by_name["customMaster"].value == "东兴海关"
+    assert by_name["supvModeCdde"].value == "一般贸易"
+    assert by_name["cutMode"].value == "一般征税"
+    assert by_name["wrapType"].value == "纸制或纤维板制盒/箱"
+    assert by_name["transMode"].value == "FOB"
+    assert by_name["cusTradeNationCode"].value == "越南"
+    assert by_name["cusTradeCountry"].value == "越南"
+    assert by_name["distinatePort"].value == "越南"
+    assert by_name["ciqEntyPortCode"].value == "东兴"
+    assert by_name["packNo"].value == "272"
+    assert by_name["grossWt"].value == "2045.266"
+    assert by_name["netWt"].value == "1793.6065"
+    assert by_name["tradeName"].value == "惠州市通达国际供应链管理有限公司"
+    assert by_name["consignorEname"].value.startswith("TONLY ELECTRON")
+    assert by_name["packNo"].status.value == "accepted"


### PR DESCRIPTION
Closes #67

## 做了什么

报关平表（`declaration_list`）没有框表 KV，表头级信息全在列里。本 PR 给 `head_map.py` 加第二条路径「表列 → 表头」：

1. **触发**：角色显式声明 `head_from_columns: true`（`sheet_roles.yaml` 新开关，目前仅 `declaration_list`）。框表角色不开，防商品表常量列误伤表头 KV。
2. **表**：复用该 sheet 的最佳商品表（`goods_map.best_goods_table` 公开），与货映射同一张表。
3. **恒定判定**：该列非空值集合无冲突（只一个值）即恒定 → 按首值出字段，证据带表头格 + 首个值格；发射复用 KV 路径（`trailing_code` / 纯码路由同样生效）。
4. **行级防线**：每行变化的列（件数 / 净重 / 毛重）值集合 >1，不出表头。
5. **单行表**：整表只有一行数据时恒定无法佐证，取值但标 `needs_review`（`single_row_column`）。
6. **表尾注记行**：通达2 R52/R53「境内发货人:… / 境外收货人:…」真机上被表格吞进表体（格子被占住 + 污染恒定列），layout 层补 `_is_note_row`（整行非空格全是同格冒号 KV → 表体截断、格子留给 same_cell）——issue 预期的现有路径由此真正接住。
7. **字段登记**：`fields.yaml` packNo/grossWt/netWt 增补 总件数 / 总毛重（千克）/ 总净重（千克）（全半角）锚点；customMaster 的「申报海关」落地（#66 已加）。

## 与 Issue 方案的一处有意偏离（需业务知悉）

Issue 原文恒定判定是「非空值在 **≥2 行**上完全一致」。真机通达2 的总件数/总净重/总毛重是**合计只填首行**（50 行里只有第 1 行有值 272 / 1793.6065 / 2045.266），按 ≥2 行会把验收要求的 packNo/grossWt/netWt 全拦掉。故改为**值集合唯一即恒定**：合计只填首行也算，行级列（每行不同）仍被值集合 >1 拦住。要收紧改 `head_map.py` 常量 `_CONSTANT_MAX_VALUES`。

## 验收

- 通达2 declaration：declDate=2026/08/13、iePort=东兴海关、customMaster=东兴海关、supvModeCdde=一般贸易、cutMode=一般征税、wrapType=纸制或纤维板制盒/箱、transMode=FOB、cusTradeNationCode=越南、cusTradeCountry=越南、distinatePort=越南、ciqEntyPortCode=东兴、packNo=272、grossWt=2045.266、netWt=1793.6065、tradeName=惠州市通达国际供应链管理有限公司（表尾 KV）、consignorEname=TONLY ELECTRON…（表尾 KV）——**全过**；码表转换正常（东兴海关=7207、越南=VNM、FOB=3）。
- 商品行不受影响：50 行，gqty 取申报数量列，customNetWt 取净重(千克)列。
- 新增单测 9 个：恒定列出字段、合计只填首行、非恒定列不出、单行 needs_review、表尾注记行 same_cell + 不进表体、draft 不走列路径、真机通达2（skipif）。
- 全量 133 passed / 3 skipped；恒信/国光/MXY/GSC/GSRUA 头字段与货行数**零回归**（改动前后逐字段对比）。

## 以后新 xlsx / 新叫法改哪

| 场景 | 改哪 | 动 Python？ |
|---|---|---|
| 平表新表头级列叫法（恒定列） | `fields.yaml` 已有字段 `anchors` | 否 |
| 恒定列判定想收紧（如要求 ≥2 行同值） | `head_map.py` 常量 `_CONSTANT_MAX_VALUES` | 是 |
| 其它角色表头也在列里 | `sheet_roles.yaml` 该角色 `head_from_columns: true` | 否 |
| 表尾冒号注记行误伤数据行 | `layout.py` `_is_note_row` | 是，通用规则 |
| 表尾注记新形状（非冒号） | `layout.py` `_is_note_row` | 是 |
| 单行表复核标记语义 | `head_map.py` `_SINGLE_ROW_ERROR` | 是 |