### PR TITLE
feat: PDF 伪 sheet 接入同一套抽取 / 组装 / 校验（#23）

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -8,6 +8,7 @@
 PYTHONPATH=src uvicorn docparse.api.app:app --host 127.0.0.1 --port 8088
 # 浏览器打开 http://127.0.0.1:8088/review
 python -m docparse.cli declare /绝对路径/表.xlsx --agent-code 4403180867 --agent-name 深圳市泰洲物流有限公司
+python -m docparse.cli declare /绝对路径/草单.pdf
 ```
 
 ## 请求
@@ -16,7 +17,7 @@ python -m docparse.cli declare /绝对路径/表.xlsx --agent-code 4403180867 --
 
 | 部分 | 来源 | 说明 |
 |---|---|---|
-| `file` | 上传 | 本期 xlsx；以后同一接口接 PDF / zip |
+| `file` | 上传 | xlsx / xls / PDF / jpg / png（同一 `POST /v1/jobs`）；zip 以后拼单 |
 | `agentCode` / `agentName` / `agentScc` / `agentCiqCode` | `fields.yaml` `caller_params` | 不解析。没传则用 YAML `default`（泰洲） |
 | `cusIEFlag` | `assembly.defaults` 可覆盖 | 默认 `E`；进口传 `I` |
 | `run` | 已有 | 默认 true，同步跑完 |
@@ -65,7 +66,7 @@ Job
 | 多一个申报单位字段 | `caller_params` 加一项 | 否（Form / OpenAPI 从 YAML 生成） |
 | 换默认申报单位 | `caller_params` 的 `default` | 否 |
 | 调用方要覆盖进出口标志 | 请求带 `cusIEFlag` | 否 |
-| 以后上传 PDF | #22 / #23 parser | 否（同一 `POST /v1/jobs`） |
+| 上传 PDF / 图片 | 已接同一 `POST /v1/jobs`（#22/#62/#23） | 否 |
 | zip 多文件拼一张单 | assemble / `extract_fields_step` 主文档选择 | 否（入口已是 list） |
 | 校验规则 | #20 数据文件 | 否（同一接口自动带闸） |
 | 结构化日志 / 错误码 | `api/errors.py` + request_id | 只改挂钩处 |

--- a/docs/assemble.md
+++ b/docs/assemble.md
@@ -4,6 +4,7 @@
 
 ```bash
 python -m docparse.cli declare /绝对路径/表.xlsx
+python -m docparse.cli declare /绝对路径/草单.pdf
 python -m docparse.cli declare /绝对路径/表.xlsx --agent-code 4403180867 --agent-name 深圳市泰洲物流有限公司
 ```
 
@@ -49,6 +50,10 @@ python -m docparse.cli declare /绝对路径/表.xlsx --agent-code 4403180867 --
 
 商品行 `customNetWt` / `customGrossWet` 仍归 #18，本层不改货表。
 
+## 多页草单表头（#23）
+
+PDF 一页一张伪 sheet，都是 `draft`。同角色按文档顺序（页序）走，**先到留下**：第 1 页有备案号 / 件毛净，第 2 页空着或只有续表，不覆盖。跨角色 overwrite 仍覆盖（draft 压过 packing）。xlsx 多 sheet 角色不同，行为不变。
+
 ## 以后新 xlsx / 新叫法改哪
 
 对照 [#31](https://github.com/Baldwinzc/docparse/issues/31)。先 `cli layout`，再 `cli head` / `cli goods`，最后 `cli declare`。
@@ -66,5 +71,6 @@ python -m docparse.cli declare /绝对路径/表.xlsx --agent-code 4403180867 --
 | 发票号要进报关单 | #37 先定落点 | 视目录 |
 | 俗称（莲塘口岸、纸箱）要转码 | #27 | 否 |
 | 货表净重抄毛重 | #18，不在这里改 | 否 |
+| PDF 多页草单表头被后页盖掉 | 同角色取前已内置；不要给 draft 开 `head_from_columns` | 否 |
 
 不要 `if company == "恒信"`。不要把商业单据上的监管方式 / 口岸编进无草单的单。

--- a/docs/goods-map.md
+++ b/docs/goods-map.md
@@ -4,6 +4,7 @@
 
 ```bash
 python -m docparse.cli goods /绝对路径/表.xlsx
+python -m docparse.cli goods /绝对路径/草单.pdf
 ```
 
 本文件只回答「已经打好角色的货表，怎么收成一张货表」。不切格子（layout）、不认角色（#16）、不拼整单（#19）、不转 code（#14）。
@@ -65,6 +66,12 @@ Sheet.tables + consume
 | `contract` | 0 | 合同货表常缺税号，不当默认主表 |
 
 有草单：草单赢。无草单：HS + 申报要素的箱单通常压过只有品名和价的发票。
+
+## 同角色多页接续（#23）
+
+PDF 草单一页一张伪 sheet。第 1 页项号 1–10、第 2 页 11–19，不能按行序对齐（会把 11 补进第 1 件）。
+
+`goods_master.concat_same_role` 默认 true：主表角色相同、且 sheet 名都是页号（`1` / `2`，#62 伪 sheet）时，按文档顺序拼成一张货表。xlsx 具名草单（「一般贸易出口」+「Sheet1」）仍只取主表，其它角色走下面的跨表补空。关掉接续把该键改 false。
 
 ## `goods_map`
 
@@ -132,6 +139,7 @@ Sheet.tables + consume
 | 千克行数量补值须≈净重、毛重补值须≥净重 | 内置规则，容差同 `qty_*` | 否 |
 | 千克行同表成交数量取净重（#75） | 内置规则；千克词表仍是 `weight_units` | 否 |
 | 新合计叫法（如 GRAND TOTAL） | `goods_master.total_row_tokens` | 否 |
+| 同角色多页不要接续（回到按行序补空） | `goods_master.concat_same_role: false` | 否 |
 | 续行落在其它已占字段且非申报要素形状 | `goods_map.py` `_route_leftovers` 补形状判定 | 是，通用规则 |
 | 三行以上叠列（四行一项） | 续行判定天然支持，验收补样本 | 否 |
 | 一列变两字段（新的稳拆） | 新 `goods_map` 值 + 拆分函数 | 是，通用规则，不按公司 |

--- a/docs/head-map.md
+++ b/docs/head-map.md
@@ -4,6 +4,7 @@
 
 ```bash
 python -m docparse.cli head /绝对路径/表.xlsx
