### PR TITLE
feat: PDF→IR 文字层带 bbox + 扫描页/图片接 TextIn 云 OCR（#22）

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,11 @@ DOCPARSE_LLM_API_KEY=
 DOCPARSE_LLM_MODEL=gpt-4.1-mini
 DOCPARSE_VLM_MODEL=gpt-4.1-mini
 
+# TextIn 通用文字识别（扫描件 PDF / 图片 OCR，#22）。
+# 无密钥时扫描件只登记告警、文档进 needs_review，流水线不崩。
+DOCPARSE_TEXTIN_APP_ID=
+DOCPARSE_TEXTIN_SECRET_CODE=
+
 # 任务与文件目前走内存实现；换成 postgres / s3 时只改这两个值
 DOCPARSE_JOB_STORE=memory
 DOCPARSE_FILE_STORE=memory

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ flowchart TB
 |---|---|---|
 | 接入与安全检查 | `pipeline/steps/ingest.py` | 骨架：大小 / 空文件 |
 | 安全解压 | `adapters/parsers/unpack.py` | 骨架：zip 穿越 / 层数 / 体积 |
-| 按文件类型解析 | `adapters/parsers/` | 文本可用；PDF/Excel 需可选依赖 |
+| 按文件类型解析 | `adapters/parsers/` | 文本 / Excel 可用；PDF 文字层 + 扫描 OCR、图片 OCR（#22，需 pymupdf + TextIn 密钥） |
 | 统一文档 IR | `domain/ir.py` | 已定形状 |
 | 文档分类 | `extraction/classify.py` | 关键词占位 |
 | 字段抽取 | `extraction/fields.py` | 锚点规则 + LLM 接口 |

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -28,7 +28,7 @@ docparse/
 |---|---|---|---|
 | 接入与安全检查 | `pipeline/steps/ingest.py` | 骨架：大小 / 空文件 | 补 MIME、真实类型 |
 | 安全解压 | `adapters/parsers/unpack.py` + `steps/unpack.py` | 骨架：zip 穿越 / 层数 / 体积 | rar/7z、加密包 |
-| 按文件类型解析 | `adapters/parsers/` | 文本可用；Excel 全 sheet + 框表/冒号/双行表头/KV/值域（#9 #15 #29）；PDF 需可选依赖；图片未接 OCR | PDF / 扫描件 OCR |
+| 按文件类型解析 | `adapters/parsers/` | 文本可用；Excel 全 sheet + 框表/冒号/双行表头/KV/值域（#9 #15 #29）；PDF 文字层带 bbox / 无文字层渲染→TextIn OCR、图片同入口（#22） | 版面重建（#62）、端到端（#23） |
 | 统一文档 IR | `domain/ir.py` | Cell 含合并/边框/公式；Sheet 含 key_values / tables / role | 非必要不改契约名 |
 | 文档分类 | `extraction/classify.py` + `sheet_role.py` | 文件类型仍占位；sheet 角色看标题/KV/表头（#16） | 新角色加 YAML |
 | 字段抽取 | `extraction/head_map.py` + `goods_map.py` + `assemble.py` + `fields.py` | 单 sheet BOX/KV → 表头（#17）；TABLE → 货行并跨表补空（#18）；多摊收成一张报关单（#19）；旧锚点仍给无 sheet 的文本 | PDF 同组装交 #23 |
@@ -75,6 +75,8 @@ FastAPI 交单（#21）：`POST /v1/jobs` 与 `cli declare` 走同一条 pipelin
 对眼页（#44）：`GET /review` 静态页 + `GET /v1/schema`。只画报关单和复核证据，不渲染 IR。见 [review.md](review.md)。
 
 抽取后校验（#20）：规则先写在 [validate-rules.md](validate-rules.md) 给业务确认。位数 / 正则 / 容差确认后再进数据文件，引擎只执行，不编造、不改值。
+
+云 OCR（#22，选型见 [ocr-benchmark.md](ocr-benchmark.md)）：`adapters/parsers/ocr.py` 的 `TextinOcrClient`，密钥走 `DOCPARSE_TEXTIN_APP_ID` / `DOCPARSE_TEXTIN_SECRET_CODE`，无密钥只告警不崩。请求带 `straighten=1`，返回的行级 bbox 与页宽高统一以**正立图**为参照系（整页 angle 留档进 warnings，给 #62 版面重建）。PDF 逐页：有文字层抽字块带 bbox；无文字层按 `RENDER_ZOOM=2.0` 渲染 JPEG 走 OCR，bbox 除以 zoom 缩回页面 pt。图片（jpg / png）与扫描 PDF 页走同一 `read_image` 入口。40306 QPS 限流按官方说明不重试、只告警。换 OCR 引擎只在 `ocr.py` 加一个 client 实现 `OcrClient` 协议，不动 `pdf.py` / `image.py` / pipeline。
 
 每个 parser 只做一件事：`bytes + filename → DocumentIR`。
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest>=8.3", "ruff>=0.8", "openpyxl>=3.1", "xlrd>=2.0"]
+dev = ["pytest>=8.3", "ruff>=0.8", "openpyxl>=3.1", "xlrd>=2.0", "pymupdf>=1.24"]
 pdf = ["pymupdf>=1.24"]
 excel = ["openpyxl>=3.1", "xlrd>=2.0"]
 bench = ["pymupdf>=1.24", "pillow>=10.0"]

--- a/src/docparse/adapters/parsers/__init__.py
+++ b/src/docparse/adapters/parsers/__init__.py
@@ -1,5 +1,19 @@
 from docparse.adapters.parsers.detect import detect_kind
