### PR TITLE
feat: 千克行同表成交数量取净重（#75）

### DIFF
--- a/docs/goods-map.md
+++ b/docs/goods-map.md
@@ -87,6 +87,9 @@ Sheet.tables + consume
 | 明确毛重 / G.W. / 总毛重 | `customGrossWet` |
 | 未区分的重量 | `customNetWt`；没有毛重列则 `customGrossWet` 空着 |
 | 法定第一数量 | 才进 `qty1` |
+| 成交数量（#75） | 单位在 `weight_units` 且同行有净重 → `gqty` 取净重（数量PCS / 件数不进成交数量）。没有净重则数量列原值。没有数量列不编 |
+
+同表改写在跨表补空之后、出门之前。补空本身仍用改写前的件数，件数过不了净重闸（#56）。已与净重一致则不改证据。
 
 表头整单件毛净交 #19。箱数不加商品字段。
 
@@ -127,6 +130,7 @@ Sheet.tables + consume
 | 某列不要从副表抄（默认无） | `goods_master.skip_fill` | 否 |
 | 哪些列要过数量闸（数量链） | `goods_master.gated_fields` | 否 |
 | 千克行数量补值须≈净重、毛重补值须≥净重 | 内置规则，容差同 `qty_*` | 否 |
+| 千克行同表成交数量取净重（#75） | 内置规则；千克词表仍是 `weight_units` | 否 |
 | 新合计叫法（如 GRAND TOTAL） | `goods_master.total_row_tokens` | 否 |
 | 续行落在其它已占字段且非申报要素形状 | `goods_map.py` `_route_leftovers` 补形状判定 | 是，通用规则 |
 | 三行以上叠列（四行一项） | 续行判定天然支持，验收补样本 | 否 |

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -66,7 +66,7 @@ sheet 角色（#16 / #65）：`schema/sheet_roles.yaml` + `extraction/sheet_role
 
 表头映射（#17）：`extraction/head_map.py` 吃已拆 `key_values`，按 `fields.yaml` 的 `anchors` / `head_map` 写成 TdecHead 候选。一次一张 sheet，多 sheet 并排放，不覆盖。`agent*` 不从文件填。中文值不转 code。名称+10 位海关代码用 `trailing_code`。运费 / 航次 / 唛码拆分见 #34–#36，发票号槽位见 #37。本地对眼：`python -m docparse.cli head file.xlsx`。见 [head-map.md](head-map.md)。
 
-商品映射（#18 / #48 / #52 / #68）：`extraction/goods_map.py` 吃已拆 `tables`，按 `fields.yaml` 的 `goods.anchors` / `goods_map` / `goods_master` 写成货行。先选主货表；跨表按行序对齐，数量对上才补空，主表已有值不覆盖。有项号列的海关表：无税号且项号空/0/同号的行并入上一件；合计行按 `total_row_tokens` 整行丢弃。`auxiliary` / `unknown` 不读。重量未区分当净重；没有毛重列则毛重空着。申报要素原文进 `gmodel`，不编 `0|0|...`。箱数不加字段。本地对眼：`python -m docparse.cli goods file.xlsx`。见 [goods-map.md](goods-map.md)。
+商品映射（#18 / #48 / #52 / #68 / #75）：`extraction/goods_map.py` 吃已拆 `tables`，按 `fields.yaml` 的 `goods.anchors` / `goods_map` / `goods_master` 写成货行。先选主货表；跨表按行序对齐，数量对上才补空，主表已有值不覆盖。有项号列的海关表：无税号且项号空/0/同号的行并入上一件；合计行按 `total_row_tokens` 整行丢弃。`auxiliary` / `unknown` 不读。重量未区分当净重；没有毛重列则毛重空着。千克行同时有数量和净重时，成交数量取净重。申报要素原文进 `gmodel`，不编 `0|0|...`。箱数不加字段。本地对眼：`python -m docparse.cli goods file.xlsx`。见 [goods-map.md](goods-map.md)。
 
 整单组装（#19）：`extraction/assemble.py` 按 `fields.yaml` 的 `assembly` 收成一张报关单。有 `draft` 抄草单，商业单据只补空并核件毛净；无草单只抄能确定的商业事实，`customs_only` 空着复核。名称转 code；转不出留原文。`agent*` 只来自调用参数。表头只有净重时视同重量，不抄进毛重。本地对眼：`python -m docparse.cli declare file.xlsx`。见 [assemble.md](assemble.md)。
 

