### PR TITLE
fix: 合单有单就交，needs_review 仍带 dec_results（#88）

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -50,16 +50,16 @@ Job
 
 ```text
 {
-  code          0 成功 / 1 待复核不交 / 2 解析失败
+  code          0 有单 / 2 解析失败
   msg
   result        true 仅 code=0
-  dec_results   成功时一张报关单；否则 null
+  dec_results   有单时一张报关单；解析失败 null
 }
 ```
 
 `dec_results`：剥 `_meta` / 货行 `_source`；有码的字段写 code；`dataSource` / `promiseItem*` 出口填死；`packName` / `packType` 复制 `wrapType`；货行 `id` 出口生成。策略在 `fields.yaml` `declare_export`。
 
-**不交**：除放行项外仍有 `needs_review`，或 `failed`。HTTP 仍 200。放行项默认 `gmodel_raw` 与 `code_table_pending`（#11 不编 `0|0|...`；币制等码表未就绪不挡合单）。转不出码、缺毛重、件毛净对不上仍不交。
+**有单就交**：`needs_review`（转不出码、缺毛重、gmodel 原文）仍 `code=0` 带 `dec_results`。对眼页继续用 `/v1/jobs` 看复核。只有 runner 接住的解析失败才 `code=2`、`dec_results=null`。
 
 ## 错误分界
 
@@ -67,8 +67,8 @@ Job
 |---|---|
 | 400 | 空文件、超大、没带 file |
 | 200 + Job `needs_review` | 对眼：缺字段、转不出 code、件毛净对不上 |
-| 200 + `{code:1, dec_results:null}` | 合单：同上，不交单 |
-| 200 + Job `failed` / `{code:2}` | 解析/组装 runner 已接住的失败 |
+| 200 + `{code:0, dec_results:{...}}` | 合单：有单就交，含待复核字段 |
+| 200 + Job `failed` / `{code:2, dec_results:null}` | 解析/组装 runner 已接住的失败 |
 | 404 | job 不存在（仅 `/v1/jobs/{id}`） |
 | 500 | 没映射到的服务器异常 |
 
@@ -90,7 +90,6 @@ Job
 | 校验规则 | #20 数据文件 | 否（同一接口自动带闸） |
 | 合单要多一个忽略键默认值 | `declare_export.constants` | 否 |
 | 合单要复制某字段（如 packName） | `declare_export.aliases` | 否 |
-| 合单多一种可放行的复核原因 | `declare_export.allow_reasons` / `allow_fields` | 否 |
 | 合单信封 / code 数字 | `api/export_dec.py` | 只改出口 |
 | 结构化日志 / 错误码 | `api/errors.py` + request_id | 只改挂钩处 |
 

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -36,7 +36,7 @@ docparse/
 | 包级对账 | `pipeline/steps/reconcile.py` | 同名字段冲突 | 金额、单号跨文件 |
 | 自动通过 / 待复核 | `pipeline/steps/route_review.py` | 只打状态 | 复核页另开 Issue |
 | FastAPI 交单 | `api/routes.py` + `pipeline/runner.py` | `POST /v1/jobs` 交 `declaration` + `reviews`（#21） | PDF / zip 拼单不改路由 |
-| 合单信封 | `api/export_dec.py` + `POST /v1/declare` | Demo `{code,msg,result,dec_results}`（#86）；`needs_review` 不交 | 新常量 / 别名 / 放行原因改 YAML |
+| 合单信封 | `api/export_dec.py` + `POST /v1/declare` | Demo `{code,msg,result,dec_results}`（#86）；有单就交 | 新常量 / 别名改 YAML |
 | 对眼页 | `api/static/review.html` + `GET /v1/schema` | 只画报关单 + reviews（#44） | 不渲染 IR |
 | 持久化接口 | `adapters/jobs/` `adapters/files/` | 内存实现；Postgres/S3 抛未实现 | 需要跨进程时再做 |
 | 云 LLM | `adapters/llm/openai_compat.py` | 未配 Key 则跳过 | 换供应商只改这里 |

--- a/src/docparse/api/export_dec.py
+++ b/src/docparse/api/export_dec.py
@@ -9,10 +9,8 @@ from docparse.domain.models import Job, JobStatus
 from docparse.schema.loader import Schema, load_schema
 
 OK_CODE = 0
-HOLD_CODE = 1
 FAIL_CODE = 2
 OK_MSG = "操作成功"
-HOLD_MSG = "待复核，不交单"
 FAIL_MSG = "解析失败"
 _META_KEY = "_meta"
 _SOURCE_KEY = "_source"
@@ -20,15 +18,13 @@ _CODES_KEY = "codes"
 
 
 def to_dec_envelope(job: Job, schema: Schema | None = None) -> dict:
-    """Job → Demo `{code, msg, result, dec_results}`。needs_review / failed 不交单。"""
+    """Job → Demo `{code, msg, result, dec_results}`。有单就交；只有解析失败不交。"""
     schema = schema or load_schema()
     if job.status == JobStatus.FAILED:
         return _envelope(FAIL_CODE, job.error or FAIL_MSG, False, None)
-    if job.status != JobStatus.SUCCEEDED and _blocking(job, schema):
-        return _envelope(HOLD_CODE, HOLD_MSG, False, None)
     declaration = job.result.declaration if job.result is not None else None
     if not declaration:
-        return _envelope(HOLD_CODE, HOLD_MSG, False, None)
+        return _envelope(FAIL_CODE, FAIL_MSG, False, None)
     return _envelope(OK_CODE, OK_MSG, True, public_declaration(declaration, schema))
 
 
@@ -51,44 +47,6 @@ def public_declaration(declaration: dict, schema: Schema | None = None) -> dict:
     for alias, source in policy.aliases.items():
         payload[alias] = payload.get(source, "")
     return payload
-
-
-def _blocking(job: Job, schema: Schema) -> bool:
-    if job.result is None or job.result.declaration is None:
-        return True
-    allowed_reasons = frozenset(schema.declare_export.allow_reasons)
-    allowed_fields = frozenset(schema.declare_export.allow_fields)
-    goods_array = schema.goods_array
-    for item in job.result.reviews:
-        if _review_allowed(item.path, item.reasons, allowed_fields, allowed_reasons, goods_array):
-            continue
-        return True
-    return False
-
-
-def _review_allowed(
-    path: str,
-    reasons: list[str],
-    allowed_fields: frozenset[str],
-    allowed_reasons: frozenset[str],
-    goods_array: str,
-) -> bool:
-    field = _field_from_path(path, goods_array)
-    if field in allowed_fields:
-        return True
-    return all(_reason_allowed(reason, allowed_reasons) for reason in reasons)
-
-
-def _reason_allowed(reason: str, allowed: frozenset[str]) -> bool:
-    if reason in allowed:
-        return True
-    return any(reason.startswith(f"{token}:") for token in allowed)
-
-
-def _field_from_path(path: str, goods_array: str) -> str:
-    if path.startswith(("goods[", f"{goods_array}[")) and "." in path:
-        return path.rsplit(".", 1)[-1]
-    return path
 
 
 def _apply_codes(payload: dict, codes: dict, goods_array: str) -> None:

--- a/src/docparse/schema/fields.yaml
+++ b/src/docparse/schema/fields.yaml
@@ -83,8 +83,8 @@ assembly:
   invoice_vocab: invoice_no
 
 # 合单出口（#86）。对眼页仍走 /v1/jobs；本段只给 POST /v1/declare。
-# 新忽略键的合单默认值加 constants；新别名复制加 aliases；新放行原因 / 字段加 allow_*。
-# 抽取不写这些键；不要按公司填。
+# 新忽略键的合单默认值加 constants；新别名复制加 aliases。
+# 抽取不写这些键；不要按公司填。有单就交，只有解析失败不交。
 declare_export:
   constants:
     dataSource: "7"
@@ -95,8 +95,6 @@ declare_export:
     packName: wrapType
     packType: wrapType
   goods_id: true
-  allow_reasons: [gmodel_raw, code_table_pending]
-  allow_fields: [gmodel]
 
 document_types:
   - customs_declaration

--- a/src/docparse/schema/loader.py
+++ b/src/docparse/schema/loader.py
@@ -121,13 +121,11 @@ class Assembly(BaseModel):
 
 
 class DeclareExport(BaseModel):
-    """合单信封（#86）。对眼页不读这里。新默认值 / 别名 / 放行原因加 YAML。"""
+    """合单信封（#86）。对眼页不读这里。新默认值 / 别名加 YAML。"""
 
     constants: dict[str, str] = Field(default_factory=dict)
     aliases: dict[str, str] = Field(default_factory=dict)
     goods_id: bool = False
-    allow_reasons: list[str] = Field(default_factory=list)
-    allow_fields: list[str] = Field(default_factory=list)
 
 
 class Schema(BaseModel):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -156,31 +156,38 @@ def test_declare_coded_draft_returns_dec_results() -> None:
     assert "一般贸易" not in str(dec)
 
 
-def test_declare_unknown_code_does_not_submit() -> None:
+def test_declare_unknown_code_still_submits() -> None:
     response = _client().post(
         "/v1/declare",
         files={"file": _xlsx({"一般贸易出口": _draft}, "hengxin.xlsx")},
     )
     assert response.status_code == 200
     body = response.json()