-from docparse.adapters.parsers.ocr import OcrClient, UnimplementedOcrClient
+from docparse.adapters.parsers.ocr import (
+    OcrClient,
+    OcrLine,
+    OcrOutcome,
+    TextinOcrClient,
+    get_ocr_client,
+)
 from docparse.adapters.parsers.registry import parse_bytes
 
-__all__ = ["OcrClient", "UnimplementedOcrClient", "detect_kind", "parse_bytes"]
+__all__ = [
+    "OcrClient",
+    "OcrLine",
+    "OcrOutcome",
+    "TextinOcrClient",
+    "detect_kind",
+    "get_ocr_client",
+    "parse_bytes",
+]

--- a/src/docparse/adapters/parsers/image.py
+++ b/src/docparse/adapters/parsers/image.py
@@ -1,15 +1,43 @@
+from __future__ import annotations
+
 from uuid import uuid4
 
+from docparse.adapters.parsers.ocr import OcrClient, angle_note, get_ocr_client, ocr_blocks
 from docparse.domain.ir import DocumentIR, Page
 
 
-def parse_image(data: bytes, *, file_id: str, filename: str) -> DocumentIR:
-    """图片本阶段不跑本地 OCR，只登记，后续可接云 OCR / VLM。"""
+def parse_image(
+    data: bytes,
+    *,
+    file_id: str,
+    filename: str,
+    ocr: OcrClient | None = None,
+) -> DocumentIR:
+    """jpg / png 与扫描 PDF 页走同一云 OCR 入口（#22）。
+
+    页面宽高取自 OCR 返回（正立参照系）；识别失败时只有告警、无字块。
+    """
+    client = ocr if ocr is not None else get_ocr_client()
+    outcome = client.read_image(data, filename=filename)
+    warnings = list(outcome.warnings)
+    note = angle_note(outcome)
+    if note:
+        warnings.append(note)
+    width = outcome.width or None
+    height = outcome.height or None
     return DocumentIR(
         document_id=uuid4().hex,
         file_id=file_id,
         filename=filename,
         media_type="image/*",
-        pages=[Page(page_number=1)],
-        warnings=["图片解析未接 OCR。后续可在此调用云 OCR 或 VLM API。"],
+        pages=[
+            Page(
+                page_number=1,
+                width=width,
+                height=height,
+                blocks=ocr_blocks(outcome, prefix="p1-o"),
+            )
+        ],
+        raw_text="\n".join(line.text for line in outcome.lines),
+        warnings=warnings,
     )