--- a/src/docparse/extraction/goods_map.py
+++ b/src/docparse/extraction/goods_map.py
@@ -23,7 +23,7 @@ def map_document_goods(
     schema = schema or load_schema()
     mapped: list[tuple[Sheet, list[GoodsItem], int]] = []
     for sheet in document.sheets:
-        items = map_sheet_goods(sheet, document, schema)
+        items = _map_sheet_goods(sheet, document, schema)
         if not items:
             continue
         mapped.append((sheet, items, items[0].master_score))
@@ -41,6 +41,8 @@ def map_document_goods(
             if sheet is master_sheet:
                 continue
             _merge_by_order(merged, items, schema)
+    for item in merged:
+        _prefer_net_as_qty(item, schema)
     return merged
 
 
@@ -50,6 +52,17 @@ def map_sheet_goods(
     schema: Schema | None = None,
 ) -> list[GoodsItem]:
     schema = schema or load_schema()
+    items = _map_sheet_goods(sheet, document, schema)
+    for item in items:
+        _prefer_net_as_qty(item, schema)
+    return items
+
+
+def _map_sheet_goods(
+    sheet: Sheet,
+    document: DocumentIR,
+    schema: Schema,
+) -> list[GoodsItem]:
     if sheet.consume in _SKIP_CONSUME:
         return []
     table = _best_table(sheet, schema)
@@ -424,6 +437,26 @@ def _close(left: float, right: float, schema: Schema) -> bool:
     delta = abs(left - right)
     scale = max(abs(left), abs(right), 1.0)
     return delta <= policy.qty_abs_tol or delta <= policy.qty_rel_tol * scale
+
+
+def _prefer_net_as_qty(item: GoodsItem, schema: Schema) -> None:
+    """千克行同时有数量和净重时，成交数量取净重。件数列（数量PCS）不进 gqty。
+
+    已与净重一致则不改证据。没有数量列不编；没有净重则保持原 gqty
+    （当纳利：数量列本身就是千克）。
+    """
+    if not _is_weight_unit(item.value_of("gunit"), schema):
+        return
+    if item.value_of("gqty") is None:
+        return
+    net_field = item.fields.get("customNetWt")
+    net = _as_number(item.value_of("customNetWt"))
+    if net_field is None or net is None:
+        return
+    current = _as_number(item.value_of("gqty"))
+    if current is not None and _close(net, current, schema):
+        return
+    item.fields["gqty"] = _retarget(net_field, "gqty", "成交数量")
 
 
 def _qty_of(item: GoodsItem, schema: Schema | None = None) -> float | None:

--- a/src/docparse/schema/fields.yaml
+++ b/src/docparse/schema/fields.yaml
@@ -845,7 +845,7 @@ goods:
     value_type: number
     sources: [customs_declaration, packing_list, invoice]
     anchors: [出货数量, 成交数量, 数量, Quantity, Q'ty, Qty, 申报数量]
-    notes: 海关商品表优先。别名交 #13。千克行跨表补数量，候选值须与净重一致（goods_master 容差）。申报数量为通达2 叫法（#66）。
+    notes: 海关商品表优先。别名交 #13。千克行同表有净重时成交数量取净重（#75）；跨表补数量，候选值须与净重一致（goods_master 容差）。申报数量为通达2 叫法（#66）。
 
   - name: gunit
     display_name: 成交单位

--- a/tests/test_goods_map.py
+++ b/tests/test_goods_map.py
@@ -22,6 +22,7 @@ REAL_GSRUA = _SUPPLY / "GSRUA26601CLLG01(1).xlsx"
 REAL_DONNELLEY = _SUPPLY / "202606 R26JU551-Y报关一般.xls"
 REAL_MXY = _SUPPLY / "MXY2026-0616 东莞-越南物料 一般出口报关资料 UPS 更新.xlsx"
 REAL_DUOKE = _SUPPLY / "6-17 多科报关资料香港出货 DKTX-2606057 多科通讯乐乐高(1).xls"
+REAL_BLU_IN = _SUPPLY / "进料加工出口报关单-BLU-HDX260271(1).xlsx"
 
 
 def _thin() -> Border:
@@ -377,6 +378,64 @@ def test_kg_row_fills_qty_only_when_close_to_net() -> None:
     assert item.fields["gqty"].evidence[0].cell.startswith("发票!")
     assert item.value_of("customGrossWet") == "7.35"
     assert item.fields["customGrossWet"].evidence[0].cell.startswith("装箱单!")
+
+
+def test_kg_row_same_table_qty_takes_net_not_pcs() -> None:
+    """同行同时有重量、数量PCS、计价单位=千克：成交数量取净重。"""
+
+    def kg_pcs_draft(sheet) -> None:
+        _draft(sheet)
+        sheet["E18"] = 5000
+        sheet["F18"] = "千克"
+        sheet["G18"] = 205
+        sheet["H18"] = 3810
+        sheet["I18"] = 781050
+
+    document = parse_excel(
+        _workbook({"一般贸易出口": kg_pcs_draft}),
+        file_id="kgpcs",
+        filename="kg-pcs.xlsx",
+    )
+    items = map_document_goods(document)
+    item = items[0]
+    assert item.value_of("gunit") == "千克"
+    assert item.value_of("customNetWt") == "205"
+    assert item.value_of("gqty") == "205"
+    assert "重量KG" in (item.fields["gqty"].evidence[0].quote or "")
+    assert item.value_of("declPrice") == "3810"
+    assert item.value_of("declTotal") == "781050"
+
+
+def test_piece_unit_keeps_pcs_qty() -> None:
+    document = parse_excel(
+        _workbook({"一般贸易出口": _draft}),
+        file_id="pcs",
+        filename="pcs.xlsx",
+    )
+    item = map_document_goods(document)[0]
+    assert item.value_of("gunit") == "只"
+    assert item.value_of("gqty") == "150"
+    assert item.value_of("customNetWt") == "5.74"
+
+
+def test_kg_row_without_net_keeps_qty() -> None:
+    def kg_qty_only(sheet) -> None:
+        _draft(sheet)
+        sheet["E18"] = 17432
+        sheet["F18"] = "千克"
+        sheet["G18"] = None
+        sheet["H18"] = 33.9028
+        sheet["I18"] = 590993
+
+    document = parse_excel(
+        _workbook({"一般贸易出口": kg_qty_only}),
+        file_id="kgonly",
+        filename="kg-qty-only.xlsx",
+    )
+    item = map_document_goods(document)[0]
+    assert item.value_of("gunit") == "千克"
+    assert item.value_of("gqty") == "17432"
+    assert item.value_of("customNetWt") is None
 
 
 def test_invoice_qty_fills_when_price_implies_same_qty() -> None:
@@ -832,6 +891,35 @@ def test_donnelley_sample_merges_three_row_item() -> None:
     assert values["destinationCountry"] == "美国"
     assert values["districtCode"] == "(44199/)东莞/"
     assert values["dutyMode"] == "照章征税"
+
+
+@pytest.mark.skipif(not REAL_BLU_IN.exists(), reason="本地进料 BLU 样本不在 CI")
+def test_blu_in_kg_qty_takes_net_not_pcs() -> None:
+    document = parse_excel(
+        REAL_BLU_IN.read_bytes(),
+        file_id="blu-in",
+        filename=REAL_BLU_IN.name,
+    )
+    items = map_document_goods(document)
+    assert len(items) == 49
+    first = items[0]
+    assert first.value_of("gunit") == "千克"
+    assert first.value_of("customNetWt") == "205"
+    assert first.value_of("gqty") == "205"
+    assert first.value_of("declPrice") == "3810"
+    assert first.value_of("declTotal") == "781050"
+    for item in items:
+        assert item.value_of("gunit") == "千克"
+        net = item.value_of("customNetWt")
+        qty = item.value_of("gqty")
+        assert net and qty
+        assert qty == net
+        price = float(item.value_of("declPrice") or "0")
+        total = float(item.value_of("declTotal") or "0")
+        if price:
+            assert abs(price * float(qty) - total) <= 0.05 or abs(
+                price * float(qty) - total
+            ) <= 0.005 * max(abs(total), 1.0)
 
 
 @pytest.mark.skipif(not REAL_MXY.exists(), reason="本地 MXY 样本不在 CI")


### PR DESCRIPTION
Closes #75

## 做了什么

#56 只收窄了跨表补空：千克行用净重对齐，件数候选不补进 `gqty`。主表已有值不覆盖，草单把「数量PCS」写成 `gqty` 后，发票上的千克数量补不进来。

进料 BLU-HDX260271 货表同时有重量、数量PCS、计价单位=千克。单价是每千克价，`总价/单价 = 净重`，不是件数。本 PR 只动映射层出门前的同表改写：

1. **单位在 `goods_master.weight_units`，且同行有净重、有数量列**：`gqty` 取 `customNetWt`（证据跟净重格）。已与净重一致则不改证据。
2. **没有数量列不编**（#56 千克行数量空仍空）。
3. **没有净重则保持原 `gqty`**（当纳利：数量列本身就是千克）。
4. **非千克**：`gqty` 仍是件数，净重不动。
5. 跨表补空仍用改写前的件数过净重闸（箱单 500 仍拦）。

不按公司写分支。件数不另开字段，不进 `qty1`。

## 验收

- 夹具：同行「重量 + 数量PCS + 千克」→ `gqty == customNetWt`，`declPrice × gqty` 对齐 `declTotal`。
- 夹具：单位=只，`gqty` 仍是 150。
- 夹具：千克行只有数量没有净重 → `gqty` 保持 17432。
- 真机进料 BLU：49 项全部 `gqty == customNetWt`（第 1 项 205，不再是 5000）。
- 恒信第 1 项（只）/ 国光 / 当纳利千克数量不回归。
- 全量 146 passed / 3 skipped。

## 以后新 xlsx / 新叫法改哪

| 场景 | 改哪 | 动 Python？ |
|---|---|---|
| 新重量单位叫法（如 tonne） | `fields.yaml` `goods_master.weight_units` | 否 |
| 数量容差 | `qty_rel_tol` / `qty_abs_tol` | 否 |
| 千克行同表成交数量取净重 | 内置规则 | 否 |
| 件数要另开字段（不进成交数量） | 先定目录槽位，再加字段 + anchors | 视目录 |
| 法定数量 `qty1` 要吃重量列 | 不要。重量走 `customNetWt` | 否 |

不要按公司写分支。不要在这一层拆版面。