### PR TITLE
fix: 对眼页上传支持 PDF / 图片（#80）

### DIFF
--- a/src/docparse/api/static/review.html
+++ b/src/docparse/api/static/review.html
@@ -85,7 +85,7 @@ function fieldInput(spec, file) {
   input.name = spec.name;
   if (file) {
     input.type = "file";
-    input.accept = ".xlsx,.xls,.xlsm";
+    input.accept = ".xlsx,.xls,.xlsm,.pdf,.jpg,.jpeg,.png,.tif,.tiff,.webp,.bmp";
     input.required = true;
   } else {
     input.type = "text";
@@ -170,7 +170,7 @@ async function boot() {
   const spec = await fetch("/v1/schema").then((r) => r.json());
   catalog = spec;
   const box = $("fields");
-  box.appendChild(fieldInput({ name: "file", display_name: "xlsx" }, true));
+  box.appendChild(fieldInput({ name: "file", display_name: "文件" }, true));
   for (const item of spec.caller) box.appendChild(fieldInput(item, false));
 }
 


### PR DESCRIPTION
Closes #80

## 做了什么

`POST /v1/jobs` 后端已能收 xlsx / xls / PDF / jpg / png（#21 / #22 / #23），但对眼页 `api/static/review.html` 的文件选择框 `accept` 还写死 `.xlsx,.xls,.xlsm`，浏览器选不了 PDF / 图片。

改两行：

1. `input.accept` 扩成与 `adapters/parsers/detect.py` 一致的后缀：`.xlsx,.xls,.xlsm,.pdf,.jpg,.jpeg,.png,.tif,.tiff,.webp,.bmp`
2. 文件框显示名 `xlsx` → `文件`

后端路由 / pipeline / detect 不动，纯前端。

## 验收对照

- [x] 文件选择框能选 `.pdf` / `.png` / `.jpg`（`accept` 已扩）
- [x] 上传 xlsx 行为不变（`detect_kind` 靠魔数 + 后缀，不依赖 accept）
- [x] 客户原件不进仓库
- [x] ruff / pytest 通过（API 测试 9 passed）

## 以后新 xlsx / 新叫法改哪

| 场景 | 改哪里 | 动 Python？ |
|---|---|---|
| 后端新增可上传的文件类型 | `detect.py` 加后缀 / 魔数；`review.html` 的 `accept` 同步加 | 后端是 Python，前端否 |
| 只想让对眼页收某种文件 | `review.html` 的 `accept` | 否 |

## 不改

路由、pipeline、parser、detect、字段目录。