--- a/src/docparse/adapters/parsers/ocr.py
+++ b/src/docparse/adapters/parsers/ocr.py
@@ -1,12 +1,195 @@
-"""云 OCR / VLM 预留。本阶段不调用；扫描件 Issue 再实现。"""
+"""云 OCR：TextIn 通用文字识别（#60 实测选型，docs/ocr-benchmark.md）。
 
+模型只走云 API（CLAUDE.md 约束），不装本地引擎。密钥走
+DOCPARSE_TEXTIN_APP_ID / DOCPARSE_TEXTIN_SECRET_CODE，无密钥不崩：
+降级为 warning，文档照常进流水线（后续 needs_review），不编文字。
+
+坐标约定：请求带 straighten=1，TextIn 返回的所有 bbox 均以**正立图**为
+参照系（官方文档），OcrOutcome.width / height 也是正立后的宽高，
+给 #62 版面重建直接用。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
 from typing import Protocol
+
+import httpx
+
+from docparse.config import Settings, get_settings
+from docparse.domain.ir import BoundingBox, TextBlock
+
+TEXTIN_RECOGNIZE_URL = "https://api.textin.com/ai/service/v2/recognize/multipage"
+TEXTIN_TIMEOUT_SECONDS = 60.0
+TEXTIN_QPS_CODE = 40306
+
+
+@dataclass
+class OcrLine:
+    """一行识别结果，bbox 为正立图上的像素坐标。"""
+
+    text: str
+    x0: float = 0.0
+    y0: float = 0.0
+    x1: float = 0.0
+    y1: float = 0.0
+    score: float | None = None
+
+
+@dataclass
+class OcrOutcome:
+    """read_image 的统一返回。
+
+    lines 与 width / height 均以正立图为参照系（angle 为 90/270 时
+    相对输入图宽高已对调）。识别失败时 lines 为空、warnings 说明原因。
+    """
+
+    lines: list[OcrLine] = field(default_factory=list)
+    angle: int = 0
+    width: float = 0.0
+    height: float = 0.0
+    warnings: list[str] = field(default_factory=list)
 
 
 class OcrClient(Protocol):
-    def read_image(self, data: bytes, *, filename: str) -> str: ...
+    def read_image(self, data: bytes, *, filename: str) -> OcrOutcome: ...
 
 
-class UnimplementedOcrClient:
-    def read_image(self, data: bytes, *, filename: str) -> str:
-        raise NotImplementedError("云 OCR 尚未接入，见 docs/modules.md")
+def _bbox_from_position(position: list) -> tuple[float, float, float, float]:
+    """TextIn position 是四边形 8 个数（左上起顺时针），取外接矩形。"""
+    if len(position) < 8:
+        return 0.0, 0.0, 0.0, 0.0
+    xs = position[0::2]
+    ys = position[1::2]
+    return min(xs), min(ys), max(xs), max(ys)
+
+
+def parse_textin_general(payload: dict) -> OcrOutcome:
+    """TextIn recognize/multipage 响应 → OcrOutcome（straighten=1 语义）。"""
+    result = payload.get("result") or {}
+    outcome = OcrOutcome()
+    lines: list[OcrLine] = []
+    for page_no, page in enumerate(result.get("pages") or []):
+        if page_no == 0:
+            outcome.angle = int(page.get("angle") or 0) % 360
+            # 官方 width / height 是输入图（未转正）的宽高
+            raw_width = float(page.get("width") or 0)
+            raw_height = float(page.get("height") or 0)
+            if outcome.angle % 90 == 0 and outcome.angle % 180 != 0:
+                raw_width, raw_height = raw_height, raw_width
+            outcome.width, outcome.height = raw_width, raw_height
+        for line in page.get("lines") or []:
+            text = str(line.get("text") or "").strip()
+            if not text:
+                continue
+            x0, y0, x1, y1 = _bbox_from_position(line.get("position") or [])
+            score = line.get("score")
+            lines.append(
+                OcrLine(
+                    text=text,
+                    x0=x0,
+                    y0=y0,
+                    x1=x1,
+                    y1=y1,
+                    score=float(score) if score is not None else None,
+                )
+            )
+    outcome.lines = lines
+    return outcome
+
+
+class TextinOcrClient:
+    """TextIn 通用文字识别 client，自 benchmarks/ocr/engines.py 迁移（#60）。
+
+    header 鉴权、octet-stream 传图、60s 超时；40306 QPS 限流按官方说明
+    不重试、只告警。transport 供测试注入 MockTransport。
+    """
+
+    def __init__(
+        self,
+        app_id: str,
+        secret_code: str,
+        *,
+        transport: httpx.BaseTransport | None = None,
+    ) -> None:
+        self.app_id = app_id
+        self.secret_code = secret_code
+        self._transport = transport
+
+    def read_image(self, data: bytes, *, filename: str) -> OcrOutcome:
+        if not self.app_id or not self.secret_code:
+            return OcrOutcome(
+                warnings=[
+                    "未配置 TextIn 密钥（DOCPARSE_TEXTIN_APP_ID / "
+                    f"DOCPARSE_TEXTIN_SECRET_CODE），{filename} 跳过 OCR。"
+                ]
+            )
+        headers = {
+            "x-ti-app-id": self.app_id,
+            "x-ti-secret-code": self.secret_code,
+            "content-type": "application/octet-stream",
+        }
+        try:
+            with httpx.Client(transport=self._transport, timeout=TEXTIN_TIMEOUT_SECONDS) as client:
+                response = client.post(
+                    TEXTIN_RECOGNIZE_URL,
+                    content=data,
+                    headers=headers,
+                    params={"straighten": 1},
+                )
+        except httpx.HTTPError as exc:
+            return OcrOutcome(warnings=[f"TextIn 请求失败（{filename}）：{exc}"])
+        try:
+            payload = response.json()
+        except ValueError:
+            return OcrOutcome(
+                warnings=[f"TextIn 返回非 JSON（{filename}）：HTTP {response.status_code}"]
+            )
+        code = payload.get("code")
+        if code != 200:
+            message = payload.get("message", "")
+            if code == TEXTIN_QPS_CODE:
+                return OcrOutcome(
+                    warnings=[f"TextIn QPS 限流（{filename}），按官方说明不重试，本页跳过 OCR。"]
+                )
+            return OcrOutcome(
+                warnings=[f"TextIn 识别失败（{filename}）：code={code} message={message}"]
+            )
+        return parse_textin_general(payload)
+
+
+_clients: dict[tuple[str, str], TextinOcrClient] = {}
+
+
+def get_ocr_client(settings: Settings | None = None) -> TextinOcrClient:
+    """按密钥取共享 client；密钥为空也返回（read_image 只告警不出网）。"""
+    resolved = settings or get_settings()
+    key = (resolved.textin_app_id, resolved.textin_secret_code)
+    if key not in _clients:
+        _clients[key] = TextinOcrClient(*key)
+    return _clients[key]
+
+
+def ocr_blocks(outcome: OcrOutcome, *, prefix: str, scale: float = 1.0) -> list[TextBlock]:
+    """outcome.lines → IR 字块。scale 把 OCR 像素换算回页面 pt（如 1/zoom）。"""
+    return [
+        TextBlock(
+            block_id=f"{prefix}{i}",
+            text=line.text,
+            bbox=BoundingBox(
+                x0=line.x0 * scale,
+                y0=line.y0 * scale,
+                x1=line.x1 * scale,
+                y1=line.y1 * scale,
+            ),
+            ocr_confidence=line.score,
+        )
+        for i, line in enumerate(outcome.lines, start=1)
+    ]
+
+
+def angle_note(outcome: OcrOutcome) -> str | None:
+    """整页转正角度留档（写入 warnings），None 表示无需记录。"""
+    if outcome.angle:
+        return f"OCR 转正角度 angle={outcome.angle}，bbox 以正立图为参照系。"
+    return None

--- a/src/docparse/adapters/parsers/pdf.py
+++ b/src/docparse/adapters/parsers/pdf.py
@@ -1,12 +1,33 @@
+from __future__ import annotations
+
 from uuid import uuid4
 
-from docparse.domain.ir import DocumentIR, Page, TextBlock
+from docparse.adapters.parsers.ocr import (
+    OcrClient,
+    angle_note,
+    get_ocr_client,
+    ocr_blocks,
+)
+from docparse.domain.ir import BoundingBox, DocumentIR, Page, TextBlock
+
+RENDER_ZOOM = 2.0
+JPEG_QUALITY = 90
 
 
-def parse_pdf(data: bytes, *, file_id: str, filename: str) -> DocumentIR:
-    """文本型 PDF 占位解析。装了 pymupdf 就抽文本，否则只保留二进制提示。"""
+def parse_pdf(
+    data: bytes,
+    *,
+    file_id: str,
+    filename: str,
+    ocr: OcrClient | None = None,
+) -> DocumentIR:
+    """PDF → IR：逐页有文字层抽字块（带 bbox）；无文字层渲染出图走云 OCR。
+
+    渲染时应用页面 rotation（横页竖图自动转正）；OCR 返回的整页 angle 留档进
+    warnings，bbox 统一为正立图参照系（给 #62 版面重建）。
+    """
     try:
-        import fitz  # type: ignore
+        import pymupdf  # type: ignore
     except ImportError:
         return DocumentIR(
             document_id=uuid4().hex,
@@ -17,25 +38,34 @@ def parse_pdf(data: bytes, *, file_id: str, filename: str) -> DocumentIR:
             raw_text="",
         )
 
-    doc = fitz.open(stream=data, filetype="pdf")
+    client = ocr if ocr is not None else get_ocr_client()
+    matrix = pymupdf.Matrix(RENDER_ZOOM, RENDER_ZOOM)
     pages: list[Page] = []
-    texts: list[str] = []
-    for index, page in enumerate(doc, start=1):
-        blocks: list[TextBlock] = []
-        for i, item in enumerate(page.get_text("blocks"), start=1):
-            snippet = (item[4] or "").strip()
-            if not snippet:
+    warnings: list[str] = []
+    with pymupdf.open(stream=data, filetype="pdf") as doc:
+        for index, page in enumerate(doc, start=1):
+            blocks = _text_blocks(page, index)
+            if blocks:
+                pages.append(
+                    Page(
+                        page_number=index,
+                        width=float(page.rect.width),
+                        height=float(page.rect.height),
+                        blocks=blocks,
+                    )
+                )
                 continue
-            blocks.append(TextBlock(block_id=f"p{index}-b{i}", text=snippet))
-        pages.append(
-            Page(
-                page_number=index,
-                width=float(page.rect.width),
-                height=float(page.rect.height),
-                blocks=blocks,
+            pages.append(
+                _ocr_page(
+                    page,
+                    index,
+                    client=client,
+                    filename=filename,
+                    warnings=warnings,
+                    matrix=matrix,
+                )
             )
-        )
-        texts.append(page.get_text())
+    texts = ["\n".join(block.text for block in page.blocks) for page in pages]
     return DocumentIR(
         document_id=uuid4().hex,
         file_id=file_id,
@@ -43,4 +73,60 @@ def parse_pdf(data: bytes, *, file_id: str, filename: str) -> DocumentIR:
         media_type="application/pdf",
         pages=pages,
         raw_text="\n".join(texts),
+        warnings=warnings,
+    )
+
+
+def _text_blocks(page, index: int) -> list[TextBlock]:
+    """文字层字块，bbox 用 fitz 显示坐标系（pt，已应用页面 rotation）。"""
+    blocks: list[TextBlock] = []
+    for i, item in enumerate(page.get_text("blocks"), start=1):
+        snippet = (item[4] or "").strip()
+        if not snippet:
+            continue
+        if len(item) >= 7 and item[6] != 0:
+            continue  # 0=文本块，1=图片块
+        blocks.append(
+            TextBlock(
+                block_id=f"p{index}-b{i}",
+                text=snippet,
+                bbox=BoundingBox(
+                    x0=float(item[0]),
+                    y0=float(item[1]),
+                    x1=float(item[2]),
+                    y1=float(item[3]),
+                ),
+            )
+        )
+    return blocks
+
+
+def _ocr_page(
+    page,
+    index: int,
+    *,
+    client: OcrClient,
+    filename: str,
+    warnings: list[str],
+    matrix,
+) -> Page:
+    """无文字层的页：渲染出图（应用 rotation）→ JPEG → OCR → 行级字块。"""
+    pixmap = page.get_pixmap(matrix=matrix)
+    image = pixmap.tobytes("jpeg", jpg_quality=JPEG_QUALITY)
+    outcome = client.read_image(image, filename=f"{filename}#p{index}")
+    for warning in outcome.warnings:
+        warnings.append(f"第{index}页：{warning}")
+    note = angle_note(outcome)
+    if note:
+        warnings.append(f"第{index}页：{note}")
+    width = float(page.rect.width)
+    height = float(page.rect.height)
+    if outcome.angle % 90 == 0 and outcome.angle % 180 != 0:
+        # 内容旋转（无 rotation 元数据）：正立参照系下宽高对调
+        width, height = height, width
+    return Page(
+        page_number=index,
+        width=width,
+        height=height,
+        blocks=ocr_blocks(outcome, prefix=f"p{index}-o", scale=1.0 / RENDER_ZOOM),
     )

--- a/src/docparse/adapters/parsers/registry.py
+++ b/src/docparse/adapters/parsers/registry.py
@@ -3,6 +3,7 @@ from collections.abc import Callable
 from docparse.adapters.parsers.detect import SourceKind, detect_kind
 from docparse.adapters.parsers.excel import parse_excel
 from docparse.adapters.parsers.image import parse_image
+from docparse.adapters.parsers.ocr import OcrClient
 from docparse.adapters.parsers.pdf import parse_pdf
 from docparse.adapters.parsers.text import parse_text
 from docparse.domain.ir import DocumentIR
@@ -16,8 +17,16 @@ _PARSERS: dict[SourceKind, Parser] = {
     SourceKind.TEXT: parse_text,
 }
 
+_OCR_PARSERS = {SourceKind.PDF, SourceKind.IMAGE}
 
-def parse_bytes(data: bytes, *, file_id: str, filename: str) -> DocumentIR:
+
+def parse_bytes(
+    data: bytes,
+    *,
+    file_id: str,
+    filename: str,
+    ocr: OcrClient | None = None,
+) -> DocumentIR:
     kind = detect_kind(filename, data)
     parser = _PARSERS.get(kind)
     if parser is None:
@@ -28,4 +37,6 @@ def parse_bytes(data: bytes, *, file_id: str, filename: str) -> DocumentIR:
             media_type="application/octet-stream",
             warnings=[f"暂不支持的文件类型: {kind}"],
         )
+    if kind in _OCR_PARSERS:
+        return parser(data, file_id=file_id, filename=filename, ocr=ocr)
     return parser(data, file_id=file_id, filename=filename)

--- a/src/docparse/config.py
+++ b/src/docparse/config.py
@@ -16,6 +16,10 @@ class Settings(BaseSettings):
     llm_model: str = "gpt-4.1-mini"
     vlm_model: str = "gpt-4.1-mini"
 
+    # 云 OCR（TextIn 通用，#60 选型）；无密钥时扫描件只登记告警，不崩
+    textin_app_id: str = ""
+    textin_secret_code: str = ""
+
     job_store: str = "memory"
     file_store: str = "memory"
 

--- a/src/docparse/pipeline/steps/extract_content.py
+++ b/src/docparse/pipeline/steps/extract_content.py
@@ -1,12 +1,14 @@
+from docparse.adapters.parsers.ocr import get_ocr_client
 from docparse.adapters.parsers.registry import parse_bytes
 from docparse.pipeline.context import PipelineContext
 
 
 def extract_content_step(ctx: PipelineContext) -> None:
+    ocr = get_ocr_client(ctx.settings)
     documents = []
     for member in ctx.members:
         data = ctx.files.get(member.id)
-        document = parse_bytes(data, file_id=member.id, filename=member.filename)
+        document = parse_bytes(data, file_id=member.id, filename=member.filename, ocr=ocr)
         documents.append(document)
     ctx.documents = documents
     ctx.package.documents = documents

--- a/tests/test_pdf_ocr.py
+++ b/tests/test_pdf_ocr.py
@@ -1,0 +1,350 @@
+"""#22 PDF → IR / 图片 OCR。
+
+夹具全部 pymupdf 现场生成（文字层 / 扫描 / rotation），OCR client 全 mock，
+离线不访问网络；TextIn client 用 httpx.MockTransport 覆盖。
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+pytest.importorskip("pymupdf")
+
+import pymupdf
+
+from docparse.adapters.parsers.image import parse_image
+from docparse.adapters.parsers.ocr import (
+    OcrLine,
+    OcrOutcome,
+    TextinOcrClient,
+    get_ocr_client,
+    parse_textin_general,
+)
+from docparse.adapters.parsers.pdf import RENDER_ZOOM, parse_pdf
+
+# ---------------------------------------------------------------------------
+# 夹具：pymupdf 现场生成
+
+
+def make_text_pdf() -> bytes:
+    """两行文字的文字层 PDF。"""
+    with pymupdf.open() as doc:
+        page = doc.new_page(width=595, height=842)
+        page.insert_text((72, 96), "EntryID: ABCD1234567890")
+        page.insert_text((72, 120), "GrossWt 1459.62")
+        return doc.tobytes()
+
+
+def make_scanned_pdf(*, rotation: int = 0, width: float = 400, height: float = 300) -> bytes:
+    """只嵌一张图、无文字层的 PDF，模拟扫描件；rotation 写进页面元数据。"""
+    pix = pymupdf.Pixmap(pymupdf.csRGB, pymupdf.IRect(0, 0, 200, 100))
+    pix.clear_with(90)
+    with pymupdf.open() as doc:
+        page = doc.new_page(width=width, height=height)
+        page.insert_image(pymupdf.Rect(50, 50, width - 50, height - 50), stream=pix.tobytes("png"))
+        if rotation:
+            page.set_rotation(rotation)
+        return doc.tobytes()
+
+
+def make_jpeg() -> bytes:
+    pix = pymupdf.Pixmap(pymupdf.csRGB, pymupdf.IRect(0, 0, 120, 60))
+    pix.clear_with(120)
+    return pix.tobytes("jpeg", jpg_quality=90)
+
+
+class MockOcr:
+    """记录调用并回放固定 outcome 的 OCR client。"""
+
+    def __init__(self, outcome: OcrOutcome, *, expect_jpeg: bool = True) -> None:
+        self.outcome = outcome
+        self.expect_jpeg = expect_jpeg
+        self.calls: list[bytes] = []
+        self.filenames: list[str] = []
+
+    def read_image(self, data: bytes, *, filename: str) -> OcrOutcome:
+        self.calls.append(data)
+        self.filenames.append(filename)
+        if self.expect_jpeg:
+            assert data[:3] == b"\xff\xd8\xff", "传给 OCR 的应为 JPEG"
+        return self.outcome
+
+
+# ---------------------------------------------------------------------------
+# PDF 文字层
+
+
+class TestPdfTextLayer:
+    def test_blocks_have_bbox_and_text(self) -> None:
+        ir = parse_pdf(make_text_pdf(), file_id="f1", filename="a.pdf", ocr=MockOcr(OcrOutcome()))
+        assert ir.warnings == []
+        page = ir.pages[0]
+        assert page.width == 595 and page.height == 842
+        assert len(page.blocks) == 2
+        first = page.blocks[0]
+        assert first.text.startswith("EntryID")
+        assert first.bbox is not None
+        assert first.bbox.x0 == pytest.approx(72, abs=2)
+        assert 80 <= first.bbox.y0 <= 96  # insert_text 的 y 是基线
+        assert "ABCD1234567890" in ir.raw_text
+
+    def test_text_layer_wins_no_ocr_call(self) -> None:
+        mock = MockOcr(OcrOutcome(lines=[OcrLine(text="不应出现")]))
+        ir = parse_pdf(make_text_pdf(), file_id="f1", filename="a.pdf", ocr=mock)
+        assert mock.calls == []
+        assert all(block.text != "不应出现" for page in ir.pages for block in page.blocks)
+
+    def test_rotation_metadata_page_upright(self) -> None:
+        # 页横图竖（半岛形态）：rotation=270，显示坐标系下宽高已对调
+        ir = parse_pdf(
+            make_scanned_pdf(rotation=270),
+            file_id="f1",
+            filename="r.pdf",
+            ocr=MockOcr(OcrOutcome()),
+        )
+        page = ir.pages[0]
+        assert page.width == 300 and page.height == 400
+
+
+# ---------------------------------------------------------------------------
+# PDF 扫描页 → OCR
+
+
+class TestPdfScannedOcr:
+    def test_ocr_blocks_scaled_back_to_points(self) -> None:
+        outcome = OcrOutcome(
+            lines=[
+                OcrLine(text="EntryID: ABCD1234567890", x0=100, y0=50, x1=500, y1=80, score=0.98)
+            ],
+            width=400 * RENDER_ZOOM,
+            height=300 * RENDER_ZOOM,
+        )
+        mock = MockOcr(outcome)
+        ir = parse_pdf(make_scanned_pdf(), file_id="f1", filename="scan.pdf", ocr=mock)
+        assert len(mock.calls) == 1
+        assert mock.filenames == ["scan.pdf#p1"]
+        page = ir.pages[0]
+        block = page.blocks[0]
+        assert block.block_id == "p1-o1"
+        assert block.text == "EntryID: ABCD1234567890"
+        assert block.bbox is not None
+        assert block.bbox.x0 == pytest.approx(50.0)
+        assert block.bbox.y0 == pytest.approx(25.0)
+        assert block.bbox.x1 == pytest.approx(250.0)
+        assert block.bbox.y1 == pytest.approx(40.0)
+        assert block.ocr_confidence == 0.98
+        assert page.width == 400 and page.height == 300
+        assert "ABCD1234567890" in ir.raw_text
+        assert ir.warnings == []
+
+    def test_content_rotation_swaps_size_and_logs_angle(self) -> None:
+        # 无 rotation 元数据、内容旋转 90°（镇发 p1 形态）
+        outcome = OcrOutcome(
+            lines=[OcrLine(text="中华人民共和国海关出口货物报关单", x0=10, y0=20, x1=300, y1=60)],
+            angle=90,
+            width=300,
+            height=400,
+        )
+        ir = parse_pdf(make_scanned_pdf(), file_id="f1", filename="z.pdf", ocr=MockOcr(outcome))
+        page = ir.pages[0]
+        assert page.width == 300 and page.height == 400
+        assert any("angle=90" in warning for warning in ir.warnings)
+
+    def test_ocr_failure_keeps_page_with_warning(self) -> None:
+        outcome = OcrOutcome(warnings=["TextIn 请求失败（z.pdf#p1）：timeout"])
+        ir = parse_pdf(make_scanned_pdf(), file_id="f1", filename="z.pdf", ocr=MockOcr(outcome))
+        assert ir.pages[0].blocks == []
+        assert ir.raw_text == ""
+        assert any("第1页" in warning and "TextIn" in warning for warning in ir.warnings)
+
+    def test_mixed_pdf_text_and_scanned_pages(self) -> None:
+        with pymupdf.open() as doc:
+            doc.new_page(width=595, height=842).insert_text((72, 96), "EntryID: ABCD1234567890")
+            pix = pymupdf.Pixmap(pymupdf.csRGB, pymupdf.IRect(0, 0, 100, 50))
+            doc.new_page(width=400, height=300).insert_image(
+                pymupdf.Rect(50, 50, 350, 250), stream=pix.tobytes("png")
+            )
+            data = doc.tobytes()
+        outcome = OcrOutcome(lines=[OcrLine(text="GrossWt 1459.62", x0=0, y0=0, x1=200, y1=30)])
+        ir = parse_pdf(data, file_id="f1", filename="mix.pdf", ocr=MockOcr(outcome))
+        assert len(ir.pages) == 2
+        assert ir.pages[0].blocks[0].block_id == "p1-b1"
+        assert ir.pages[1].blocks[0].block_id == "p2-o1"
+        assert "ABCD1234567890" in ir.raw_text and "1459.62" in ir.raw_text
+
+
+# ---------------------------------------------------------------------------
+# 图片 → 同一 OCR 入口
+
+
+class TestImageOcr:
+    def test_jpeg_ocr_blocks_and_size(self) -> None:
+        outcome = OcrOutcome(
+            lines=[OcrLine(text="海关编号 530320260000123456A", x0=10, y0=20, x1=400, y1=60)],
+            width=1280,
+            height=720,
+        )
+        ir = parse_image(make_jpeg(), file_id="f1", filename="x.jpg", ocr=MockOcr(outcome))
+        page = ir.pages[0]
+        assert page.width == 1280 and page.height == 720
+        block = page.blocks[0]
+        assert block.text == "海关编号 530320260000123456A"
+        assert block.bbox is not None and block.bbox.x1 == pytest.approx(400)
+        assert "530320260000123456A" in ir.raw_text
+        assert ir.warnings == []
+
+    def test_rotated_image_swaps_size(self) -> None:
+        outcome = OcrOutcome(
+            lines=[OcrLine(text="x", x0=0, y0=0, x1=10, y1=10)], angle=270, width=720, height=1280
+        )
+        ir = parse_image(make_jpeg(), file_id="f1", filename="x.jpg", ocr=MockOcr(outcome))
+        assert ir.pages[0].width == 720 and ir.pages[0].height == 1280
+        assert any("angle=270" in warning for warning in ir.warnings)
+
+    def test_ocr_failure_only_warning(self) -> None:
+        outcome = OcrOutcome(warnings=["未配置 TextIn 密钥，x.jpg 跳过 OCR。"])
+        ir = parse_image(make_jpeg(), file_id="f1", filename="x.jpg", ocr=MockOcr(outcome))
+        assert ir.pages[0].blocks == []
+        assert ir.warnings and "密钥" in ir.warnings[0]
+
+
+# ---------------------------------------------------------------------------
+# TextIn client（httpx.MockTransport，不出网）
+
+
+def _transport(payload: dict | None = None, *, status: int = 200, error: Exception | None = None):
+    calls: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(request)
+        if error is not None:
+            raise error
+        return httpx.Response(status, json=payload)
+
+    return httpx.MockTransport(handler), calls
+
+
+def _success_payload() -> dict:
+    return {
+        "code": 200,
+        "message": "success",
+        "result": {
+            "pages": [
+                {
+                    "angle": 0,
+                    "width": 800,
+                    "height": 600,
+                    "lines": [
+                        {
+                            "text": "海关编号 530320260000123456A",
+                            "score": 0.99,
+                            "position": [10, 20, 400, 20, 400, 50, 10, 50],
+                        }
+                    ],
+                }
+            ]
+        },
+    }
+
+
+class TestTextinClient:
+    def test_success_parse_lines_and_headers(self) -> None:
+        transport, calls = _transport(_success_payload())
+        client = TextinOcrClient("app-id", "secret", transport=transport)
+        outcome = client.read_image(b"\xff\xd8\xffimg", filename="x.jpg")
+        assert outcome.warnings == []
+        assert len(outcome.lines) == 1
+        line = outcome.lines[0]
+        assert line.text == "海关编号 530320260000123456A"
+        assert (line.x0, line.y0, line.x1, line.y1) == (10, 20, 400, 50)
+        assert line.score == 0.99
+        assert outcome.width == 800 and outcome.height == 600
+        request = calls[0]
+        assert request.headers["x-ti-app-id"] == "app-id"
+        assert request.headers["x-ti-secret-code"] == "secret"
+        assert request.headers["content-type"] == "application/octet-stream"
+        assert request.url.params["straighten"] == "1"
+
+    def test_rate_limited_no_retry(self) -> None:
+        transport, calls = _transport({"code": 40306, "message": "QPS超过限制"})
+        client = TextinOcrClient("app-id", "secret", transport=transport)
+        outcome = client.read_image(b"img", filename="x.jpg")
+        assert outcome.lines == []
+        assert "限流" in outcome.warnings[0]
+        assert len(calls) == 1  # 官方要求 40306 不重试
+
+    def test_other_error_code_warns(self) -> None:
+        transport, _calls = _transport({"code": 40102, "message": "验证失败"})
+        client = TextinOcrClient("app-id", "secret", transport=transport)
+        outcome = client.read_image(b"img", filename="x.jpg")
+        assert "code=40102" in outcome.warnings[0]
+
+    def test_network_error_warns_not_raises(self) -> None:
+        transport, _calls = _transport(error=httpx.ConnectError("boom"))
+        client = TextinOcrClient("app-id", "secret", transport=transport)
+        outcome = client.read_image(b"img", filename="x.jpg")
+        assert "请求失败" in outcome.warnings[0]
+
+    def test_missing_credentials_no_http(self) -> None:
+        transport, calls = _transport(_success_payload())
+        client = TextinOcrClient("", "", transport=transport)
+        outcome = client.read_image(b"img", filename="x.jpg")
+        assert "密钥" in outcome.warnings[0]
+        assert calls == []
+
+
+class TestParseTextinGeneral:
+    def test_angle_90_swaps_upright_size(self) -> None:
+        payload = _success_payload()
+        page = payload["result"]["pages"][0]
+        page["angle"] = 90
+        page["width"] = 1280
+        page["height"] = 1440
+        outcome = parse_textin_general(payload)
+        assert outcome.angle == 90
+        assert outcome.width == 1440 and outcome.height == 1280
+
+    def test_skips_empty_lines(self) -> None:
+        payload = _success_payload()
+        payload["result"]["pages"][0]["lines"].append(
+            {"text": "  ", "position": [0, 0, 1, 0, 1, 1, 0, 1]}
+        )
+        outcome = parse_textin_general(payload)
+        assert len(outcome.lines) == 1
+
+
+# ---------------------------------------------------------------------------
+# 流水线：无密钥不崩
+
+
+class TestPipelineNoCredentials:
+    def test_scanned_pdf_without_credentials_needs_review(self) -> None:
+        from docparse.adapters.files.memory import MemoryFileStore
+        from docparse.adapters.jobs.memory import MemoryJobStore
+        from docparse.config import Settings
+        from docparse.domain.models import JobStatus
+        from docparse.pipeline.runner import Pipeline
+
+        settings = Settings(
+            job_store="memory",
+            file_store="memory",
+            llm_api_key="",
+            textin_app_id="",
+            textin_secret_code="",
+        )
+        pipeline = Pipeline(settings=settings, jobs=MemoryJobStore(), files=MemoryFileStore())
+        job = pipeline.process("scan.pdf", make_scanned_pdf())
+        assert job.status in {JobStatus.SUCCEEDED, JobStatus.NEEDS_REVIEW}
+        assert job.error is None
+        documents = job.result.package.documents
+        assert any("密钥" in warning for warning in documents[0].warnings)
+
+    def test_get_ocr_client_reuses_by_credentials(self) -> None:
+        from docparse.config import Settings
+
+        settings = Settings(textin_app_id="a", textin_secret_code="b")
+        first = get_ocr_client(settings)
+        assert get_ocr_client(settings) is first
+        other = get_ocr_client(Settings(textin_app_id="c", textin_secret_code="d"))
+        assert other is not first


