### PR TITLE
feat: 合单出口 Demo 信封 POST /v1/declare（#86）

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,6 +1,11 @@
 # FastAPI：一张报关单 JSON
 
-`POST /v1/jobs` 收文件和调用方参数，走与 `cli declare` 同一条 pipeline，交出一张报关单。本层不解析、不认公司。对眼页见 [review.md](review.md)。
+两个入口、同一条 pipeline。本层不解析、不认公司。对眼页见 [review.md](review.md)。
+
+| 入口 | 给谁 | 信封 |
+|---|---|---|
+| `POST /v1/jobs` | 对眼页 | Job + `declaration`（名称 + `_meta`）+ `reviews` |
+| `POST /v1/declare` | 合单 | Demo `{code, msg, result, dec_results}`；字段上是 code |
 
 本地：
 
@@ -13,47 +18,61 @@ python -m docparse.cli declare /绝对路径/草单.pdf
 
 ## 请求
 
-`multipart/form-data`。
+两个入口都是 `multipart/form-data`。合单入口忽略 `run`，始终同步跑完。
 
 | 部分 | 来源 | 说明 |
 |---|---|---|
-| `file` | 上传 | xlsx / xls / PDF / jpg / png（同一 `POST /v1/jobs`）；zip 以后拼单 |
+| `file` | 上传 | xlsx / xls / PDF / jpg / png；zip 以后拼单 |
 | `agentCode` / `agentName` / `agentScc` / `agentCiqCode` | `fields.yaml` `caller_params` | 不解析。没传则用 YAML `default`（泰洲） |
 | `cusIEFlag` | `assembly.defaults` 可覆盖 | 默认 `E`；进口传 `I` |
-| `run` | 已有 | 默认 true，同步跑完 |
+| `run` | 仅 `/v1/jobs` | 默认 true，同步跑完 |
 
 Form 字段名单从 YAML 生成。未知键忽略，不 400。
 
 每个请求生成 `X-Request-Id`（可自带），写进响应头和 Job。
 
-## 响应
-
-还是 Job 信封：
+## 对眼响应（`POST /v1/jobs`）
 
 ```text
 Job
   status              succeeded | needs_review | failed
   request_id
   caller              请求里收下的调用方参数
-  result.declaration  与 cli declare 同一份 JSON（含 _meta）
+  result.declaration  与 cli declare 同一份 JSON（含 _meta；字段上是名称）
   result.reviews      字段级 status + 证据（sheet / cell / quote）
   result.package      IR / 旧 fields，调试用
   result.error        仅 failed
 ```
 
-`declaration` 缺的键空字符串，不删键。合单系统丢掉 `_meta` / `reviews` 即可提交。
+`declaration` 缺的键空字符串，不删键。
+
+## 合单响应（`POST /v1/declare`）
+
+```text
+{
+  code          0 成功 / 1 待复核不交 / 2 解析失败
+  msg
+  result        true 仅 code=0
+  dec_results   成功时一张报关单；否则 null
+}
+```
+
+`dec_results`：剥 `_meta` / 货行 `_source`；有码的字段写 code；`dataSource` / `promiseItem*` 出口填死；`packName` / `packType` 复制 `wrapType`；货行 `id` 出口生成。策略在 `fields.yaml` `declare_export`。
+
+**不交**：除放行项外仍有 `needs_review`，或 `failed`。HTTP 仍 200。放行项默认 `gmodel_raw` 与 `code_table_pending`（#11 不编 `0|0|...`；币制等码表未就绪不挡合单）。转不出码、缺毛重、件毛净对不上仍不交。
 
 ## 错误分界
 
 | HTTP | 何时 |
 |---|---|
 | 400 | 空文件、超大、没带 file |
-| 200 + `needs_review` | 缺字段、转不出 code、件毛净对不上 |
-| 200 + `failed` | 解析/组装 runner 已接住的失败 |
-| 404 | job 不存在 |
+| 200 + Job `needs_review` | 对眼：缺字段、转不出 code、件毛净对不上 |
+| 200 + `{code:1, dec_results:null}` | 合单：同上，不交单 |
+| 200 + Job `failed` / `{code:2}` | 解析/组装 runner 已接住的失败 |
+| 404 | job 不存在（仅 `/v1/jobs/{id}`） |
 | 500 | 没映射到的服务器异常 |
 
