### PR TITLE
docs: 交接按压缩包解压部署，不写仓库地址（#92）

### DIFF
--- a/docs/handover.md
+++ b/docs/handover.md
@@ -10,11 +10,10 @@
 
 ## 1. 本机部署
 
-需要：Python 3.11+，能访问外网（扫描件走合合 TextIn）。没有 Docker 配方，按单机 uvicorn 即可。
+需要：Python 3.11+，能访问外网（扫描件走合合 TextIn）。没有 Docker 配方，按单机 uvicorn 即可。解压收到的压缩包，进入项目根目录（有 `pyproject.toml` 的那一层）：
 
 ```bash
-git clone https://github.com/Baldwinzc/docparse.git
-cd docparse
+cd <解压后的项目目录>
 python3.11 -m venv .venv
 source .venv/bin/activate          # Windows: .venv\Scripts\activate
 pip install -e ".[dev]"


### PR DESCRIPTION
Closes #92

## 改了什么

#90 / PR #91 合入后部署节仍是 `git clone` 仓库地址。对接方收压缩包，不应暴露仓库。

`docs/handover.md` 改为：解压后进入有 `pyproject.toml` 的目录再起 uvicorn。

## 以后新 xlsx / 新叫法改哪

本文只改部署入口文案。字段 / 接口仍见 handover 其余节与 `docs/api.md`。