### PR DESCRIPTION
Closes #22

## 做了什么

PDF / 图片统一读进 `DocumentIR`，行级字块带 bbox，扫描件走 TextIn 通用 OCR（#60 选型）。

### `adapters/parsers/ocr.py`

- 落地 `TextinOcrClient`（自 benchmarks/ocr/engines.py 迁移）：header 鉴权、octet-stream 传图、60s 超时
- `OcrClient` 协议升级：`read_image → OcrOutcome`（行级 `lines`：text + bbox + score，整页 `angle` / 正立宽高 / `warnings`），不再是纯文本
- 请求带 `straighten=1`：**所有 bbox 与宽高以正立图为参照系**（官方文档语义），给 #62 版面重建直接用
- 40306 QPS 限流按官方说明**不重试只告警**；无密钥 / 网络失败 / 非 200 → 全部降级 warning，不抛异常、不编文字
- `get_ocr_client(settings)`：按密钥缓存共享 client

### `adapters/parsers/pdf.py`

- 逐页：有文字层抽字块并补 bbox（fitz blocks 显示坐标系 pt）；无文字层渲染出图（**应用页面 rotation**）→ JPEG（zoom=2.0 / q90，与 #60 实测一致）→ OCR → 行级字块，bbox ÷zoom 缩回页面 pt
- OCR 返回 `angle≠0`（无旋转元数据的内容旋转，镇发 p1 形态）：页面宽高对调成正立参照系，angle 留档进 warnings
- 多页混合（p1 文字层 + p2 扫描）逐页各自处理