-业务失败不是 500。映射只在 `api/errors.py`。
+业务失败不是 500。映射只在 `api/errors.py`。合单信封在 `api/export_dec.py`。
 
 ## 以后新 xlsx / 新叫法改哪
 
@@ -66,9 +85,13 @@ Job
 | 多一个申报单位字段 | `caller_params` 加一项 | 否（Form / OpenAPI 从 YAML 生成） |
 | 换默认申报单位 | `caller_params` 的 `default` | 否 |
 | 调用方要覆盖进出口标志 | 请求带 `cusIEFlag` | 否 |
-| 上传 PDF / 图片 | 已接同一 `POST /v1/jobs`（#22/#62/#23） | 否 |
+| 上传 PDF / 图片 | 已接同一入口（#22/#62/#23） | 否 |
 | zip 多文件拼一张单 | assemble / `extract_fields_step` 主文档选择 | 否（入口已是 list） |
 | 校验规则 | #20 数据文件 | 否（同一接口自动带闸） |
+| 合单要多一个忽略键默认值 | `declare_export.constants` | 否 |
+| 合单要复制某字段（如 packName） | `declare_export.aliases` | 否 |
+| 合单多一种可放行的复核原因 | `declare_export.allow_reasons` / `allow_fields` | 否 |
+| 合单信封 / code 数字 | `api/export_dec.py` | 只改出口 |
 | 结构化日志 / 错误码 | `api/errors.py` + request_id | 只改挂钩处 |
 
-不要 `if company == "恒信"`。不要在 `routes.py` 写死 `agent*`。
+不要 `if company == "恒信"`。不要在 `routes.py` 写死 `agent*`。不要把 `/v1/jobs` 改成 Demo 信封。

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -36,6 +36,7 @@ docparse/
 | 包级对账 | `pipeline/steps/reconcile.py` | 同名字段冲突 | 金额、单号跨文件 |
 | 自动通过 / 待复核 | `pipeline/steps/route_review.py` | 只打状态 | 复核页另开 Issue |
 | FastAPI 交单 | `api/routes.py` + `pipeline/runner.py` | `POST /v1/jobs` 交 `declaration` + `reviews`（#21） | PDF / zip 拼单不改路由 |
+| 合单信封 | `api/export_dec.py` + `POST /v1/declare` | Demo `{code,msg,result,dec_results}`（#86）；`needs_review` 不交 | 新常量 / 别名 / 放行原因改 YAML |
 | 对眼页 | `api/static/review.html` + `GET /v1/schema` | 只画报关单 + reviews（#44） | 不渲染 IR |
 | 持久化接口 | `adapters/jobs/` `adapters/files/` | 内存实现；Postgres/S3 抛未实现 | 需要跨进程时再做 |
 | 云 LLM | `adapters/llm/openai_compat.py` | 未配 Key 则跳过 | 换供应商只改这里 |
@@ -70,7 +71,7 @@ sheet 角色（#16 / #65）：`schema/sheet_roles.yaml` + `extraction/sheet_role
 
 整单组装（#19）：`extraction/assemble.py` 按 `fields.yaml` 的 `assembly` 收成一张报关单。有 `draft` 抄草单，商业单据只补空并核件毛净；无草单只抄能确定的商业事实，`customs_only` 空着复核。名称转 code；转不出留原文。`agent*` 只来自调用参数。表头只有净重时视同重量，不抄进毛重。本地对眼：`python -m docparse.cli declare file.xlsx`。见 [assemble.md](assemble.md)。
 
