### PR TITLE
feat: OCR 字块重建伪格子，复用现有版面刀（#62）

### DIFF
--- a/docs/layout-vocab.md
+++ b/docs/layout-vocab.md
@@ -78,3 +78,7 @@
 ## 增别名
 
 改 YAML，不必改 Python。新格子关系（不是新文案）另开刀法 Issue。以后新表对照 [#31](https://github.com/Baldwinzc/docparse/issues/31)。
+
+## OCR 伪格子（#62）
+
+扫描页 / 文字层 PDF 没有 Excel 格子。`ocr_layout.py` 把 `pages[].blocks` 建成伪 `Sheet.cells` 后，**同一套** `split_sheet` + 本词表拆 KV / 表。不在这里加第二套 BOX / TABLE。新叫法仍改 YAML；行带容差 / 列间隙是几何参数，改 `ocr_layout.py` 常量。

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -28,7 +28,7 @@ docparse/
 |---|---|---|---|
 | 接入与安全检查 | `pipeline/steps/ingest.py` | 骨架：大小 / 空文件 | 补 MIME、真实类型 |
 | 安全解压 | `adapters/parsers/unpack.py` + `steps/unpack.py` | 骨架：zip 穿越 / 层数 / 体积 | rar/7z、加密包 |
-| 按文件类型解析 | `adapters/parsers/` | 文本可用；Excel 全 sheet + 框表/冒号/双行表头/KV/值域（#9 #15 #29）；PDF 文字层带 bbox / 无文字层渲染→TextIn OCR、图片同入口（#22） | 版面重建（#62）、端到端（#23） |
+| 按文件类型解析 | `adapters/parsers/` | 文本可用；Excel 全 sheet + 框表/冒号/双行表头/KV/值域（#9 #15 #29）；PDF 文字层带 bbox / 无文字层渲染→TextIn OCR、图片同入口（#22）；OCR 字块重建伪格子（#62） | 端到端（#23） |
 | 统一文档 IR | `domain/ir.py` | Cell 含合并/边框/公式；Sheet 含 key_values / tables / role | 非必要不改契约名 |
 | 文档分类 | `extraction/classify.py` + `sheet_role.py` | 文件类型仍占位；sheet 角色看标题/KV/表头（#16） | 新角色加 YAML |
 | 字段抽取 | `extraction/head_map.py` + `goods_map.py` + `assemble.py` + `fields.py` | 单 sheet BOX/KV → 表头（#17）；TABLE → 货行并跨表补空（#18）；多摊收成一张报关单（#19）；旧锚点仍给无 sheet 的文本 | PDF 同组装交 #23 |
@@ -76,7 +76,9 @@ FastAPI 交单（#21）：`POST /v1/jobs` 与 `cli declare` 走同一条 pipelin
 
 抽取后校验（#20）：规则先写在 [validate-rules.md](validate-rules.md) 给业务确认。位数 / 正则 / 容差确认后再进数据文件，引擎只执行，不编造、不改值。
 
-云 OCR（#22，选型见 [ocr-benchmark.md](ocr-benchmark.md)）：`adapters/parsers/ocr.py` 的 `TextinOcrClient`，密钥走 `DOCPARSE_TEXTIN_APP_ID` / `DOCPARSE_TEXTIN_SECRET_CODE`，无密钥只告警不崩。请求带 `straighten=1`，返回的行级 bbox 与页宽高统一以**正立图**为参照系（整页 angle 留档进 warnings，给 #62 版面重建）。PDF 逐页：有文字层抽字块带 bbox；无文字层按 `RENDER_ZOOM=2.0` 渲染 JPEG 走 OCR，bbox 除以 zoom 缩回页面 pt。图片（jpg / png）与扫描 PDF 页走同一 `read_image` 入口。40306 QPS 限流按官方说明不重试、只告警。换 OCR 引擎只在 `ocr.py` 加一个 client 实现 `OcrClient` 协议，不动 `pdf.py` / `image.py` / pipeline。
+云 OCR（#22，选型见 [ocr-benchmark.md](ocr-benchmark.md)）：`adapters/parsers/ocr.py` 的 `TextinOcrClient`，密钥走 `DOCPARSE_TEXTIN_APP_ID` / `DOCPARSE_TEXTIN_SECRET_CODE`，无密钥只告警不崩。请求带 `straighten=1`，返回的行级 bbox 与页宽高统一以**正立图**为参照系（整页 angle 留档进 warnings）。PDF 逐页：有文字层抽字块带 bbox；无文字层按 `RENDER_ZOOM=2.0` 渲染 JPEG 走 OCR，bbox 除以 zoom 缩回页面 pt。图片（jpg / png）与扫描 PDF 页走同一 `read_image` 入口。40306 QPS 限流按官方说明不重试、只告警。换 OCR 引擎只在 `ocr.py` 加一个 client 实现 `OcrClient` 协议，不动 `pdf.py` / `image.py` / pipeline。
+
+OCR 版面重建（#62）：`pipeline/steps/reconstruct_layout.py` 挂在 extract 之后、classify 之前。文档有 `pages[].blocks` 且无 `sheets` 时，`adapters/parsers/ocr_layout.py` 按行带聚类 + 分区列切分造伪格子（地址 `p{页}r{行}c{列}`，bbox / block_ids 回指原字块），再复用 `layout.split_sheet` + `sheet_role`。xlsx 已有 sheets 原样跳过。词表 / 刀法零新增。端到端出报关单交 #23。本地对眼：`python -m docparse.cli layout scan.pdf`。
 
 每个 parser 只做一件事：`bytes + filename → DocumentIR`。
 

--- a/src/docparse/adapters/parsers/__init__.py
+++ b/src/docparse/adapters/parsers/__init__.py
@@ -6,6 +6,7 @@ from docparse.adapters.parsers.ocr import (
     TextinOcrClient,
     get_ocr_client,
 )
+from docparse.adapters.parsers.ocr_layout import reconstruct_document, reconstruct_page
 from docparse.adapters.parsers.registry import parse_bytes
 
 __all__ = [
@@ -16,4 +17,6 @@ __all__ = [
     "detect_kind",
     "get_ocr_client",
     "parse_bytes",
+    "reconstruct_document",
+    "reconstruct_page",
 ]

--- a/src/docparse/adapters/parsers/ocr_layout.py
+++ b/src/docparse/adapters/parsers/ocr_layout.py
@@ -1,0 +1,406 @@
+"""OCR 字块 → 伪格子（#62）。
+
+扫描页 / 文字层 PDF 进 IR 后只有 pages[].blocks。xlsx 全链路吃的是
+Sheet.cells + split_sheet 拆出的 KV / 表。本模块只做几何重建：
+
+    行带聚类 → 分区列切分 → 同列跨行合并 → 压缩空行 → Sheet.cells
+
+表头 KV 与商品表各自定列，避免商品列边界把框表标签挤进同一格。
+随后复用 layout.split_sheet + sheet_role，不写第二套词表 / 刀法。
+已有 sheets 的文档（xlsx）原样返回。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from docparse.adapters.parsers.layout import split_sheet
+from docparse.domain.ir import BoundingBox, Cell, DocumentIR, Page, Sheet, TextBlock
+from docparse.extraction.sheet_role import classify_sheets
+
+# 行带：中心 y 差 ≤ max(行高×比例, 绝对下限) 并入同一行。
+# 半岛真机行带约 65px（#60）；文字层 PDF 是 pt，取绝对值下限兜底。
+_ROW_GAP_RATIO = 0.55
+_ROW_GAP_MIN = 8.0
+# 列边界：相邻字块 x 中心差超过这个倍数才切开。
+_COL_GAP_RATIO = 0.55
+_COL_GAP_MIN = 12.0
+# 跨行合并：下一行同列字块相对当前格高度不超过这个倍数。
+_MERGE_HEIGHT_RATIO = 1.6
+# 表头行：优先用含 TABLE token 的行定列；找不到再用最密的一行。
+_HEADER_MIN_BLOCKS = 3
+
+
+@dataclass
+class _Placed:
+    block: TextBlock
+    bbox: BoundingBox
+
+    @property
+    def cx(self) -> float:
+        return (self.bbox.x0 + self.bbox.x1) / 2.0
+
+    @property
+    def cy(self) -> float:
+        return (self.bbox.y0 + self.bbox.y1) / 2.0
+
+    @property
+    def height(self) -> float:
+        return max(self.bbox.y1 - self.bbox.y0, 1.0)
+
+    @property
+    def width(self) -> float:
+        return max(self.bbox.x1 - self.bbox.x0, 1.0)
+
+
+@dataclass
+class _Band:
+    items: list[_Placed]
+
+    @property
+    def y0(self) -> float:
+        return min(item.bbox.y0 for item in self.items)
+
+    @property
+    def y1(self) -> float:
+        return max(item.bbox.y1 for item in self.items)
+
+    @property
+    def cy(self) -> float:
+        return (self.y0 + self.y1) / 2.0
+
+    @property
+    def height(self) -> float:
+        return max(self.y1 - self.y0, 1.0)
+
+
+def reconstruct_document(document: DocumentIR) -> DocumentIR:
+    """有 pages[].blocks 且无 sheets 时重建伪 sheet；否则原样返回。"""
+    if document.sheets:
+        return document
+    pages = [page for page in document.pages if any(_usable(block) for block in page.blocks)]
+    if not pages:
+        return document
+    sheets = [reconstruct_page(page) for page in pages]
+    rebuilt = document.model_copy(update={"sheets": sheets})
+    classify_sheets(rebuilt)
+    return rebuilt
+
+
+def reconstruct_page(page: Page) -> Sheet:
+    """一页字块 → 一张伪 sheet（name = 页号），已跑 split_sheet。"""
+    placed = [_place(block) for block in page.blocks if _usable(block)]
+    if not placed:
+        return split_sheet(Sheet(name=str(page.page_number), cells=[]))
+    bands = _cluster_rows(placed)
+    cells = _cells_by_region(bands, page.page_number)
+    return split_sheet(Sheet(name=str(page.page_number), cells=cells))
+
+
+def _usable(block: TextBlock) -> bool:
+    return bool(block.text.strip()) and block.bbox is not None
+
+
+def _place(block: TextBlock) -> _Placed:
+    assert block.bbox is not None
+    return _Placed(block=block, bbox=block.bbox)
+
+
+def _cluster_rows(placed: list[_Placed]) -> list[_Band]:
+    """按 y 中心聚类成行带，行内再按 x 排序。"""
+    ordered = sorted(placed, key=lambda item: (item.cy, item.cx))
+    bands: list[_Band] = []
+    for item in ordered:
+        if bands and _same_row(item, bands[-1]):
+            bands[-1].items.append(item)
+            continue
+        bands.append(_Band(items=[item]))
+    for band in bands:
+        band.items.sort(key=lambda item: item.cx)
+    return bands
+
+
+def _same_row(item: _Placed, band: _Band) -> bool:
+    gap = max(band.height * _ROW_GAP_RATIO, _ROW_GAP_MIN)
+    return abs(item.cy - band.cy) <= gap
+
+
+def _cells_by_region(bands: list[_Band], page_number: int) -> list[Cell]:
+    """表头 KV 与商品表分区定列，行号跨区连续。"""
+    header = _header_band(bands)
+    if header is None:
+        return _cells_from_bands(bands, _column_bounds(bands), page_number, 0)
+    header_idx = bands.index(header)
+    pre, post = bands[:header_idx], bands[header_idx:]
+    cells: list[Cell] = []
+    if pre:
+        cells.extend(_cells_from_bands(pre, _column_bounds(pre), page_number, 0))
+    used_rows = {cell.row or 0 for cell in cells}
+    offset = max(used_rows) if used_rows else 0
+    cells.extend(_cells_from_bands(post, _column_bounds(post), page_number, offset))
+    return cells
+
+
+def _column_bounds(bands: list[_Band]) -> list[tuple[float, float]]:
+    """列区间：优先用表头行；框表区按行内空隙投票，避免标题长块带偏。"""
+    if not bands:
+        return [(0.0, 1.0)]
+    header = _header_band(bands)
+    if header is not None:
+        return _bounds_from_seeds(header.items, bands)
+    # 框表：用最密的标签行定列（海关框表同一行标签最多），取值行只往已定列里放。
+    label_bands = [band for band in bands if _looks_like_label_band(band)]
+    if label_bands:
+        densest_label = max(label_bands, key=lambda band: len(band.items))
+        return _bounds_from_seeds(densest_label.items, bands)
+    seed_bands = bands
+    cuts = _gap_cuts(seed_bands)
+    left = _span_x0(bands) - 1.0
+    right = _span_x1(bands) + 1.0
+    if not cuts:
+        densest = max(seed_bands, key=lambda band: len(band.items)).items
+        return _bounds_from_seeds(densest, bands)
+    bounds: list[tuple[float, float]] = []
+    start = left
+    for cut in cuts:
+        bounds.append((start, cut))
+        start = cut
+    bounds.append((start, right))
+    return bounds
+
+
+def _bounds_from_seeds(seeds: list[_Placed], bands: list[_Band]) -> list[tuple[float, float]]:
+    if not seeds:
+        return [(_span_x0(bands), _span_x1(bands))]
+    widths = [item.width for item in seeds]
+    typical = sorted(widths)[len(widths) // 2]
+    gap = max(typical * _COL_GAP_RATIO, _COL_GAP_MIN)
+    groups: list[list[_Placed]] = [[seeds[0]]]
+    for item in seeds[1:]:
+        if item.cx - groups[-1][-1].cx > gap:
+            groups.append([item])
+        else:
+            groups[-1].append(item)
+    edges = [_group_x(group) for group in groups]
+    mids = [(edges[i][1] + edges[i + 1][0]) / 2.0 for i in range(len(edges) - 1)]
+    left = min(edges[0][0], _span_x0(bands)) - 1.0
+    right = max(edges[-1][1], _span_x1(bands)) + 1.0
+    bounds: list[tuple[float, float]] = []
+    start = left
+    for mid in mids:
+        bounds.append((start, mid))
+        start = mid
+    bounds.append((start, right))
+    return bounds
+
+
+def _gap_cuts(bands: list[_Band]) -> list[float]:
+    """框表区：收集各行相邻字块之间的空隙中点，相近的并成列缝。"""
+    raw: list[float] = []
+    for band in bands:
+        items = sorted(band.items, key=lambda item: item.cx)
+        if len(items) < 2:
+            continue
+        widths = [item.width for item in items]
+        typical = sorted(widths)[len(widths) // 2]
+        min_gap = max(typical * _COL_GAP_RATIO, _COL_GAP_MIN)
+        for left, right in zip(items, items[1:], strict=False):
+            if right.bbox.x0 - left.bbox.x1 >= min_gap:
+                raw.append((left.bbox.x1 + right.bbox.x0) / 2.0)
+    if not raw:
+        return []
+    raw.sort()
+    clusters: list[list[float]] = [[raw[0]]]
+    merge_tol = max(_COL_GAP_MIN, (raw[-1] - raw[0]) * 0.04)
+    for cut in raw[1:]:
+        if cut - clusters[-1][-1] <= merge_tol:
+            clusters[-1].append(cut)
+        else:
+            clusters.append([cut])
+    # 多行时丢掉只出现一次的缝（标题长块空隙）；单行框表直接用该行的缝。
+    voters = sum(1 for band in bands if len(band.items) >= 2)
+    need = 2 if voters >= 2 else 1
+    return [sum(group) / len(group) for group in clusters if len(group) >= need]
+
+
+def _looks_like_label_band(band: _Band) -> bool:
+    """标签行：多数是短标签，且没有长取值（公司名 / 单号）。"""
+    if len(band.items) < 2:
+        return False
+    short = 0
+    long = 0
+    numeric = 0
+    for item in band.items:
+        text = item.block.text.strip()
+        if _looks_numeric(text):
+            numeric += 1
+        elif len(text) <= 12:
+            short += 1
+        elif len(text) >= 18:
+            long += 1
+    if long:
+        return False
+    return short >= 2 and short > numeric
+
+
+def _looks_numeric(text: str) -> bool:
+    compact = text.replace(",", "").replace(".", "", 1)
+    return bool(compact) and compact.isdigit()
+
+
+def _header_band(bands: list[_Band]) -> _Band | None:
+    from docparse.schema.loader import load_layout_vocab
+
+    tokens = load_layout_vocab().table_tokens()
+    best: _Band | None = None
+    best_hits = 0
+    for band in bands:
+        if len(band.items) < _HEADER_MIN_BLOCKS:
+            continue
+        hits = sum(1 for item in band.items if _hits_token(item.block.text, tokens))
+        if hits >= 2 and hits > best_hits:
+            best = band
+            best_hits = hits
+    return best
+
+
+def _hits_token(text: str, tokens: tuple[str, ...]) -> bool:
+    return any(token.casefold() in text.casefold() for token in tokens)
+
+
+def _group_x(group: list[_Placed]) -> tuple[float, float]:
+    return min(item.bbox.x0 for item in group), max(item.bbox.x1 for item in group)
+
+
+def _span_x0(bands: list[_Band]) -> float:
+    return min(item.bbox.x0 for band in bands for item in band.items)
+
+
+def _span_x1(bands: list[_Band]) -> float:
+    return max(item.bbox.x1 for band in bands for item in band.items)
+
+
+def _assign_column(item: _Placed, columns: list[tuple[float, float]]) -> int:
+    """按水平重叠最大列归属。同左缘、值更宽时中心会漂到下一列，不能只看 cx。"""
+    best = 0
+    best_overlap = -1.0
+    for index, (left, right) in enumerate(columns):
+        overlap = min(item.bbox.x1, right) - max(item.bbox.x0, left)
+        if overlap > best_overlap:
+            best_overlap = overlap
+            best = index
+    if best_overlap > 0:
+        return best
+    for index, (left, right) in enumerate(columns):
+        if left <= item.cx < right:
+            return index
+    return len(columns) - 1
+
+
+def _cells_from_bands(
+    bands: list[_Band],
+    columns: list[tuple[float, float]],
+    page_number: int,
+    row_offset: int,
+) -> list[Cell]:
+    """行带 × 列区间 → 格子；稀疏续行并入上一格后压缩行号。"""
+    grid: list[list[_Placed | None]] = []
+    for band in bands:
+        row: list[_Placed | None] = [None] * len(columns)
+        for item in band.items:
+            col = _assign_column(item, columns)
+            row[col] = _join_same_cell(row[col], item)
+        grid.append(row)
+
+    consumed: set[tuple[int, int]] = set()
+    for row_idx, row in enumerate(grid):
+        for col_idx, seed in enumerate(row):
+            if seed is None or (row_idx, col_idx) in consumed:
+                continue
+            last = row_idx
+            for nxt in range(row_idx + 1, len(grid)):
+                other = grid[nxt][col_idx]
+                if other is None:
+                    continue
+                if not _should_merge(
+                    grid[nxt], members_height=seed, other=other, row_gap=nxt - last
+                ):
+                    break
+                seed = _join_same_cell(seed, other)
+                grid[row_idx][col_idx] = seed
+                grid[nxt][col_idx] = None
+                consumed.add((nxt, col_idx))
+                last = nxt
+
+    kept = [row for row in grid if any(item is not None for item in row)]
+    cells: list[Cell] = []
+    for row_idx, row in enumerate(kept):
+        for col_idx, item in enumerate(row):
+            if item is None:
+                continue
+            cells.append(_make_cell(item, row_offset + row_idx + 1, col_idx + 1, page_number))
+    return cells
+
+
+def _join_same_cell(existing: _Placed | None, incoming: _Placed) -> _Placed:
+    """同一格多个字块：同行空格连接，跨行换行连接。"""
+    if existing is None:
+        return incoming
+    sep = "\n" if incoming.bbox.y0 >= existing.bbox.y1 - 1 else " "
+    text = f"{existing.block.text}{sep}{incoming.block.text}".strip()
+    bbox = _union_bbox(existing.bbox, incoming.bbox)
+    ids = ",".join(
+        part for part in (existing.block.block_id, incoming.block.block_id) if part
+    )
+    block = existing.block.model_copy(
+        update={"text": text, "bbox": bbox, "block_id": ids or existing.block.block_id}
+    )
+    return _Placed(block=block, bbox=bbox)
+
+
+def _should_merge(
+    next_row: list[_Placed | None],
+    *,
+    members_height: _Placed,
+    other: _Placed,
+    row_gap: int,
+) -> bool:
+    """品名 / 规格跨行：下一行几乎只有这一列，且紧贴上一格。"""
+    if row_gap > 1:
+        return False
+    limit = max(members_height.height * _MERGE_HEIGHT_RATIO, _ROW_GAP_MIN)
+    if other.bbox.y0 - members_height.bbox.y1 > limit:
+        return False
+    filled = sum(1 for item in next_row if item is not None)
+    # 数据行 / 框表标签行多列有值，不并；续行通常只剩品名或规格一列。
+    if filled > 1:
+        return False
+    if other.width > members_height.width * 1.8:
+        return False
+    return True
+
+
+def _make_cell(item: _Placed, row: int, column: int, page_number: int) -> Cell:
+    text = item.block.text.strip()
+    ids: list[str] = []
+    for part in (item.block.block_id or "").split(","):
+        if part and part not in ids:
+            ids.append(part)
+    return Cell(
+        address=f"p{page_number}r{row}c{column}",
+        value=text,
+        raw_value=text or None,
+        row=row,
+        column=column,
+        bbox=item.bbox,
+        block_ids=ids,
+    )
+
+
+def _union_bbox(left: BoundingBox, right: BoundingBox) -> BoundingBox:
+    return BoundingBox(
+        x0=min(left.x0, right.x0),
+        y0=min(left.y0, right.y0),
+        x1=max(left.x1, right.x1),
+        y1=max(left.y1, right.y1),
+    )

--- a/src/docparse/cli.py
+++ b/src/docparse/cli.py
@@ -5,6 +5,7 @@ import json
 from pathlib import Path
 from uuid import uuid4
 
+from docparse.adapters.parsers.ocr_layout import reconstruct_document
 from docparse.adapters.parsers.registry import parse_bytes
 from docparse.extraction.goods_map import map_document_goods, map_sheet_goods
 from docparse.extraction.head_map import map_sheet_head
@@ -65,7 +66,9 @@ def _parse(path: Path) -> int:
 
 
 def _layout(path: Path) -> int:
-    document = parse_bytes(path.read_bytes(), file_id=uuid4().hex, filename=path.name)
+    document = reconstruct_document(
+        parse_bytes(path.read_bytes(), file_id=uuid4().hex, filename=path.name)
+    )
     payload = {
         "filename": document.filename,
         "warnings": document.warnings,
@@ -88,7 +91,9 @@ def _layout(path: Path) -> int:
 
 
 def _head(path: Path) -> int:
-    document = parse_bytes(path.read_bytes(), file_id=uuid4().hex, filename=path.name)
+    document = reconstruct_document(
+        parse_bytes(path.read_bytes(), file_id=uuid4().hex, filename=path.name)
+    )
     payload = {
         "filename": document.filename,
         "sheets": [
@@ -114,7 +119,9 @@ def _head(path: Path) -> int:
 
 
 def _goods(path: Path) -> int:
-    document = parse_bytes(path.read_bytes(), file_id=uuid4().hex, filename=path.name)
+    document = reconstruct_document(
+        parse_bytes(path.read_bytes(), file_id=uuid4().hex, filename=path.name)
+    )
     payload = {
         "filename": document.filename,
         "sheets": [

--- a/src/docparse/domain/ir.py
+++ b/src/docparse/domain/ir.py
@@ -42,6 +42,9 @@ class Cell(BaseModel):
     merge_range: str | None = None
     formula: str | None = None
     border: CellBorder | None = None
+    # OCR 伪格子回指原字块（#62）。xlsx 格子保持空。
+    bbox: BoundingBox | None = None
+    block_ids: list[str] = Field(default_factory=list)
 
 
 class KeyValue(BaseModel):

--- a/src/docparse/pipeline/runner.py
+++ b/src/docparse/pipeline/runner.py
@@ -17,6 +17,7 @@ from docparse.pipeline.steps.extract_content import extract_content_step
 from docparse.pipeline.steps.extract_fields import extract_fields_step
 from docparse.pipeline.steps.ingest import ingest_step
 from docparse.pipeline.steps.reconcile import reconcile_step
+from docparse.pipeline.steps.reconstruct_layout import reconstruct_layout_step
 from docparse.pipeline.steps.route_review import route_review_step
 from docparse.pipeline.steps.unpack import unpack_step
 from docparse.pipeline.steps.validate import validate_step
@@ -28,6 +29,7 @@ DEFAULT_STEPS: list[tuple[str, Step]] = [
     ("ingest", ingest_step),
     ("unpack", unpack_step),
     ("extract", extract_content_step),
+    ("reconstruct", reconstruct_layout_step),
     ("classify", classify_step),
     ("extract_fields", extract_fields_step),
     ("validate", validate_step),

--- a/src/docparse/pipeline/steps/reconstruct_layout.py
+++ b/src/docparse/pipeline/steps/reconstruct_layout.py
@@ -1,0 +1,8 @@
+from docparse.adapters.parsers.ocr_layout import reconstruct_document
+from docparse.pipeline.context import PipelineContext
+
+
+def reconstruct_layout_step(ctx: PipelineContext) -> None:
+    """有 pages[].blocks 且无 sheets 时重建伪格子；xlsx 路径原样跳过。"""
+    ctx.documents = [reconstruct_document(document) for document in ctx.documents]
+    ctx.package.documents = ctx.documents

--- a/tests/test_ocr_layout.py
+++ b/tests/test_ocr_layout.py
@@ -1,0 +1,337 @@
+"""#62 OCR 版面重建。夹具按 #60 真机 y/x 分布程序造，不含客户数据。"""
+
+from __future__ import annotations
+
+from docparse.adapters.parsers.ocr_layout import reconstruct_document, reconstruct_page
+from docparse.domain.ir import BoundingBox, Cell, DocumentIR, Page, Sheet, TextBlock
+from docparse.extraction.sheet_role import classify_sheet
+from docparse.pipeline.runner import DEFAULT_STEPS
+from docparse.pipeline.steps.reconstruct_layout import reconstruct_layout_step
+
+# 半岛真机（#60）：行带约 65px，列中心大致
+# 项号 70 / HS+品名 116 / 数量 768 / 单价 929 / 总价 1020 / 原产国 1088
+_ROW_H = 65.0
+_TABLE_XS = {
+    "项号": (50, 90),
+    "商品编号": (100, 250),
+    "商品名称及规格型号": (260, 520),
+    "数量": (740, 800),
+    "单价": (900, 960),
+    "总价": (990, 1050),
+    "原产国": (1070, 1140),
+}
+
+
+def _block(block_id: str, text: str, x0: float, y0: float, x1: float, y1: float) -> TextBlock:
+    return TextBlock(
+        block_id=block_id,
+        text=text,
+        bbox=BoundingBox(x0=x0, y0=y0, x1=x1, y1=y1),
+        ocr_confidence=0.98,
+    )
+
+
+def _kv_pair(
+    prefix: str,
+    key: str,
+    value: str,
+    *,
+    x: float,
+    y: float,
+    key_w: float = 90,
+    val_w: float = 160,
+    h: float = 22,
+    gap: float = 28,
+) -> list[TextBlock]:
+    """上标签下取值（框表 below 策略）。"""
+    return [
+        _block(f"{prefix}k", key, x, y, x + key_w, y + h),
+        _block(f"{prefix}v", value, x, y + gap, x + val_w, y + gap + h),
+    ]
+
+
+def peninsula_like_blocks() -> list[TextBlock]:
+    """合成报关单页：框表 KV + 商品表（含跨行品名）。数字是自造的。"""
+    blocks: list[TextBlock] = [
+        _block("t1", "中华人民共和国海关出口货物报关单", 40, 20, 520, 48),
+    ]
+    # 框表：备案号 / 境外发货人 左右；件数 / 毛重 / 净重 横排
+    blocks.extend(_kv_pair("man", "备案号", "T0000W000001", x=40, y=70, val_w=140))
+    blocks.extend(
+        _kv_pair(
+            "cons",
+            "境外发货人",
+            "NORTHWIND TRADING LIMITED",
+            x=360,
+            y=70,
+            key_w=100,
+            val_w=280,
+        )
+    )
+    blocks.extend(_kv_pair("pk", "件数", "214", x=40, y=150, key_w=50, val_w=60))
+    blocks.extend(_kv_pair("gw", "毛重", "1459.62", x=160, y=150, key_w=50, val_w=80))
+    blocks.extend(_kv_pair("nw", "净重", "485", x=280, y=150, key_w=50, val_w=60))
+
+    header_y = 260.0
+    for name, (x0, x1) in _TABLE_XS.items():
+        blocks.append(_block(f"h-{name}", name, x0, header_y, x1, header_y + 24))
+
+    goods = [
+        ("1", "1905310000", "黄油酥饼", "120", "1.2", "144", "中国"),
+        ("2", "1905900000", "巧克力派", "80", "2.5", "200", "中国"),
+        ("3", "1806320000", "夹心饼干", "14", "3.1", "43.4", "中国"),
+    ]
+    y = header_y + _ROW_H
+    for index, (gno, hs, name, qty, price, total, origin) in enumerate(goods, start=1):
+        values = {
+            "项号": gno,
+            "商品编号": hs,
+            "商品名称及规格型号": name,
+            "数量": qty,
+            "单价": price,
+            "总价": total,
+            "原产国": origin,
+        }
+        for col, text in values.items():
+            x0, x1 = _TABLE_XS[col]
+            blocks.append(_block(f"g{index}-{col}", text, x0, y, x1, y + 22))
+        if index == 1:
+            # 第 1 件规格跨到下一行同列（多行格）
+            nx0, nx1 = _TABLE_XS["商品名称及规格型号"]
+            blocks.append(
+                _block("g1-spec", "规格:原味", nx0, y + 28, nx0 + 90, y + 48)
+            )
+        y += _ROW_H
+    return blocks
+
+
+def peninsula_like_document() -> DocumentIR:
+    blocks = peninsula_like_blocks()
+    return DocumentIR(
+        document_id="d1",
+        file_id="f1",
+        filename="scan.pdf",
+        media_type="application/pdf",
+        pages=[Page(page_number=1, width=1200, height=800, blocks=blocks)],
+        raw_text="\n".join(block.text for block in blocks),
+    )
+
+
+def _kv(sheet, key: str) -> str | None:
+    for item in sheet.key_values:
+        if item.key == key:
+            return item.value
+    return None
+
+
+class TestReconstructPeninsulaLike:
+    def test_rebuilds_kv_and_goods_table(self) -> None:
+        document = reconstruct_document(peninsula_like_document())
+        assert len(document.sheets) == 1
+        sheet = document.sheets[0]
+        assert sheet.name == "1"
+        assert _kv(sheet, "备案号") == "T0000W000001"
+        assert _kv(sheet, "境外发货人") == "NORTHWIND TRADING LIMITED"
+        assert _kv(sheet, "件数") == "214"
+        assert _kv(sheet, "毛重") == "1459.62"
+        assert _kv(sheet, "净重") == "485"
+        assert sheet.tables
+        table = sheet.tables[0]
+        assert "项号" in table.headers
+        assert "商品编号" in table.headers
+        assert len(table.rows) == 3
+        first = table.rows[0]
+        assert first["项号"] == "1"
+        assert first["商品编号"] == "1905310000"
+        assert first["数量"] == "120"
+
+    def test_merges_multiline_goods_name(self) -> None:
+        document = reconstruct_document(peninsula_like_document())
+        table = document.sheets[0].tables[0]
+        name_header = next(h for h in table.headers if "商品名称" in h)
+        assert "黄油酥饼" in table.rows[0][name_header]
+        assert "规格:原味" in table.rows[0][name_header]
+        # 规格行没有另开一件商品
+        assert len(table.rows) == 3
+
+    def test_cells_point_back_to_blocks(self) -> None:
+        document = reconstruct_document(peninsula_like_document())
+        sheet = document.sheets[0]
+        hit = next(cell for cell in sheet.cells if cell.value == "T0000W000001")
+        assert hit.bbox is not None
+        assert hit.block_ids
+        assert all(item.startswith("man") or item for item in hit.block_ids)
+        assert hit.address.startswith("p1r")
+
+    def test_sheet_role_is_draft(self) -> None:
+        document = reconstruct_document(peninsula_like_document())
+        sheet = classify_sheet(document.sheets[0], filename="scan.pdf")
+        assert sheet.role == "draft"
+        assert sheet.consume == "primary"
+
+
+class TestReconstructGuards:
+    def test_skips_document_that_already_has_sheets(self) -> None:
+        existing = Sheet(
+            name="一般贸易出口",
+            cells=[Cell(address="A1", value="已有格子", row=1, column=1)],
+        )
+        original = DocumentIR(
+            document_id="xlsx",
+            file_id="x",
+            filename="draft.xlsx",
+            media_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            pages=[
+                Page(
+                    page_number=1,
+                    blocks=[_block("ignored", "备案号", 10, 10, 80, 30)],
+                )
+            ],
+            sheets=[existing],
+        )
+        rebuilt = reconstruct_document(original)
+        assert rebuilt.sheets is original.sheets
+        assert rebuilt.sheets[0].cells[0].value == "已有格子"
+
+    def test_empty_pages_stay_sheetless(self) -> None:
+        document = DocumentIR(
+            document_id="d2",
+            file_id="f2",
+            filename="blank.pdf",
+            media_type="application/pdf",
+            pages=[Page(page_number=1, width=100, height=100, blocks=[])],
+        )
+        rebuilt = reconstruct_document(document)
+        assert rebuilt.sheets == []
+
+    def test_blocks_without_bbox_are_ignored(self) -> None:
+        document = DocumentIR(
+            document_id="d3",
+            file_id="f3",
+            filename="nobbox.pdf",
+            media_type="application/pdf",
+            pages=[
+                Page(
+                    page_number=1,
+                    blocks=[TextBlock(block_id="a", text="备案号")],
+                )
+            ],
+        )
+        rebuilt = reconstruct_document(document)
+        assert rebuilt.sheets == []
+
+    def test_two_pages_become_two_sheets(self) -> None:
+        page1 = Page(
+            page_number=1,
+            width=400,
+            height=200,
+            blocks=[_block("a", "备案号", 10, 10, 80, 30), _block("b", "X1", 10, 40, 80, 60)],
+        )
+        page2 = Page(
+            page_number=2,
+            width=400,
+            height=200,
+            blocks=[_block("c", "件数", 10, 10, 50, 30), _block("d", "3", 10, 40, 40, 60)],
+        )
+        document = DocumentIR(
+            document_id="d4",
+            file_id="f4",
+            filename="two.pdf",
+            media_type="application/pdf",
+            pages=[page1, page2],
+        )
+        rebuilt = reconstruct_document(document)
+        assert [sheet.name for sheet in rebuilt.sheets] == ["1", "2"]
+
+
+class TestPipelineHook:
+    def test_step_sits_between_extract_and_classify(self) -> None:
+        names = [name for name, _ in DEFAULT_STEPS]
+        assert names.index("extract") + 1 == names.index("reconstruct")
+        assert names.index("reconstruct") + 1 == names.index("classify")
+
+    def test_step_rebuilds_sheets_on_context(self) -> None:
+        class _Pkg:
+            def __init__(self) -> None:
+                self.documents: list[DocumentIR] = []
+
+        class _Ctx:
+            def __init__(self) -> None:
+                self.documents = [peninsula_like_document()]
+                self.package = _Pkg()
+
+        ctx = _Ctx()
+        reconstruct_layout_step(ctx)
+        assert ctx.documents[0].sheets
+        assert ctx.documents[0].sheets[0].key_values
+        assert ctx.package.documents is ctx.documents
+
+
+class TestColumnOverlap:
+    def test_wider_value_stays_under_short_label(self) -> None:
+        """同左缘、值更宽时按重叠归属，不漂到下一列。"""
+        page = Page(
+            page_number=1,
+            width=400,
+            height=160,
+            blocks=[
+                _block("k1", "件数", 10, 10, 40, 28),
+                _block("k2", "备案号", 200, 10, 240, 28),
+                _block("k3", "毛重", 320, 10, 360, 28),
+                _block("v1", "214", 10, 40, 40, 58),
+                _block("v2", "T5352W000228", 200, 40, 300, 58),
+                _block("v3", "12.5", 320, 40, 360, 58),
+            ],
+        )
+        sheet = reconstruct_page(page)
+        pairs = {item.key: item.value for item in sheet.key_values}
+        assert pairs.get("备案号") == "T5352W000228"
+        assert pairs.get("件数") == "214"
+
+    def test_long_title_does_not_steal_box_columns(self) -> None:
+        """横贯标题不当列种子；短标签行定列，值按重叠落回标签列。"""
+        page = Page(
+            page_number=1,
+            width=800,
+            height=220,
+            blocks=[
+                _block("title", "中华人民共和国海关出口货物报关单", 80, 10, 520, 32),
+                _block("k1", "境外发货人", 40, 50, 100, 70),
+                _block("k2", "运输方式", 240, 50, 300, 70),
+                _block("k3", "备案号", 520, 50, 560, 70),
+                _block("v1", "NORTHWIND TRADING LIMITED", 40, 80, 220, 100),
+                _block("v2", "公路运输", 240, 80, 300, 100),
+                _block("v3", "T0000W000001", 520, 80, 600, 100),
+                _block("k4", "件数", 40, 130, 80, 150),
+                _block("k5", "毛重", 200, 130, 240, 150),
+                _block("k6", "净重", 360, 130, 400, 150),
+                _block("v4", "214", 40, 160, 80, 180),
+                _block("v5", "1459.62", 200, 160, 260, 180),
+                _block("v6", "485", 360, 160, 400, 180),
+            ],
+        )
+        sheet = reconstruct_page(page)
+        pairs = {item.key: item.value for item in sheet.key_values}
+        assert pairs.get("备案号") == "T0000W000001"
+        assert pairs.get("境外发货人") == "NORTHWIND TRADING LIMITED"
+        assert pairs.get("件数") == "214"
+        assert pairs.get("毛重") == "1459.62"
+        assert pairs.get("净重") == "485"
+
+
+class TestReconstructPageAddress:
+    def test_address_uses_page_row_column(self) -> None:
+        page = Page(
+            page_number=3,
+            width=300,
+            height=120,
+            blocks=[
+                _block("a", "项号", 10, 10, 40, 28),
+                _block("b", "数量", 80, 10, 120, 28),
+                _block("c", "单价", 160, 10, 200, 28),
+            ],
+        )
+        sheet = reconstruct_page(page)
+        addresses = {cell.address for cell in sheet.cells}
+        assert "p3r1c1" in addresses
+        assert all(item.startswith("p3r") for item in addresses)


### PR DESCRIPTION
Closes #62

## 做了什么

扫描件 / 文字层 PDF 进 IR 后只有 `pages[].blocks`（text + bbox）。xlsx 全链路吃的是 `Sheet.cells` + `split_sheet` 拆出的 KV / 表。本 PR 补中间层：按几何把散字块拼回格子，再复用现有版面刀，不写第二套词表。

```text
PDF/图 → OCR 字块（#22）
       → 伪格子 Sheet.cells（本 PR）
       → layout.split_sheet + sheet_role（现成）
       → head_map / goods_map / assemble（#23 端到端）
```

xlsx 已有 sheets 的文档这一步原样跳过。

### 几何规则（相对容差，不写死样本坐标）

| Excel 已有的 | OCR 这边怎么得到 |
|---|---|
| 同一行 | 字块中心 y 差 ≤ 行高×0.55（下限 8pt）→ 同一行带 |
| 同一列 | 框表用最密标签行、商品表用 TABLE 表头行，按相邻空隙切列；值按水平重叠最大列归属 |
| 一个格子 | 第 r 行 × 第 c 列合成 Cell，地址 `p{页}r{行}c{列}` |
| 合并格（品名跨两行） | 下一行同列、几乎只有这一列有字、高度贴着 → 换行并入上一格后压缩空行 |

伪格子带 `bbox` / `block_ids` 回指原字块。分区定列：表头 KV 与商品表各自切列，避免商品列边界把框表标签挤进同一格。

### 流水线

`reconstruct` 挂在 extract 之后、classify 之前。`cli layout / head / goods` 对 PDF 也先重建再打印。

不改：字段目录、词表内容、映射、组装、校验、parser、FastAPI 路由。客户原件不进仓库。

## 验收对照

- [x] 合成 blocks 夹具能重建 KV + 商品表（件数 / 毛重 / 净重 / 备案号 / 境外发货人 + 3 行货表）
- [x] 多行格（品名 + 规格）合并成一个格子，不另开一件商品
- [x] 伪 sheet 能被现有 sheet_role 识别为 draft
- [x] `layout_vocab.yaml` 零新增
- [x] 客户原件不进仓库；测试全离线
- [x] ruff / pytest 通过（178 passed / 3 skipped）

半岛真机（本地人工，OCR 额度用尽后改用坐标回放）：件毛净 214 / 1459.62 / 485 在包装种类表；境外发货人 Peninsula Merchandising Limited；备案号 T5352W000228 与值同列；商品项号 1–6 + 7–19 两页都在。端到端出报关单交 #23。

## 以后新 xlsx / 新叫法改哪

| 场景 | 改哪 | 动不动 Python |
|---|---|---|
| 新框表 / 商品表叫法 | `layout_vocab.yaml`（BOX / TABLE），与 xlsx 同一套 | 否 |
| 行带太宽 / 太窄（两行并一行或一行拆两行） | `ocr_layout.py` 的 `_ROW_GAP_RATIO` / `_ROW_GAP_MIN` | 否（改常量） |
| 列切太碎 / 切不开 | `_COL_GAP_RATIO` / `_COL_GAP_MIN` | 否（改常量） |
| 品名跨行该并没并 / 不该并并了 | `_MERGE_HEIGHT_RATIO` 与「下一行几乎只有一列」 | 是（一处判定） |
| 新格子关系（不是新文案） | 另开刀法 Issue，不动本模块 | - |
| PDF 出报关单 JSON | #23 | - |

不要 `if 半岛`。不要在本层写字段锚点。

## 不改

字段目录、词表内容、head_map / goods_map / assemble、校验、FastAPI 路由、OCR 引擎。