+python -m docparse.cli head /绝对路径/草单.pdf
 ```
 
 本文件只回答「一张已经打好角色的 sheet，原文怎么变成表头字段」。不切格子（layout）、不认角色（#16）、不拼整单（#19）、不转 code（#14）。

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -28,10 +28,10 @@ docparse/
 |---|---|---|---|
 | 接入与安全检查 | `pipeline/steps/ingest.py` | 骨架：大小 / 空文件 | 补 MIME、真实类型 |
 | 安全解压 | `adapters/parsers/unpack.py` + `steps/unpack.py` | 骨架：zip 穿越 / 层数 / 体积 | rar/7z、加密包 |
-| 按文件类型解析 | `adapters/parsers/` | 文本可用；Excel 全 sheet + 框表/冒号/双行表头/KV/值域（#9 #15 #29）；PDF 文字层带 bbox / 无文字层渲染→TextIn OCR、图片同入口（#22）；OCR 字块重建伪格子（#62） | 端到端（#23） |
+| 按文件类型解析 | `adapters/parsers/` | 文本可用；Excel 全 sheet + 框表/冒号/双行表头/KV/值域（#9 #15 #29）；PDF 文字层带 bbox / 无文字层渲染→TextIn OCR、图片同入口（#22）；OCR 字块重建伪格子（#62）；伪 sheet 接同一套抽取 / 组装 / 校验（#23） | zip 拼单 |
 | 统一文档 IR | `domain/ir.py` | Cell 含合并/边框/公式；Sheet 含 key_values / tables / role | 非必要不改契约名 |
 | 文档分类 | `extraction/classify.py` + `sheet_role.py` | 文件类型仍占位；sheet 角色看标题/KV/表头（#16） | 新角色加 YAML |
-| 字段抽取 | `extraction/head_map.py` + `goods_map.py` + `assemble.py` + `fields.py` | 单 sheet BOX/KV → 表头（#17）；TABLE → 货行并跨表补空（#18）；多摊收成一张报关单（#19）；旧锚点仍给无 sheet 的文本 | PDF 同组装交 #23 |
+| 字段抽取 | `extraction/head_map.py` + `goods_map.py` + `assemble.py` + `fields.py` | 单 sheet BOX/KV → 表头（#17）；TABLE → 货行并跨表补空（#18）；多摊收成一张报关单（#19）；伪 sheet 同路径（#23：境外发货人锚点、框表标签 fold_key、多页表头取前、同角色货表接续）；旧锚点仍给无 sheet 的文本 | zip 拼单 |
 | 标准化与校验 | `extraction/validate.py` | 骨架：格式 / 证据；业务闸未接 | 规则清单见 [validate-rules.md](validate-rules.md)，确认后由 #20 执行 |
 | 包级对账 | `pipeline/steps/reconcile.py` | 同名字段冲突 | 金额、单号跨文件 |
 | 自动通过 / 待复核 | `pipeline/steps/route_review.py` | 只打状态 | 复核页另开 Issue |
@@ -78,7 +78,9 @@ FastAPI 交单（#21）：`POST /v1/jobs` 与 `cli declare` 走同一条 pipelin
 
 云 OCR（#22，选型见 [ocr-benchmark.md](ocr-benchmark.md)）：`adapters/parsers/ocr.py` 的 `TextinOcrClient`，密钥走 `DOCPARSE_TEXTIN_APP_ID` / `DOCPARSE_TEXTIN_SECRET_CODE`，无密钥只告警不崩。请求带 `straighten=1`，返回的行级 bbox 与页宽高统一以**正立图**为参照系（整页 angle 留档进 warnings）。PDF 逐页：有文字层抽字块带 bbox；无文字层按 `RENDER_ZOOM=2.0` 渲染 JPEG 走 OCR，bbox 除以 zoom 缩回页面 pt。图片（jpg / png）与扫描 PDF 页走同一 `read_image` 入口。40306 QPS 限流按官方说明不重试、只告警。换 OCR 引擎只在 `ocr.py` 加一个 client 实现 `OcrClient` 协议，不动 `pdf.py` / `image.py` / pipeline。
 
-OCR 版面重建（#62）：`pipeline/steps/reconstruct_layout.py` 挂在 extract 之后、classify 之前。文档有 `pages[].blocks` 且无 `sheets` 时，`adapters/parsers/ocr_layout.py` 按行带聚类 + 分区列切分造伪格子（地址 `p{页}r{行}c{列}`，bbox / block_ids 回指原字块），再复用 `layout.split_sheet` + `sheet_role`。xlsx 已有 sheets 原样跳过。词表 / 刀法零新增。端到端出报关单交 #23。本地对眼：`python -m docparse.cli layout scan.pdf`。
+OCR 版面重建（#62）：`pipeline/steps/reconstruct_layout.py` 挂在 extract 之后、classify 之前。文档有 `pages[].blocks` 且无 `sheets` 时，`adapters/parsers/ocr_layout.py` 按行带聚类 + 分区列切分造伪格子（地址 `p{页}r{行}c{列}`，bbox / block_ids 回指原字块），再复用 `layout.split_sheet` + `sheet_role`。xlsx 已有 sheets 原样跳过。词表 / 刀法零新增。本地对眼：`python -m docparse.cli layout scan.pdf`。
+
+PDF 端到端（#23）：伪 sheet 走现有 `classify_sheets` / `head_map` / `goods_map` / `assemble` / `validate`，不另写字段目录。出口「境外发货人」= `consignorEname`（锚点）。框表标签横排走 `fold_key`（`包装种类（22）` 不当商品表）。多页草单表头取前、同角色货表按页序接续。`POST /v1/jobs` 上传 PDF / jpg / png 与 xlsx 同形。本地对眼：`python -m docparse.cli declare scan.pdf`。半岛关键表头对 #60：毛重 1459.62 / 净重 485 / 件数 214 / 备案号 T5352W000228 / 境外发货人 Peninsula Merchandising Limited；对不上 `needs_review`，不编造。客户原件不进仓库。
 
 每个 parser 只做一件事：`bytes + filename → DocumentIR`。
 

--- a/src/docparse/adapters/parsers/layout.py
+++ b/src/docparse/adapters/parsers/layout.py
@@ -182,12 +182,18 @@ def _blank_if_placeholder(text: str) -> str:
     return "" if _is_placeholder(text) else text
 
 
+def _box_norms() -> frozenset[str]:
+    return frozenset(_norm_label(item) for item in _box_labels())
+
+
 def _is_box_label_row(row_cells: list[Cell]) -> bool:
     """框表标签横排（包装种类/件数/毛重…）不当表头。只看 BOX，不看 KV。
 
     占位格视同空（#64）：不占「整行 BOX」的名额，也不破坏判定。
+    词形与 KV 一样走 fold_key（#23）：「包装种类（22）」＝「包装种类」，
+    OCR 尾码不把整行抬成商品表。
     """
-    labels = _box_labels()
+    norms = _box_norms()
     hits = 0
     present = 0
     for cell in row_cells:
@@ -195,7 +201,7 @@ def _is_box_label_row(row_cells: list[Cell]) -> bool:
         if _is_placeholder(cleaned):
             continue
         present += 1
-        if cleaned in labels:
+        if _norm_label(cleaned) in norms:
             hits += 1
     return hits >= 3 and hits == present
 

--- a/src/docparse/extraction/assemble.py
+++ b/src/docparse/extraction/assemble.py
@@ -131,9 +131,14 @@ def declaration_reviews(
 
 
 def _ordered_sheets(document: DocumentIR, policy: Assembly) -> list[Sheet]:
+    """同角色按文档顺序（PDF 页序）。表头取前，不按 sheet 名字符串排。"""
     eligible = [sheet for sheet in document.sheets if sheet.consume not in _SKIP_CONSUME]
     rank = {role: index for index, role in enumerate(policy.role_priority)}
-    return sorted(eligible, key=lambda sheet: (rank.get(sheet.role, len(rank)), sheet.name))
+    order = {id(sheet): index for index, sheet in enumerate(document.sheets)}
+    return sorted(
+        eligible,
+        key=lambda sheet: (rank.get(sheet.role, len(rank)), order.get(id(sheet), 0)),
+    )
 
 
 def _overwrite_roles(policy: Assembly) -> frozenset[str]:
@@ -158,6 +163,7 @@ def _merge_head(
     masters = _overwrite_roles(policy)
     has_draft = _has_master(sheets, policy)
     merged: dict[str, ExtractedField] = {}
+    source_role: dict[str, str] = {}
     for sheet in sheets:
         mode = policy.fill.get(sheet.role, "fill")
         if mode == "ignore":
@@ -173,9 +179,13 @@ def _merge_head(
             current = merged.get(field.name)
             if current is None or not (current.value or "").strip():
                 merged[field.name] = deepcopy(field)
+                source_role[field.name] = sheet.role
                 continue
-            if mode == "overwrite":
+            # 同角色多页：先到的表头留下（PDF 草单跨页取前，#23）。
+            # 跨角色 overwrite 仍覆盖（draft 压过 packing）。
+            if mode == "overwrite" and source_role.get(field.name) != sheet.role:
                 merged[field.name] = deepcopy(field)
+                source_role[field.name] = sheet.role
     return merged
 
 

--- a/src/docparse/extraction/goods_map.py
+++ b/src/docparse/extraction/goods_map.py
@@ -13,6 +13,8 @@ from docparse.schema.textnorm import fold_key, fold_spaced
 _LEADING_HS = re.compile(r"^(\d{8,10})")
 _SKIP_CONSUME = frozenset({"exclude"})
 _GOODS_LAYOUTS = frozenset({"table_col"})
+# PDF 伪 sheet 名是页号（#62 reconstruct）。xlsx 草单名不是数字，不接续。
+_PAGE_SHEET_NAME = re.compile(r"^(sheet\s*\d+|\d+)$", re.IGNORECASE)
 
 
 def map_document_goods(
@@ -35,15 +37,35 @@ def map_document_goods(
     )
     if master_items[0].master_score < schema.goods_master.min_score:
         return []
-    merged = [deepcopy(item) for item in master_items]
+    same_role = [
+        (sheet, items) for sheet, items, _ in mapped if sheet.role == master_sheet.role
+    ]
+    concat_pages = schema.goods_master.concat_same_role and _concat_page_sheets(same_role)
+    if concat_pages:
+        # PDF 草单跨页：页号伪 sheet、项号 1–10 / 11–19 按文档顺序拼一张。
+        # xlsx 两张具名 draft（进料加工 + Sheet1）不走这里，仍只取主表。
+        merged = [deepcopy(item) for _, items in same_role for item in items]
+    else:
+        merged = [deepcopy(item) for item in master_items]
     if schema.goods_master.merge_supplement:
         for sheet, items, _ in mapped:
             if sheet is master_sheet:
+                continue
+            if concat_pages and sheet.role == master_sheet.role:
                 continue
             _merge_by_order(merged, items, schema)
     for item in merged:
         _prefer_net_as_qty(item, schema)
     return merged
+
+
+def _is_page_sheet(sheet: Sheet) -> bool:
+    return bool(_PAGE_SHEET_NAME.match(sheet.name.strip()))
+
+
+def _concat_page_sheets(same_role: list[tuple[Sheet, list[GoodsItem]]]) -> bool:
+    """同角色 ≥2 张且全是页号名 → 跨页接续。具名 xlsx draft 不接。"""
+    return len(same_role) > 1 and all(_is_page_sheet(sheet) for sheet, _ in same_role)
 
 
 def map_sheet_goods(

--- a/src/docparse/schema/fields.yaml
+++ b/src/docparse/schema/fields.yaml
@@ -18,6 +18,9 @@ goods_master:
   # 合计行词表（#68）。任一带这些词的格子整行丢弃，不并单、不成商品。
   # 新叫法（如 GRAND TOTAL）加这里，不写公司分支。
   total_row_tokens: [合计, 合計, 總計, 总计, 小计, 小計, Total, Summary]
+  # 同角色页号伪 sheet 接续（#23）。PDF 草单跨页项号 1–10 / 11–19 拼一张；
+  # xlsx 具名 draft 不接；箱单 / 发票仍按行序补空。
+  concat_same_role: true
   role_bonus:
     draft: 10
     declaration_list: 10
@@ -406,8 +409,8 @@ head:
     group: head
     layout: box_kv
     sources: [customs_declaration]
-    anchors: [境外收货人, 境外收发货人, 买方BUYER, 买方, BUYER, 买 方, Bill To]
-    notes: 出口草单「境外收货人」。出口商业单据买方 / Bill To 只补充。
+    anchors: [境外收货人, 境外发货人, 境外收发货人, 买方BUYER, 买方, BUYER, 买 方, Bill To]
+    notes: 出口草单「境外收货人」；进境备案清单「境外发货人」同一字段。出口商业单据买方 / Bill To 只补充。
 
   - name: ownerName
     display_name: 生产销售单位名称

--- a/src/docparse/schema/loader.py
+++ b/src/docparse/schema/loader.py
@@ -84,6 +84,8 @@ class GoodsMaster(BaseModel):
     total_row_tokens: list[str] = Field(
         default_factory=lambda: ["合计", "合計", "總計", "总计", "小计", "小計", "Total", "Summary"]
     )
+    # 同角色页号伪 sheet 接续（#23）。PDF 草单跨页拼一张；xlsx 具名 draft 不接。
+    concat_same_role: bool = True
 
 
 _FILL_MODES = frozenset({"overwrite", "fill", "ignore"})

--- a/src/docparse/schema/sheet_roles.yaml
+++ b/src/docparse/schema/sheet_roles.yaml
@@ -84,6 +84,8 @@ roles:
           source: GSC 出仓备案清单 BOX
         - text: 境外收货人
           source: GSC 出仓备案清单 BOX
+        - text: 境外发货人
+          source: 进境备案清单 / 半岛扫描件 BOX（#23）
         - text: 生产销售单位
           source: 多科 / 当纳利草单 BOX
       headers:

--- a/tests/test_assemble.py
+++ b/tests/test_assemble.py
@@ -82,6 +82,44 @@ def test_draft_is_copied_and_codes_are_looked_up() -> None:
     assert reviews["iePort"].evidence
 
 
+def test_same_role_pages_keep_first_head() -> None:
+    """两页 draft：第 1 页有备案号，第 2 页空着或另值，表头取前（#23）。"""
+    from docparse.adapters.parsers.layout import split_sheet
+    from docparse.domain.ir import Cell, DocumentIR, Sheet
+    from docparse.extraction.sheet_role import classify_sheet
+
+    def _page(name: str, *, manual: str, pack: str) -> Sheet:
+        cells = [
+            Cell(address="A1", value="中华人民共和国海关出口货物报关单", row=1, column=1),
+            Cell(address="A2", value="备案号", row=2, column=1),
+            Cell(address="A3", value=manual, row=3, column=1),
+            Cell(address="B2", value="件数", row=2, column=2),
+            Cell(address="B3", value=pack, row=3, column=2),
+            Cell(address="A5", value="项号", row=5, column=1),
+            Cell(address="B5", value="商品编号", row=5, column=2),
+            Cell(address="C5", value="商品名称及规格型号", row=5, column=3),
+            Cell(address="A6", value="1", row=6, column=1),
+            Cell(address="B6", value="1905310000", row=6, column=2),
+            Cell(address="C6", value="饼", row=6, column=3),
+        ]
+        sheet = split_sheet(Sheet(name=name, cells=cells))
+        return classify_sheet(sheet, filename="scan.pdf")
+
+    document = DocumentIR(
+        document_id="pages",
+        file_id="f",
+        filename="scan.pdf",
+        media_type="application/pdf",
+        sheets=[
+            _page("1", manual="T5352W000228", pack="214"),
+            _page("2", manual="SHOULD-NOT-WIN", pack="999"),
+        ],
+    )
+    payload = declaration_payload(assemble_declaration(document))
+    assert payload["manualNo"] == "T5352W000228"
+    assert payload["packNo"] == "214"
+
+
 def test_caller_overrides_default_ie_flag() -> None:
     document = _parse({"一般贸易出口": _draft}, "draft-only.xlsx")
     payload = declaration_payload(assemble_declaration(document, agent={"cusIEFlag": "I"}))

--- a/tests/test_excel_layout.py
+++ b/tests/test_excel_layout.py
@@ -204,6 +204,40 @@ def test_box_label_row_is_not_a_table() -> None:
     assert 17 in header_rows
 
 
+def test_box_label_row_folds_trailing_code() -> None:
+    """OCR「包装种类（22）」整行仍当框表标签，值走 below KV，不当商品表（#23）。"""
+    from docparse.adapters.parsers.layout import split_sheet
+    from docparse.domain.ir import Cell, Sheet
+
+    cells = [
+        Cell(address="A1", value="包装种类（22）", row=1, column=1),
+        Cell(address="B1", value="件数", row=1, column=2),
+        Cell(address="C1", value="毛重（千克）", row=1, column=3),
+        Cell(address="D1", value="净重（千克）", row=1, column=4),
+        Cell(address="E1", value="成交方式", row=1, column=5),
+        Cell(address="A2", value="纸箱", row=2, column=1),
+        Cell(address="B2", value="214", row=2, column=2),
+        Cell(address="C2", value="1459.62", row=2, column=3),
+        Cell(address="D2", value="485", row=2, column=4),
+        Cell(address="E2", value="FOB", row=2, column=5),
+        Cell(address="A4", value="项号", row=4, column=1),
+        Cell(address="B4", value="商品编号", row=4, column=2),
+        Cell(address="C4", value="商品名称及规格型号", row=4, column=3),
+        Cell(address="A5", value="1", row=5, column=1),
+        Cell(address="B5", value="1905310000", row=5, column=2),
+        Cell(address="C5", value="黄油酥饼", row=5, column=3),
+    ]
+    sheet = split_sheet(Sheet(name="1", cells=cells))
+    pairs = {item.key: item.value for item in sheet.key_values}
+    assert pairs["包装种类（22）"] == "纸箱"
+    assert pairs["件数"] == "214"
+    assert pairs["毛重（千克）"] == "1459.62"
+    assert pairs["净重（千克）"] == "485"
+    assert len(sheet.tables) == 1
+    assert sheet.tables[0].header_row == 4
+    assert "项号" in sheet.tables[0].headers
+
+
 def _kv_colon_workbook() -> bytes:
     book = Workbook()
     packing = book.active

--- a/tests/test_goods_map.py
+++ b/tests/test_goods_map.py
@@ -232,6 +232,46 @@ def test_ten_digit_customs_code_header_maps_hs() -> None:
     assert items[0].value_of("gname") == "贴纸"
 
 
+def test_same_role_pages_concat_instead_of_row_align() -> None:
+    """两页 draft 项号 1–2 / 3–4 接成 4 行，不把第 2 页第 1 件补进第 1 件（#23）。"""
+    from docparse.adapters.parsers.layout import split_sheet
+    from docparse.domain.ir import Cell, DocumentIR, Sheet
+    from docparse.extraction.sheet_role import classify_sheet
+
+    def _page(name: str, start: int, count: int) -> Sheet:
+        cells = [
+            Cell(address="A1", value="中华人民共和国海关出口货物报关单", row=1, column=1),
+            Cell(address="A2", value="项号", row=2, column=1),
+            Cell(address="B2", value="商品编号", row=2, column=2),
+            Cell(address="C2", value="商品名称及规格型号", row=2, column=3),
+            Cell(address="D2", value="数量", row=2, column=4),
+        ]
+        for offset in range(count):
+            gno = start + offset
+            row = 3 + offset
+            cells.extend(
+                [
+                    Cell(address=f"A{row}", value=str(gno), row=row, column=1),
+                    Cell(address=f"B{row}", value=f"190531000{gno}", row=row, column=2),
+                    Cell(address=f"C{row}", value=f"商品{gno}", row=row, column=3),
+                    Cell(address=f"D{row}", value=str(gno * 10), row=row, column=4),
+                ]
+            )
+        sheet = split_sheet(Sheet(name=name, cells=cells))
+        return classify_sheet(sheet, filename="scan.pdf")
+
+    document = DocumentIR(
+        document_id="pages",
+        file_id="f",
+        filename="scan.pdf",
+        media_type="application/pdf",
+        sheets=[_page("1", 1, 2), _page("2", 3, 2)],
+    )
+    items = map_document_goods(document)
+    assert [item.value_of("gno") for item in items] == ["1", "2", "3", "4"]
+    assert [item.value_of("gname") for item in items] == ["商品1", "商品2", "商品3", "商品4"]
+
+
 def test_packing_fills_gross_when_qty_aligns() -> None:
     document = parse_excel(
         _workbook({"一般贸易出口": _draft, "装箱单": _packing}),

--- a/tests/test_head_map.py
+++ b/tests/test_head_map.py
@@ -136,6 +136,7 @@ def test_schema_head_map_flags() -> None:
     assert schema.field("agentCode").parse is False
     assert "卖方SELLER" in schema.field("tradeName").anchors
     assert "Bill To" in schema.field("consignorEname").anchors
+    assert "境外发货人" in schema.field("consignorEname").anchors
     assert "合同号CONTRACT NO." in schema.field("contrNo").anchors
 
 

--- a/tests/test_pdf_e2e.py
+++ b/tests/test_pdf_e2e.py
@@ -1,0 +1,364 @@
+"""#23 PDF 伪 sheet 接入同一套抽取 / 组装 / 校验。
+
+夹具程序造，不含客户数据。半岛关键表头用 #60 参照数字自造，
+境外发货人用 NORTHWIND，不把客户原件写进仓库。
+"""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+import pytest
+
+from docparse.adapters.files.memory import MemoryFileStore
+from docparse.adapters.jobs.memory import MemoryJobStore
+from docparse.adapters.parsers.ocr import OcrLine, OcrOutcome
+from docparse.adapters.parsers.ocr_layout import reconstruct_document
+from docparse.config import Settings, get_settings
+from docparse.domain.ir import BoundingBox, DocumentIR, Page, TextBlock
+from docparse.extraction.assemble import assemble_declaration, declaration_payload
+from docparse.pipeline.runner import Pipeline
+from docparse.schema.loader import load_schema
+from test_ocr_layout import peninsula_like_blocks, peninsula_like_document
+from test_pdf_ocr import make_jpeg, make_text_pdf
+
+_DEMO = Path("/Users/baldwin/Desktop/taizhou/AI识别Demo")
+REAL_PENINSULA = _DEMO / "SJ25084373-310795HKD.pdf"
+
+_ROW_H = 65.0
+_TABLE_XS = {
+    "项号": (50, 90),
+    "商品编号": (100, 250),
+    "商品名称及规格型号": (260, 520),
+    "数量": (740, 800),
+    "单价": (900, 960),
+    "总价": (990, 1050),
+    "原产国": (1070, 1140),
+}
+
+
+def _block(block_id: str, text: str, x0: float, y0: float, x1: float, y1: float) -> TextBlock:
+    return TextBlock(
+        block_id=block_id,
+        text=text,
+        bbox=BoundingBox(x0=x0, y0=y0, x1=x1, y1=y1),
+        ocr_confidence=0.98,
+    )
+
+
+def _kv_pair(
+    prefix: str,
+    key: str,
+    value: str,
+    *,
+    x: float,
+    y: float,
+    key_w: float = 90,
+    val_w: float = 160,
+    h: float = 22,
+    gap: float = 28,
+) -> list[TextBlock]:
+    return [
+        _block(f"{prefix}k", key, x, y, x + key_w, y + h),
+        _block(f"{prefix}v", value, x, y + gap, x + val_w, y + gap + h),
+    ]
+
+
+def _goods_header(y: float) -> list[TextBlock]:
+    return [
+        _block(f"h-{name}", name, x0, y, x1, y + 24) for name, (x0, x1) in _TABLE_XS.items()
+    ]
+
+
+def _goods_row(
+    index: int,
+    gno: str,
+    hs: str,
+    name: str,
+    qty: str,
+    price: str,
+    total: str,
+    origin: str,
+    y: float,
+) -> list[TextBlock]:
+    values = {
+        "项号": gno,
+        "商品编号": hs,
+        "商品名称及规格型号": name,
+        "数量": qty,
+        "单价": price,
+        "总价": total,
+        "原产国": origin,
+    }
+    blocks: list[TextBlock] = []
+    for col, text in values.items():
+        x0, x1 = _TABLE_XS[col]
+        blocks.append(_block(f"g{index}-{col}", text, x0, y, x1, y + 22))
+    return blocks
+
+
+def two_page_draft_document() -> DocumentIR:
+    """第 1 页表头 + 项号 1–2；第 2 页续表项号 3。数字自造。"""
+    page1: list[TextBlock] = [
+        _block("t1", "中华人民共和国海关出口货物报关单", 40, 20, 520, 48),
+    ]
+    page1.extend(_kv_pair("man", "备案号", "T0000W000001", x=40, y=70, val_w=140))
+    page1.extend(
+        _kv_pair(
+            "cons",
+            "境外发货人",
+            "NORTHWIND TRADING LIMITED",
+            x=360,
+            y=70,
+            key_w=100,
+            val_w=280,
+        )
+    )
+    page1.extend(_kv_pair("pk", "件数", "214", x=40, y=150, key_w=50, val_w=60))
+    page1.extend(_kv_pair("gw", "毛重", "1459.62", x=160, y=150, key_w=50, val_w=80))
+    page1.extend(_kv_pair("nw", "净重", "485", x=280, y=150, key_w=50, val_w=60))
+    header_y = 260.0
+    page1.extend(_goods_header(header_y))
+    page1.extend(
+        _goods_row(
+            1, "1", "1905310000", "黄油酥饼", "120", "1.2", "144", "中国", header_y + _ROW_H
+        )
+    )
+    page1.extend(
+        _goods_row(
+            2, "2", "1905900000", "巧克力派", "80", "2.5", "200", "中国", header_y + 2 * _ROW_H
+        )
+    )
+
+    page2: list[TextBlock] = [
+        _block("t2", "中华人民共和国海关出口货物报关单", 40, 20, 520, 48),
+    ]
+    page2.extend(_goods_header(80.0))
+    page2.extend(
+        _goods_row(3, "3", "1806320000", "夹心饼干", "14", "3.1", "43.4", "中国", 80.0 + _ROW_H)
+    )
+
+    return DocumentIR(
+        document_id="d-two",
+        file_id="f-two",
+        filename="scan.pdf",
+        media_type="application/pdf",
+        pages=[
+            Page(page_number=1, width=1200, height=800, blocks=page1),
+            Page(page_number=2, width=1200, height=800, blocks=page2),
+        ],
+        raw_text="",
+    )
+
+
+def coded_box_document() -> DocumentIR:
+    """包装种类（22）横排标签 + 下一行取值，应走 KV 不当商品表。"""
+    blocks: list[TextBlock] = [
+        _block("t1", "中华人民共和国海关出口货物报关单", 40, 20, 520, 48),
+        _block("k1", "包装种类（22）", 40, 150, 140, 172),
+        _block("k2", "件数", 180, 150, 230, 172),
+        _block("k3", "毛重（千克）", 280, 150, 380, 172),
+        _block("k4", "净重（千克）", 420, 150, 520, 172),
+        _block("k5", "成交方式", 560, 150, 640, 172),
+        _block("v1", "纸箱", 40, 180, 100, 202),
+        _block("v2", "214", 180, 180, 230, 202),
+        _block("v3", "1459.62", 280, 180, 360, 202),
+        _block("v4", "485", 420, 180, 480, 202),
+        _block("v5", "FOB", 560, 180, 610, 202),
+    ]
+    blocks.extend(_kv_pair("man", "备案号", "T0000W000001", x=40, y=70, val_w=140))
+    blocks.extend(
+        _kv_pair(
+            "cons",
+            "境外发货人",
+            "NORTHWIND TRADING LIMITED",
+            x=360,
+            y=70,
+            key_w=100,
+            val_w=280,
+        )
+    )
+    header_y = 280.0
+    blocks.extend(_goods_header(header_y))
+    blocks.extend(
+        _goods_row(1, "1", "1905310000", "黄油酥饼", "120", "1.2", "144", "中国", header_y + _ROW_H)
+    )
+    return DocumentIR(
+        document_id="d-box",
+        file_id="f-box",
+        filename="scan.pdf",
+        media_type="application/pdf",
+        pages=[Page(page_number=1, width=1200, height=800, blocks=blocks)],
+        raw_text="",
+    )
+
+
+def _payload(document: DocumentIR) -> dict:
+    rebuilt = reconstruct_document(document)
+    return declaration_payload(assemble_declaration(rebuilt))
+
+
+def test_peninsula_like_declaration_shape() -> None:
+    payload = _payload(peninsula_like_document())
+    schema = load_schema()
+    for spec in schema.head:
+        assert spec.name in payload
+    assert schema.goods_array in payload
+    assert payload["manualNo"] == "T0000W000001"
+    assert payload["consignorEname"] == "NORTHWIND TRADING LIMITED"
+    assert payload["packNo"] == "214"
+    assert payload["grossWt"] == "1459.62"
+    assert payload["netWt"] == "485"
+    goods = payload[schema.goods_array]
+    assert len(goods) == 3
+    assert goods[0]["gno"] == "1"
+    assert goods[0]["codeTs"] == "1905310000"
+    assert "黄油酥饼" in goods[0]["gname"]
+    assert payload["_meta"]["has_draft"] is True
+
+
+def test_coded_box_labels_map_pack_gross_net() -> None:
+    payload = _payload(coded_box_document())
+    assert payload["packNo"] == "214"
+    assert payload["grossWt"] == "1459.62"
+    assert payload["netWt"] == "485"
+    assert payload["wrapType"] == "纸箱"
+    assert payload["transMode"] == "FOB"
+    assert payload["consignorEname"] == "NORTHWIND TRADING LIMITED"
+    assert len(payload["tdecGoodsitemsVoArr"]) == 1
+
+
+def test_two_page_draft_concatenates_goods_and_keeps_first_head() -> None:
+    payload = _payload(two_page_draft_document())
+    assert payload["manualNo"] == "T0000W000001"
+    assert payload["consignorEname"] == "NORTHWIND TRADING LIMITED"
+    assert payload["packNo"] == "214"
+    goods = payload["tdecGoodsitemsVoArr"]
+    assert [item["gno"] for item in goods] == ["1", "2", "3"]
+    assert goods[2]["gname"] == "夹心饼干"
+
+
+def _pipeline() -> Pipeline:
+    settings = Settings(job_store="memory", file_store="memory", llm_api_key="")
+    return Pipeline(settings=settings, jobs=MemoryJobStore(), files=MemoryFileStore())
+
+
+def test_text_layer_pdf_pipeline_returns_declaration() -> None:
+    pytest.importorskip("pymupdf")
+    job = _pipeline().process("a.pdf", make_text_pdf())
+    assert job.status.value != "failed"
+    assert job.result is not None
+    declaration = job.result.declaration
+    assert declaration is not None
+    schema = load_schema()
+    for spec in schema.head:
+        assert spec.name in declaration
+    assert schema.goods_array in declaration
+
+
+def test_api_upload_pdf_same_shape_as_xlsx() -> None:
+    pytest.importorskip("pymupdf")
+    from fastapi.testclient import TestClient
+
+    from docparse.api.app import create_app
+    from docparse.api.routes import get_pipeline
+
+    pipeline = _pipeline()
+    app = create_app()
+    app.dependency_overrides[get_pipeline] = lambda: pipeline
+    response = TestClient(app).post(
+        "/v1/jobs",
+        files={"file": ("a.pdf", io.BytesIO(make_text_pdf()), "application/pdf")},
+        data={"agentCode": "4403180867", "agentName": "深圳市泰洲物流有限公司"},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    declaration = body["result"]["declaration"]
+    assert "contrNo" in declaration
+    assert "tdecGoodsitemsVoArr" in declaration
+    assert declaration["agentCode"] == "4403180867"
+    assert "_meta" in declaration
+    assert "reviews" in body["result"]
+
+
+def test_api_upload_png_same_shape(monkeypatch: pytest.MonkeyPatch) -> None:
+    pytest.importorskip("pymupdf")
+    from fastapi.testclient import TestClient
+
+    from docparse.api.app import create_app
+    from docparse.api.routes import get_pipeline
+
+    class _Ocr:
+        def read_image(self, data: bytes, *, filename: str) -> OcrOutcome:
+            return OcrOutcome(
+                lines=[
+                    OcrLine(
+                        text=block.text,
+                        x0=block.bbox.x0,
+                        y0=block.bbox.y0,
+                        x1=block.bbox.x1,
+                        y1=block.bbox.y1,
+                        score=0.98,
+                    )
+                    for block in peninsula_like_blocks()
+                    if block.bbox is not None
+                ],
+                width=1200,
+                height=800,
+            )
+
+    monkeypatch.setattr(
+        "docparse.pipeline.steps.extract_content.get_ocr_client",
+        lambda settings=None: _Ocr(),
+    )
+    pipeline = _pipeline()
+    app = create_app()
+    app.dependency_overrides[get_pipeline] = lambda: pipeline
+    response = TestClient(app).post(
+        "/v1/jobs",
+        files={"file": ("scan.png", io.BytesIO(make_jpeg()), "image/png")},
+    )
+    assert response.status_code == 200
+    declaration = response.json()["result"]["declaration"]
+    assert declaration is not None
+    assert declaration["manualNo"] == "T0000W000001"
+    assert declaration["consignorEname"] == "NORTHWIND TRADING LIMITED"
+    assert declaration["packNo"] == "214"
+    assert "tdecGoodsitemsVoArr" in declaration
+    assert len(declaration["tdecGoodsitemsVoArr"]) == 3
+
+
+def _has_textin() -> bool:
+    settings = get_settings()
+    return bool(settings.textin_app_id and settings.textin_secret_code)
+
+
+@pytest.mark.skipif(
+    not REAL_PENINSULA.exists() or not _has_textin(),
+    reason="本地半岛样本 + TextIn 密钥才跑，客户原件不入库",
+)
+def test_peninsula_sample_key_head_fields() -> None:
+    """本地真机：关键表头对 #60；对不上 needs_review，不编造。"""
+    job = _pipeline().process(REAL_PENINSULA.name, REAL_PENINSULA.read_bytes())
+    assert job.status.value != "failed"
+    payload = job.result.declaration if job.result else None
+    assert payload is not None
+    expected = {
+        "grossWt": "1459.62",
+        "netWt": "485",
+        "packNo": "214",
+        "manualNo": "T5352W000228",
+        "consignorEname": "Peninsula Merchandising Limited",
+    }
+    for name, value in expected.items():
+        got = (payload.get(name) or "").strip()
+        if got:
+            assert got == value, f"{name}: got {got!r} expected {value!r}"
+        else:
+            reasons = payload.get("_meta", {}).get("review_reasons") or []
+            assert any(name in reason for reason in reasons) or job.status.value == "needs_review"
+    goods = payload.get("tdecGoodsitemsVoArr") or []
+    if goods:
+        assert len(goods) <= 19
+        assert goods[0].get("gno") in {"1", "01", ""}


### PR DESCRIPTION
Closes #23

## 做了什么

#22 读进字块、#62 重建伪 Sheet 之后，本 PR 把伪 sheet 接进同一套角色 / 映射 / 组装 / 校验，端到端出报关单 JSON。不另写字段目录，不改路由。

```text
PDF/图 → OCR 字块（#22）
       → 伪格子 + split_sheet（#62）
       → classify / head_map / goods_map / assemble / validate（本 PR）
       → 与 xlsx 同形的 declaration