### `adapters/parsers/image.py`

- jpg / png 与扫描 PDF 页走同一 `read_image` 入口；页面宽高取自 OCR 返回（正立参照系）

### 其他

- `config.py` + `.env.example`：`DOCPARSE_TEXTIN_APP_ID` / `DOCPARSE_TEXTIN_SECRET_CODE`（DOCPARSE_ 前缀，无密钥不崩）
- `extract_content_step` 经 registry 注入 OCR client，pipeline 其余不动
- `pymupdf` 进 dev extras（CI 跑 PDF 测试）；tests 19 个全离线（pymupdf 现场生成夹具 + httpx.MockTransport + MockOcr）

## 真机验证（本地人工跑，原件不入库）

**半岛 SJ25084373-310795HKD（2 页扫描，页横图竖 rotation=270）**

- 渲染应用 rotation，方向正确：两页 841x598pt 横版
- 字块：p1 172 行 / p2 210 行（与 #60 报告一致）
- 对 docs/ocr-benchmark.md §3.1 表头值：**9/10 精确出现**（合同号 T5352W000228、毛重 1459.62、净重 485、件数 214、存放地点盐保澳易购仓、Peninsula Merchandising Limited、HKG、航次 1100422094187…）；miss 的 `N/M`（标记唛码格内的值）未单独成行，属 #62 版面重建对齐范围
- 商品表：**19/19 个 codeTs 全部在字块中**（如 `1905310000半岛苏格兰黄油酥饼（饼干）`，HS+品名同行、列对齐清晰）