-    assert body["code"] != 0
-    assert body["result"] is False
-    assert body["dec_results"] is None
+    assert body["code"] == 0
+    assert body["result"] is True
+    dec = body["dec_results"]
+    assert dec["contrNo"] == "HDX2026-251"
+    assert dec["supvModeCdde"] == "0110"
+    assert dec["iePort"] == "莲塘口岸"
+    assert "_meta" not in dec
 
 
-def test_declare_missing_gross_does_not_submit() -> None:
+def test_declare_missing_gross_still_submits() -> None:
     response = _client().post(
         "/v1/declare",
         files={"file": _xlsx({"总箱单": _net_only_packing}, "net-only.xlsx")},
     )
     assert response.status_code == 200
     body = response.json()
-    assert body["code"] != 0
-    assert body["result"] is False
-    assert body["dec_results"] is None
+    assert body["code"] == 0
+    assert body["result"] is True
+    dec = body["dec_results"]
+    assert dec["netWt"] == "2825.47"
+    assert dec["grossWt"] == ""
+    assert "_meta" not in dec
 
 
-def test_jobs_still_returns_meta_when_declare_holds() -> None:
+def test_jobs_still_returns_meta_when_declare_submits() -> None:
     response = _client().post(
         "/v1/jobs",
         files={"file": _xlsx({"一般贸易出口": _draft}, "hengxin.xlsx")},

--- a/tests/test_export_dec.py
+++ b/tests/test_export_dec.py
@@ -58,41 +58,34 @@ def test_public_declaration_strips_meta_and_writes_codes() -> None:
     assert "_source" in source["tdecGoodsitemsVoArr"][0]
 
 
-def test_gmodel_raw_alone_still_submits() -> None:
-    declaration = {
-        "contrNo": "A",
-        "tdecGoodsitemsVoArr": [{"gname": "x", "gmodel": "原文"}],
-        "_meta": {"review_reasons": ["goods[1].gmodel:gmodel_raw"], "codes": {}},
-    }
+def test_needs_review_still_submits() -> None:
     job = _job(
         status=JobStatus.NEEDS_REVIEW,
-        declaration=declaration,
+        declaration={
+            "contrNo": "A",
+            "iePort": "莲塘口岸",
+            "tdecGoodsitemsVoArr": [{"gname": "x", "gmodel": "原文"}],
+            "_meta": {"codes": {}},
+        },
         reviews=[
+            FieldReview(
+                path="iePort",
+                status="needs_review",
+                reasons=["unknown_code:海关口岸代码"],
+            ),
             FieldReview(
                 path="tdecGoodsitemsVoArr[0].gmodel",
                 status="needs_review",
                 reasons=["gmodel_raw"],
-            )
+            ),
         ],
     )
     body = to_dec_envelope(job)
     assert body["code"] == 0
     assert body["result"] is True
     assert body["dec_results"]["contrNo"] == "A"
-
-
-def test_unknown_code_does_not_submit() -> None:
-    job = _job(
-        status=JobStatus.NEEDS_REVIEW,
-        declaration={"contrNo": "A", "iePort": "莲塘口岸", "_meta": {}},
-        reviews=[
-            FieldReview(path="iePort", status="needs_review", reasons=["unknown_code:海关口岸代码"])
-        ],
-    )
-    body = to_dec_envelope(job)
-    assert body["code"] == 1
-    assert body["result"] is False
-    assert body["dec_results"] is None
+    assert body["dec_results"]["iePort"] == "莲塘口岸"
+    assert "_meta" not in body["dec_results"]
 
 
 def test_failed_job_does_not_submit() -> None:


### PR DESCRIPTION
Closes #88

## 改了什么

#86 / PR #87 合入后，`POST /v1/declare` 在 `needs_review` 时丢掉 `dec_results`。SJ25084373 这类扫描件合单只看到三行信封。

改为有单就交：

- 有 `declaration` → `code=0` + `dec_results`（仍剥 `_meta` / `_source`，有码写 code）
- 只有解析失败 → `code=2`、`dec_results=null`
- `/v1/jobs` 和对眼页不动

## 验收对照

| 项 | 结果 |
|---|---|
| 恒信俗称夹具（莲塘口岸转不出码） | `code=0`，`contrNo` 有值 |
| 只有净重没有毛重 | `code=0`，`grossWt=""` |
| 解析失败 | `dec_results=null` |
| `/v1/jobs` | 仍带 `_meta` + `reviews` |

## 以后新 xlsx / 新叫法改哪

| 你看到的现象 | 改哪里 | 动 API Python？ |
|---|---|---|
| 合单要多一个忽略键默认值 | `declare_export.constants` | 否 |
| 合单要复制某字段 | `declare_export.aliases` | 否 |
| 合单信封 / code 数字 | `api/export_dec.py` | 只改出口 |
| 对眼页复核 | 不要改 `/v1/jobs` | 否 |