```

#62 留给本 Issue 的两处一并收：

1. `consignorEname.anchors` 补「境外发货人」（只改 YAML）
2. `_is_box_label_row` 与 KV 一样走 `fold_key`，`包装种类（22）` 整行仍当框表标签，值回 below KV；draft 不开 `head_from_columns`

多页报关单：同角色按文档顺序，表头先到留下；货表只对**页号伪 sheet**（`1` / `2`）接续，xlsx 具名 draft（进料加工 + Sheet1）仍只取主表。

## 验收对照

- [x] 输出 JSON 形状与 xlsx 路径相同（head 全键 + `tdecGoodsitemsVoArr`）
- [x] 文字层夹具能出报关单对象（允许部分字段 review）
- [x] 合成半岛形态：备案号 / 境外发货人 / 件数 214 / 毛重 1459.62 / 净重 485 能进表头；两页货表 1–2 + 3 接成 3 行
- [x] OCR `包装种类（22）` 横排不当商品表，件毛净进表头
- [x] API 上传 PDF / png 走通，响应同形
- [x] 客户原件不进仓库
- [x] ruff / pytest 通过（187 passed / 4 skipped）

半岛真机（本地 + TextIn 密钥才跑，CI 跳过）：毛重 1459.62 / 净重 485 / 件数 214 / 备案号 T5352W000228 / 境外发货人 Peninsula Merchandising Limited；对不上 `needs_review`，不编造。

## 以后新 xlsx / 新叫法改哪

| 你看到的现象 | 改哪里 | 动 Python？ |
|---|---|---|
| 新叫法（境外发货人、包装种类尾码） | `fields.yaml` anchors / `layout_vocab.yaml` BOX | 否（尾码已被 fold_key 吃掉） |
| 进境清单「境外发货人」对不上 | `consignorEname.anchors` 已含；新别名仍加 YAML | 否 |
| 框表标签带尾码被抬成商品表 | `_is_box_label_row` 已走 fold_key；新标签加 BOX 词表 | 否 |
| PDF 多页货表没接上 | sheet 名须是页号；`goods_master.concat_same_role` | 否 |
| 同角色多页不要接续 | `goods_master.concat_same_role: false` | 否 |
| 多页表头被后页盖掉 | 同角色取前已内置；不要给 draft 开 `head_from_columns` | 否 |
| 新表头 / 货列 | `fields.yaml` | 否 |
| 新单据角色 | `sheet_roles.yaml` | 否 |
| 上传 PDF / 图片 | 已接同一 `POST /v1/jobs` | 否 |

不要 `if 半岛`。不要给所有 draft 开 `head_from_columns`。

## 不改

zip、新 OCR 厂商、VLM、路由。客户原件不入库。