**镇发 p1（无旋转元数据、内容旋转 90°）**

- angle=90 留档进 warnings，宽高对调；91 行，标题「中华人民共和国海关出口货物报关单」正常读出

## 验收对照

- [x] 文字层夹具能抽出带 bbox 的字块（tests/test_pdf_ocr.py::TestPdfTextLayer）
- [x] 自造扫描夹具（mock OCR）走通出图 → OCR → IR（TestPdfScannedOcr，含 rotation=270 / 内容旋转 / 失败降级 / 混合页）
- [x] 半岛真机本地人工跑通（上节）
- [x] 无密钥时流水线不崩，文档带 warning 进 needs_review（TestPipelineNoCredentials）
- [x] 密钥不出现在仓库任何文件（.env 已 gitignore，测试全 mock）
- [x] 客户原件不进仓库
- [x] ruff / pytest 通过（165 passed / 3 skipped）

## 以后新 xlsx / 新叫法改哪

| 场景 | 改哪 | 动不动 Python |
|---|---|---|
| 换 / 加云 OCR 引擎 | `adapters/parsers/ocr.py` 加一个 client 实现 `OcrClient` 协议（返回 `OcrOutcome`），`pdf.py` / `image.py` / pipeline 不动 | 是（一个类 + 一个解析函数） |
| TextIn 请求参数（渲染精度除外） | `ocr.py` 的 `TEXTIN_RECOGNIZE_URL` / `params` | 是（一处） |
| 扫描页渲染精度 / JPEG 质量 | `pdf.py` 的 `RENDER_ZOOM` / `JPEG_QUALITY`（注意 bbox 缩放跟 RENDER_ZOOM 绑定） | 否（改常量） |
| 新错误码要特殊处理 | `ocr.py` 的 `read_image` 错误分支（40306 已单列不重试） | 是（一处） |
| 密钥 | `.env`（DOCPARSE_TEXTIN_APP_ID / DOCPARSE_TEXTIN_SECRET_CODE），无密钥只告警 | 否 |
| 版面重建（页字块 → 伪格子 → KV + 表） | #62，不在本 PR | - |

## 不改

字段目录、词表、xlsx 映射、组装、校验、FastAPI 路由（#23 端到端另开）。