-FastAPI 交单（#21）：`POST /v1/jobs` 与 `cli declare` 走同一条 pipeline。调用方参数跟 `caller_params` 走，不写死四个 agent。响应是 Job + `result.declaration` + `result.reviews`。见 [api.md](api.md)。
+FastAPI 交单（#21 / #86）：`POST /v1/jobs` 与 `cli declare` 走同一条 pipeline，响应对眼用的 Job。合单走 `POST /v1/declare`，出口在 `api/export_dec.py`，策略在 `fields.yaml` `declare_export`。调用方参数跟 `caller_params` 走，不写死四个 agent。见 [api.md](api.md)。
 
 对眼页（#44）：`GET /review` 静态页 + `GET /v1/schema`。只画报关单和复核证据，不渲染 IR。见 [review.md](review.md)。
 

--- a/src/docparse/api/app.py
+++ b/src/docparse/api/app.py
@@ -5,7 +5,8 @@ from uuid import uuid4
 from fastapi import FastAPI, Request
 
 from docparse.api.errors import unhandled_error_handler
-from docparse.api.routes import REQUEST_ID_HEADER, router
+from docparse.api.routes import router
+from docparse.api.submit import REQUEST_ID_HEADER
 from docparse.config import get_settings
 
 

--- a/src/docparse/api/export_dec.py
+++ b/src/docparse/api/export_dec.py
@@ -1,0 +1,118 @@
+"""合单信封。对眼页继续吃 Job；本层只改出口，不解析。"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from uuid import uuid4
+
+from docparse.domain.models import Job, JobStatus
+from docparse.schema.loader import Schema, load_schema
+
+OK_CODE = 0
+HOLD_CODE = 1
+FAIL_CODE = 2
+OK_MSG = "操作成功"
+HOLD_MSG = "待复核，不交单"
+FAIL_MSG = "解析失败"
+_META_KEY = "_meta"
+_SOURCE_KEY = "_source"
+_CODES_KEY = "codes"
+
+
+def to_dec_envelope(job: Job, schema: Schema | None = None) -> dict:
+    """Job → Demo `{code, msg, result, dec_results}`。needs_review / failed 不交单。"""
+    schema = schema or load_schema()
+    if job.status == JobStatus.FAILED:
+        return _envelope(FAIL_CODE, job.error or FAIL_MSG, False, None)
+    if job.status != JobStatus.SUCCEEDED and _blocking(job, schema):
+        return _envelope(HOLD_CODE, HOLD_MSG, False, None)
+    declaration = job.result.declaration if job.result is not None else None
+    if not declaration:
+        return _envelope(HOLD_CODE, HOLD_MSG, False, None)
+    return _envelope(OK_CODE, OK_MSG, True, public_declaration(declaration, schema))
+
+
+def public_declaration(declaration: dict, schema: Schema | None = None) -> dict:
+    """剥对眼键，码写进字段，补合单常量。不改传入对象。"""
+    schema = schema or load_schema()
+    policy = schema.declare_export
+    payload = deepcopy(declaration)
+    meta = payload.pop(_META_KEY, {}) or {}
+    codes = meta.get(_CODES_KEY) or {}
+    _apply_codes(payload, codes, schema.goods_array)
+    goods = payload.get(schema.goods_array) or []
+    for item in goods:
+        item.pop(_SOURCE_KEY, None)
+        if policy.goods_id:
+            item["id"] = str(uuid4())
+    payload[schema.goods_array] = goods
+    for name, value in policy.constants.items():
+        payload[name] = value
+    for alias, source in policy.aliases.items():
+        payload[alias] = payload.get(source, "")
+    return payload
+
+
+def _blocking(job: Job, schema: Schema) -> bool:
+    if job.result is None or job.result.declaration is None:
+        return True
+    allowed_reasons = frozenset(schema.declare_export.allow_reasons)
+    allowed_fields = frozenset(schema.declare_export.allow_fields)
+    goods_array = schema.goods_array
+    for item in job.result.reviews:
+        if _review_allowed(item.path, item.reasons, allowed_fields, allowed_reasons, goods_array):
+            continue
+        return True
+    return False
+
+
+def _review_allowed(
+    path: str,
+    reasons: list[str],
+    allowed_fields: frozenset[str],
+    allowed_reasons: frozenset[str],
+    goods_array: str,
+) -> bool:
+    field = _field_from_path(path, goods_array)
+    if field in allowed_fields:
+        return True
+    return all(_reason_allowed(reason, allowed_reasons) for reason in reasons)
+
+
+def _reason_allowed(reason: str, allowed: frozenset[str]) -> bool:
+    if reason in allowed:
+        return True
+    return any(reason.startswith(f"{token}:") for token in allowed)
+
+
+def _field_from_path(path: str, goods_array: str) -> str:
+    if path.startswith(("goods[", f"{goods_array}[")) and "." in path:
+        return path.rsplit(".", 1)[-1]
+    return path
+
+
+def _apply_codes(payload: dict, codes: dict, goods_array: str) -> None:
+    goods = payload.get(goods_array) or []
+    for path, code in codes.items():
+        text = str(code or "").strip()
+        if not text:
+            continue
+        if path.startswith(f"{goods_array}[") and "." in path:
+            index_text, name = path[len(goods_array) + 1 :].split("].", 1)
+            try:
+                index = int(index_text)
+            except ValueError:
+                continue
+            if 0 <= index < len(goods):
+                goods[index][name] = text
+            continue
+        payload[path] = text
+
+
+def _envelope(code: int, msg: str, ok: bool, dec_results: dict | None) -> dict:
+    return {
+        "code": code,
+        "msg": msg,
+        "result": ok,
+        "dec_results": dec_results,
+    }

--- a/src/docparse/api/routes.py
+++ b/src/docparse/api/routes.py
@@ -6,16 +6,15 @@ from pathlib import Path
 from fastapi import APIRouter, Depends, Request
 from fastapi.responses import FileResponse
 
-from docparse.api.caller import RESERVED_FORM_KEYS, collect_caller
 from docparse.api.catalog import schema_catalog
-from docparse.api.errors import bad_request, not_found
-from docparse.api.schemas import JOB_EXAMPLE, multipart_openapi
+from docparse.api.errors import not_found
+from docparse.api.export_dec import to_dec_envelope
+from docparse.api.schemas import DECLARE_EXAMPLE, JOB_EXAMPLE, multipart_openapi
+from docparse.api.submit import submit_upload
 from docparse.domain.models import Job
 from docparse.pipeline.runner import Pipeline
 
 _REVIEW_PAGE = Path(__file__).with_name("static") / "review.html"
-
-REQUEST_ID_HEADER = "X-Request-Id"
 
 router = APIRouter()
 
@@ -23,17 +22,6 @@ router = APIRouter()
 @lru_cache(maxsize=1)
 def get_pipeline() -> Pipeline:
     return Pipeline()
-
-
-def _request_id(request: Request) -> str:
-    header = request.headers.get(REQUEST_ID_HEADER)
-    if header:
-        return header
-    return getattr(request.state, "request_id", "")
-
-
-def _truthy(value: object) -> bool:
-    return str(value).strip().lower() not in {"0", "false", "no", ""}
 
 
 @router.get("/health")
@@ -62,31 +50,20 @@ async def create_job(
     request: Request,
     pipeline: Pipeline = Depends(get_pipeline),
 ) -> Job:
-    form = await request.form()
-    upload = form.get("file")
-    if upload is None or not hasattr(upload, "read"):
-        raise bad_request("missing file")
-    data = await upload.read()
-    filename = getattr(upload, "filename", None) or "upload.bin"
-    fields = {
-        key: str(value)
-        for key, value in form.items()
-        if key not in RESERVED_FORM_KEYS and not hasattr(value, "filename")
-    }
-    caller = collect_caller(fields)
-    run_value = form.get("run", "true")
-    try:
-        job = pipeline.submit(
-            filename,
-            data,
-            caller=caller,
-            request_id=_request_id(request) or None,
-        )
-    except ValueError as exc:
-        raise bad_request(str(exc)) from exc
-    if _truthy(run_value):
-        job = pipeline.run_job(job.id)
-    return job
+    return await submit_upload(request, pipeline)
+
+
+@router.post(
+    "/v1/declare",
+    openapi_extra=multipart_openapi(),
+    responses={200: {"content": {"application/json": {"example": DECLARE_EXAMPLE}}}},
+)
+async def create_declaration(
+    request: Request,
+    pipeline: Pipeline = Depends(get_pipeline),
+) -> dict:
+    job = await submit_upload(request, pipeline, run=True)
+    return to_dec_envelope(job)
 
 
 @router.get("/v1/jobs/{job_id}", response_model=Job)

--- a/src/docparse/api/schemas.py
+++ b/src/docparse/api/schemas.py
@@ -5,6 +5,25 @@ from __future__ import annotations
 from docparse.api.caller import accepted_caller_keys
 from docparse.schema.loader import Schema, load_schema
 
+DECLARE_EXAMPLE = {
+    "code": 0,
+    "msg": "操作成功",
+    "result": True,
+    "dec_results": {
+        "contrNo": "HDX2026-251",
+        "grossWt": "296.46",
+        "netWt": "218.375",
+        "agentCode": "4403180867",
+        "agentName": "深圳市泰洲物流有限公司",
+        "supvModeCdde": "0110",
+        "dataSource": "7",
+        "tdecGoodsitemsVoArr": [
+            {"gname": "表壳配件/壳体", "gqty": "150", "gunit": "008"},
+        ],
+    },
+}
+
+
 JOB_EXAMPLE = {
     "id": "ab12cd",
     "status": "needs_review",

--- a/src/docparse/api/submit.py
+++ b/src/docparse/api/submit.py
@@ -1,0 +1,52 @@
+"""上传 form → pipeline。/v1/jobs 与 /v1/declare 共用，不复制解析。"""
+
+from __future__ import annotations
+
+from fastapi import Request
+
+from docparse.api.caller import RESERVED_FORM_KEYS, collect_caller
+from docparse.api.errors import bad_request
+from docparse.domain.models import Job
+from docparse.pipeline.runner import Pipeline
+
+REQUEST_ID_HEADER = "X-Request-Id"
+
+
+def request_id(request: Request) -> str:
+    header = request.headers.get(REQUEST_ID_HEADER)
+    if header:
+        return header
+    return getattr(request.state, "request_id", "")
+
+
+def truthy(value: object) -> bool:
+    return str(value).strip().lower() not in {"0", "false", "no", ""}
+
+
+async def submit_upload(request: Request, pipeline: Pipeline, *, run: bool | None = None) -> Job:
+    form = await request.form()
+    upload = form.get("file")
+    if upload is None or not hasattr(upload, "read"):
+        raise bad_request("missing file")
+    data = await upload.read()
+    filename = getattr(upload, "filename", None) or "upload.bin"
+    fields = {
+        key: str(value)
+        for key, value in form.items()
+        if key not in RESERVED_FORM_KEYS and not hasattr(value, "filename")
+    }
+    caller = collect_caller(fields)
+    if run is None:
+        run = truthy(form.get("run", "true"))
+    try:
+        job = pipeline.submit(
+            filename,
+            data,
+            caller=caller,
+            request_id=request_id(request) or None,
+        )
+    except ValueError as exc:
+        raise bad_request(str(exc)) from exc
+    if run:
+        job = pipeline.run_job(job.id)
+    return job

--- a/src/docparse/schema/fields.yaml
+++ b/src/docparse/schema/fields.yaml
@@ -82,6 +82,22 @@ assembly:
     copy_net_to_gross: false
   invoice_vocab: invoice_no
 
+# 合单出口（#86）。对眼页仍走 /v1/jobs；本段只给 POST /v1/declare。
+# 新忽略键的合单默认值加 constants；新别名复制加 aliases；新放行原因 / 字段加 allow_*。
+# 抽取不写这些键；不要按公司填。
+declare_export:
+  constants:
+    dataSource: "7"
+    promiseItem1: "0"
+    promiseItem2: "0"
+    promiseItem3: "0"
+  aliases:
+    packName: wrapType
+    packType: wrapType
+  goods_id: true
+  allow_reasons: [gmodel_raw, code_table_pending]
+  allow_fields: [gmodel]
+
 document_types:
   - customs_declaration
   - invoice
@@ -200,7 +216,7 @@ ignored:
     layout: none
     parse: false
     ignore: true
-    notes: json 标注可忽略。不要生成 UUID。输出商品项时不要写这个键。
+    notes: json 标注可忽略。抽取不写。合单出口（#86）按 declare_export.goods_id 生成，不进抽取。
 
   - name: sysBillNo
     display_name: 公司单据编号

--- a/src/docparse/schema/loader.py
+++ b/src/docparse/schema/loader.py
@@ -120,12 +120,23 @@ class Assembly(BaseModel):
         return self
 
 
+class DeclareExport(BaseModel):
+    """合单信封（#86）。对眼页不读这里。新默认值 / 别名 / 放行原因加 YAML。"""
+
+    constants: dict[str, str] = Field(default_factory=dict)
+    aliases: dict[str, str] = Field(default_factory=dict)
+    goods_id: bool = False
+    allow_reasons: list[str] = Field(default_factory=list)
+    allow_fields: list[str] = Field(default_factory=list)
+
+
 class Schema(BaseModel):
     version: int = 2
     document_types: list[str] = Field(default_factory=list)
     goods_array: str = "tdecGoodsitemsVoArr"
     goods_master: GoodsMaster = Field(default_factory=GoodsMaster)
     assembly: Assembly = Field(default_factory=Assembly)
+    declare_export: DeclareExport = Field(default_factory=DeclareExport)
     port_mapping: list[PortMapping] = Field(default_factory=list)
     caller_params: list[FieldSpec] = Field(default_factory=list)
     ignored: list[FieldSpec] = Field(default_factory=list)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -16,7 +16,7 @@ from docparse.api.app import create_app
 from docparse.api.routes import get_pipeline
 from docparse.config import Settings
 from docparse.pipeline.runner import Pipeline
-from xlsx_fixtures import _draft, _net_only_packing, _workbook
+from xlsx_fixtures import _coded_draft, _draft, _net_only_packing, _workbook
 
 
 def _client() -> TestClient:
@@ -120,6 +120,84 @@ def test_missing_file_is_400() -> None:
     assert response.status_code == 400
 
 
+def test_declare_coded_draft_returns_dec_results() -> None:
+    response = _client().post(
+        "/v1/declare",
+        files={"file": _xlsx({"一般贸易出口": _coded_draft}, "coded.xlsx")},
+        data={"agentCode": "4403180867", "agentName": "深圳市泰洲物流有限公司"},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["code"] == 0
+    assert body["result"] is True
+    assert body["msg"] == "操作成功"
+    dec = body["dec_results"]
+    assert dec["contrNo"] == "HDX2026-251"
+    assert dec["grossWt"] == "296.46"
+    assert dec["supvModeCdde"] == "0110"
+    assert dec["cusTrafMode"] == "4"
+    assert dec["transMode"] == "3"
+    assert dec["wrapType"] == "99"
+    assert dec["packName"] == "99"
+    assert dec["packType"] == "99"
+    assert dec["iePort"] == "5304"
+    assert dec["dataSource"] == "7"
+    assert dec["promiseItem1"] == "0"
+    assert "_meta" not in dec
+    goods = dec["tdecGoodsitemsVoArr"]
+    assert goods
+    assert goods[0]["gname"] == "表壳配件/壳体"
+    assert goods[0]["gunit"] == "008"
+    assert goods[0]["cusOriginCountry"] == "CHN"
+    assert goods[0]["destinationCountry"] == "HKG"
+    assert goods[0]["districtCode"] == "44139"
+    assert "_source" not in goods[0]
+    assert goods[0]["id"]
+    assert "一般贸易" not in str(dec)
+
+
+def test_declare_unknown_code_does_not_submit() -> None:
+    response = _client().post(
+        "/v1/declare",
+        files={"file": _xlsx({"一般贸易出口": _draft}, "hengxin.xlsx")},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["code"] != 0
+    assert body["result"] is False
+    assert body["dec_results"] is None
+
+
+def test_declare_missing_gross_does_not_submit() -> None:
+    response = _client().post(
+        "/v1/declare",
+        files={"file": _xlsx({"总箱单": _net_only_packing}, "net-only.xlsx")},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["code"] != 0
+    assert body["result"] is False
+    assert body["dec_results"] is None
+
+
+def test_jobs_still_returns_meta_when_declare_holds() -> None:
+    response = _client().post(
+        "/v1/jobs",
+        files={"file": _xlsx({"一般贸易出口": _draft}, "hengxin.xlsx")},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "needs_review"
+    assert body["result"]["declaration"]["_meta"]
+    assert body["result"]["declaration"]["supvModeCdde"] == "一般贸易"
+    assert body["result"]["reviews"]
+
+
+def test_declare_missing_file_is_400() -> None:
+    response = _client().post("/v1/declare", data={"agentCode": "4403180867"})
+    assert response.status_code == 400
+
+
 def test_openapi_shows_caller_and_goods_array() -> None:
     spec = _client().get("/openapi.json").json()
     text = str(spec)
@@ -127,6 +205,7 @@ def test_openapi_shows_caller_and_goods_array() -> None:
     assert "4403180867" in text
     assert "tdecGoodsitemsVoArr" in text
     assert "/v1/jobs" in spec["paths"]
+    assert "/v1/declare" in spec["paths"]
     assert "/health" in spec["paths"]
 
 

--- a/tests/test_export_dec.py
+++ b/tests/test_export_dec.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from docparse.api.export_dec import public_declaration, to_dec_envelope
+from docparse.domain.models import FieldReview, Job, JobStatus, ParseJobResult
+from docparse.schema.loader import load_schema
+
+
+def _job(
+    *,
+    status: JobStatus,
+    declaration: dict | None,
+    reviews: list[FieldReview] | None = None,
+) -> Job:
+    return Job(
+        source_filename="x.xlsx",
+        status=status,
+        result=ParseJobResult(
+            status=status,
+            declaration=declaration,
+            reviews=reviews or [],
+        ),
+    )
+
+
+def test_public_declaration_strips_meta_and_writes_codes() -> None:
+    schema = load_schema()
+    source = {
+        "contrNo": "HDX2026-251",
+        "supvModeCdde": "一般贸易",
+        "wrapType": "其他包装",
+        "tdecGoodsitemsVoArr": [
+            {
+                "gname": "表壳配件/壳体",
+                "gunit": "只",
+                "_source": {"role": "draft", "sheet": "一般贸易出口"},
+            }
+        ],
+        "_meta": {
+            "codes": {
+                "supvModeCdde": "0110",
+                "wrapType": "99",
+                "tdecGoodsitemsVoArr[0].gunit": "008",
+            }
+        },
+    }
+    payload = public_declaration(source, schema)
+    assert payload["supvModeCdde"] == "0110"
+    assert payload["wrapType"] == "99"
+    assert payload["packName"] == "99"
+    assert payload["packType"] == "99"
+    assert payload["dataSource"] == "7"
+    assert payload["promiseItem1"] == "0"
+    assert "_meta" not in payload
+    assert "_source" not in payload["tdecGoodsitemsVoArr"][0]
+    assert payload["tdecGoodsitemsVoArr"][0]["gunit"] == "008"
+    assert payload["tdecGoodsitemsVoArr"][0]["id"]
+    assert source["_meta"]["codes"]["supvModeCdde"] == "0110"
+    assert "_source" in source["tdecGoodsitemsVoArr"][0]
+
+
+def test_gmodel_raw_alone_still_submits() -> None:
+    declaration = {
+        "contrNo": "A",
+        "tdecGoodsitemsVoArr": [{"gname": "x", "gmodel": "原文"}],
+        "_meta": {"review_reasons": ["goods[1].gmodel:gmodel_raw"], "codes": {}},
+    }
+    job = _job(
+        status=JobStatus.NEEDS_REVIEW,
+        declaration=declaration,
+        reviews=[
+            FieldReview(
+                path="tdecGoodsitemsVoArr[0].gmodel",
+                status="needs_review",
+                reasons=["gmodel_raw"],
+            )
+        ],
+    )
+    body = to_dec_envelope(job)
+    assert body["code"] == 0
+    assert body["result"] is True
+    assert body["dec_results"]["contrNo"] == "A"
+
+
+def test_unknown_code_does_not_submit() -> None:
+    job = _job(
+        status=JobStatus.NEEDS_REVIEW,
+        declaration={"contrNo": "A", "iePort": "莲塘口岸", "_meta": {}},
+        reviews=[
+            FieldReview(path="iePort", status="needs_review", reasons=["unknown_code:海关口岸代码"])
+        ],
+    )
+    body = to_dec_envelope(job)
+    assert body["code"] == 1
+    assert body["result"] is False
+    assert body["dec_results"] is None
+
+
+def test_failed_job_does_not_submit() -> None:
+    job = Job(source_filename="x.xlsx", status=JobStatus.FAILED, error="boom")
+    job.result = ParseJobResult(status=JobStatus.FAILED, error="boom")
+    body = to_dec_envelope(job)
+    assert body["code"] == 2
+    assert body["result"] is False
+    assert body["dec_results"] is None
+    assert "boom" in body["msg"]

--- a/tests/xlsx_fixtures.py
+++ b/tests/xlsx_fixtures.py
@@ -102,6 +102,14 @@ def _draft(sheet) -> None:
             cell.border = _thin()
 
 
+def _coded_draft(sheet) -> None:
+    """码表能转上的草单。合单出口验收用；俗称（莲塘口岸 / 其它）仍走 _draft。"""
+    _draft(sheet)
+    sheet["E4"] = "蛇口海关"
+    sheet["A12"] = "其他包装"
+    sheet["J18"] = "HKD"
+
+
 def _packing(sheet) -> None:
     sheet["A1"] = "PACKING LIST"
     sheet["I4"] = "Invoice No.﹕"


### PR DESCRIPTION
Closes #86

## 改了什么

合单要 Demo `{code, msg, result, dec_results}`，对眼页要 Job + `_meta` + `reviews`。一个 URL 两种信封会互踩，所以另开入口，同一条 pipeline。

- 新增 `POST /v1/declare`：multipart 与 `/v1/jobs` 相同，始终同步跑完
- 出口在 `api/export_dec.py`：剥 `_meta` / `_source`，有码的字段写 code，不带 IR
- `/v1/jobs`、对眼页、抽取 / 组装不动
- **不交**：除放行项外仍有 `needs_review`，或 `failed`。HTTP 仍 200，`dec_results=null`
- 放行：`gmodel_raw`（#11 不编 `0|0|...`）、`code_table_pending`（币制等码表未就绪不挡合单）
- 出口填死：`dataSource=7`、`promiseItem*=0`；`packName`/`packType` 复制 `wrapType`；货行 `id` 出口生成 UUID，不进抽取
- 策略在 `fields.yaml` `declare_export`，不写死在路由

## 验收对照

| 项 | 结果 |
|---|---|
| 码都能转上的夹具 | `POST /v1/declare` → `code=0`，`supvModeCdde=0110`，无 `_meta` / `_source` |
| 恒信俗称（莲塘口岸 / 其它） | `code≠0`，`dec_results=null` |
| 只有净重没有毛重 | `code≠0`，不交 |
| `/v1/jobs` | 仍返回 Job + `_meta` + 中文名 |
| 缺 file | 400 |
| 现有测试 | 217 passed, 4 skipped |

## 以后新 xlsx / 新叫法改哪

| 你看到的现象 | 改哪里 | 动 API Python？ |
|---|---|---|
| 合单要多一个忽略键默认值 | `fields.yaml` `declare_export.constants` | 否 |
| 合单要复制某字段（如 packName） | `declare_export.aliases` | 否 |
| 合单多一种可放行的复核原因 | `declare_export.allow_reasons` / `allow_fields` | 否 |
| 新表头 / 货列 | `fields.yaml` 目录 | 否（declaration 按目录收） |
| 新字段要转 code | 字段写 `code_table` + 码表加行 | 否 |
| 合单信封 / code 数字 | `api/export_dec.py` | 只改出口 |
| 对眼页字段展示 | 不要改 `/v1/jobs` | 否 |

不要把 `/v1/jobs` 改成 Demo 信封。不要按 HKG 那份瘦 JSON 砍目录字段。